### PR TITLE
Header improvements

### DIFF
--- a/app/components/cards/PostsList.jsx
+++ b/app/components/cards/PostsList.jsx
@@ -8,6 +8,7 @@ import {findParent} from 'app/utils/DomUtils';
 import Icon from 'app/components/elements/Icon';
 import shouldComponentUpdate from 'app/utils/shouldComponentUpdate';
 import {connect} from 'react-redux'
+import { translate } from 'app/Translator.js';
 
 function topPosition(domElt) {
     if (!domElt) {
@@ -206,9 +207,9 @@ class PostsList extends React.Component {
                 {showPost && <div id="post_overlay" className="PostsList__post_overlay" tabIndex={0}>
                     <div className="PostsList__post_top_overlay">
                         <div className="PostsList__post_top_bar">
-                            <button className="back-button" type="button" title="Back" onClick={() => { this.setState({showPost: null}) }}>
-                                <span aria-hidden="true"><Icon name="chevron-left" /></span>
-                            </button>
+                            <ul className="menu back-button-menu">
+                                <li><a onClick={(e) => {e.preventDefault(); this.setState({showPost: null}) }} href="#"><i><Icon name="chevron-left" /></i> <span>{translate('go_back')}</span></a></li>
+                            </ul>
                             <CloseButton onClick={this.closePostModal} />
                         </div>
                     </div>

--- a/app/components/cards/PostsList.scss
+++ b/app/components/cards/PostsList.scss
@@ -18,7 +18,7 @@
   left: 0;
   width: 100%;
   z-index: 310;
-  height: 2.5rem;
+  height: 3rem;
   overflow-x: hidden;
   overflow-y: scroll;
   border-bottom: 1px solid $light-gray;
@@ -27,24 +27,19 @@
 .PostsList__post_top_bar {
   position: relative;
   width: 100%;
-  height: 2.5rem;
+  height: 3rem;
   margin: 0 auto;
-  padding: 0.3rem 0.9rem 0;
   background-color: $white;
   overflow: hidden;
+  a {
+    span.Icon path {
+      fill: map-get($foundation-palette, 'primary');
+    }
+  }
   > .close-button {
     visibility: hidden;
     top: 1rem;
     right: 0;
-  }
-  > .back-button {
-    position: relative;
-    font-size: 2em;
-    line-height: 1;
-    cursor: pointer;
-    path {
-      fill: map-get($foundation-palette, 'primary');
-    }
   }
 }
 
@@ -75,7 +70,7 @@ body.with-post-overlay {
     > .close-button {
       visibility: visible;
     }
-    > .back-button {
+    > .back-button-menu {
       visibility: hidden;
     }
   }

--- a/app/components/modules/Header.scss
+++ b/app/components/modules/Header.scss
@@ -53,7 +53,7 @@
   }
   @media screen and (max-width: 39.9375em) {
       .shrink {
-          padding: .3rem 1rem;
+          padding: 0 1rem;
       }
   }
 }

--- a/app/components/modules/TopRightMenu.jsx
+++ b/app/components/modules/TopRightMenu.jsx
@@ -49,7 +49,7 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
         ];
         return (
             <ul className={mcn + mcl}>
-                <li className={lcn}><a href="/static/search.html" title="Search">{vertical ? <span>Search</span> : <Icon name="search" />}</a></li>
+                <li className={lcn + " Header__search"}><a href="/static/search.html" title="Search">{vertical ? <span>Search</span> : <Icon name="search" />}</a></li>
                 {submit_story}
                 <LinkWithDropdown
                     closeOnClickOutside
@@ -66,7 +66,7 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
                         <div className="TopRightMenu__notificounter"><NotifiCounter fields="total" /></div>
                     </li>}
                 </LinkWithDropdown>
-                {toggleOffCanvasMenu && <li className="toggle-menu"><a href="#" onClick={toggleOffCanvasMenu}>
+                {toggleOffCanvasMenu && <li className="toggle-menu Header__hamburger"><a href="#" onClick={toggleOffCanvasMenu}>
                     <span className="hamburger" />
                 </a></li>}
             </ul>
@@ -75,9 +75,9 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
     if (probablyLoggedIn) {
         return (
             <ul className={mcn + mcl}>
-                {!vertical && <li><a href="/static/search.html" title="Search"><Icon name="search" /></a></li>}
+                {!vertical && <li className="Header__search"><a href="/static/search.html" title="Search"><Icon name="search" /></a></li>}
                 <li className={lcn}><LoadingIndicator type="circle" inline /></li>
-                {toggleOffCanvasMenu && <li className="toggle-menu"><a href="#" onClick={toggleOffCanvasMenu}>
+                {toggleOffCanvasMenu && <li className="toggle-menu Header__hamburger"><a href="#" onClick={toggleOffCanvasMenu}>
                     <span className="hamburger" />
                 </a></li>}
             </ul>
@@ -85,11 +85,11 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
     }
     return (
         <ul className={mcn + mcl}>
-            {!vertical && <li><a href="/static/search.html" title="Search"><Icon name="search" /></a></li>}
+            {!vertical && <li className="Header__search"><a href="/static/search.html" title="Search"><Icon name="search" /></a></li>}
             <li className={lcn}><a href="/enter_email">Sign Up</a></li>
             <li className={lcn}><a href="/login.html" onClick={showLogin}>Login</a></li>
             {submit_story}
-            {toggleOffCanvasMenu && <li className="toggle-menu"><a href="#" onClick={toggleOffCanvasMenu}>
+            {toggleOffCanvasMenu && <li className="toggle-menu Header__hamburger"><a href="#" onClick={toggleOffCanvasMenu}>
                 <span className="hamburger" />
             </a></li>}
         </ul>

--- a/app/components/modules/TopRightMenu.scss
+++ b/app/components/modules/TopRightMenu.scss
@@ -13,7 +13,9 @@
 li.Header__userpic {
   padding: 0;
   position: relative;
-
+  a {
+      padding: 6px;
+  }
   .Userpic {
     width: 36px !important;
     height: 36px !important;
@@ -27,5 +29,23 @@ li.Header__userpic {
     right: 0;
     > .NotifiCounter {
         display: block;
+    }
+}
+
+div.Header__top
+{
+    li.Header__search {
+        padding: 0;
+        > a {
+            padding: 14px;
+        }
+    }
+    li.Header__hamburger.toggle-menu {
+        &.toggle-menu {
+            padding-left: 0.25rem;
+        }
+        > a {
+            padding: 14px;
+        }
     }
 }

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -20,6 +20,7 @@ const en = 	{
 	privacy_policy: "Privacy Policy",
 	terms_of_service: "Terms of Service",
 	sign_up: "Sign Up",
+	go_back: "Back",
 	/* end navigation */
 	buy: 'Buy',
 	sell: 'Sell',

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -16,6 +16,7 @@ const es = 	{
 	privacy_policy: "Política de Privacidad",
 	terms_of_service: "Terminos de Servicio",
 	sign_up: "Sign Up",
+	go_back: "Back",
 	/* end navigation */
 	buy: 'Comprar',
 	sell: 'Vender',

--- a/app/locales/es_AR.js
+++ b/app/locales/es_AR.js
@@ -16,6 +16,7 @@ const es_AR = 	{
 	privacy_policy: "Política de Privacidad",
 	terms_of_service: "Términos de Servicio",
 	sign_up: "Registro",
+	go_back: "Back",
 	/* end navigation */
 	buy: 'Comprar',
 	sell: 'Vender',

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -16,6 +16,7 @@ const fr = 	{
 	privacy_policy: "Politique de Confidentialité",
 	terms_of_service: "Conditions d'utilisation",
 	sign_up: "Inscription",
+	go_back: "Back",
 	/* end navigation */
 	buy: 'Acheter',
 	sell: 'Vendre',

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -16,6 +16,7 @@ const it = 	{
 	privacy_policy: "Privacy Policy",
 	terms_of_service: "Termini di Servizio",
 	sign_up: "Iscriviti",
+	go_back: "Back",
 	/* end navigation */
 	buy: 'Compra',
 	sell: 'Vendi',

--- a/app/locales/jp.js
+++ b/app/locales/jp.js
@@ -16,6 +16,7 @@ const jp = 	{
 	privacy_policy: "プライバシーポリシー",
 	terms_of_service: "利用規約",
 	sign_up: "サインアップ",
+	go_back: "Back",
 	/* end navigation */
 	buy: '買う',
 	sell: '売る',


### PR DESCRIPTION
This PR fixes some issues with the clickable area of some of the icons in the top header. In particular the back arrow button in the post overlay mode was very hard to hit, I've modified it so the clickable area is bigger and it includes a 'back' text making it look very similar to the standard iOS back button.

The clickable area of the user icon, search magnifying glass and the hamburger menu have also been increased.

![image](https://cloud.githubusercontent.com/assets/6890015/25266228/c1f95556-2670-11e7-828f-ff38f6b9992d.png)
