### PR TITLE
fix incorrect arr index access in claim rewards dialog

### DIFF
--- a/app/components/modules/UserWallet.jsx
+++ b/app/components/modules/UserWallet.jsx
@@ -226,7 +226,7 @@ class UserWallet extends React.Component {
               rewards_str = `${rewards[0]}, ${rewards[1]} and ${rewards[2]}`;
               break;
           case 2:
-              rewards_str = `${rewards[0]} and ${rewards[2]}`;
+              rewards_str = `${rewards[0]} and ${rewards[1]}`;
               break;
           case 1:
               rewards_str = `${rewards[0]}`;


### PR DESCRIPTION
Bug:
![image](https://cloud.githubusercontent.com/assets/5168676/25098719/a40d3450-2377-11e7-9c34-84f039aa375d.png)
