### PR TITLE
Add @ symbol to witness voting page

### DIFF
--- a/app/components/pages/Witnesses.jsx
+++ b/app/components/pages/Witnesses.jsx
@@ -158,6 +158,7 @@ class Witnesses extends React.Component {
                         <p>{translate('if_you_want_to_vote_outside_of_top_enter_account_name')}.</p>
                         <form>
                             <div className="input-group">
+                                <span className="input-group-label">@</span>
                                 <input className="input-group-field" type="text" style={{float: "left", width: "75%", maxWidth: "20rem"}} value={customUsername} onChange={onWitnessChange} />
                                 <div className="input-group-button">
                                     <button className="button" onClick={accountWitnessVote.bind(this, customUsername, !(witness_votes ? witness_votes.has(customUsername) : null))}>{translate('vote')}</button>
@@ -188,6 +189,7 @@ class Witnesses extends React.Component {
                         </div> :
                         <form>
                             <div className="input-group">
+                                <span className="input-group-label">@</span>
                                 <input className="input-group-field bold" type="text" style={{float: "left", width: "75%", maxWidth: "20rem"}} value={proxy} onChange={(e) => {this.setState({proxy: e.target.value});}} />
                                 <div className="input-group-button">
                                     <button style={{marginBottom: 0}} className="button" onClick={accountWitnessProxy}>{translate('witness_proxy_set')}</button>


### PR DESCRIPTION
There are two places on the witness voting page where users can manually enter a username (outside the top 50, and proxy voting). This PR adds the @ symbol in front of the two text boxes, which is consistent with the other places on the site that usernames are entered (such as the transfer page).

Screen Shot:
![image](https://cloud.githubusercontent.com/assets/20735105/25552895/0d5fa39c-2c6b-11e7-92af-4d1362412e79.png)
