### PR TITLE
New feed link update

### DIFF
--- a/app/components/pages/PostsIndex.jsx
+++ b/app/components/pages/PostsIndex.jsx
@@ -79,8 +79,8 @@ class PostsIndex extends React.Component {
                     {translate('empty_feed_1')}.<br /><br />
                     {translate('empty_feed_2')}.<br /><br />
                     <Link to="/trending">{translate('empty_feed_3')}</Link><br />
-                    <Link to="/steemit/@thecryptofiend/the-missing-faq-a-beginners-guide-to-using-steemit">{translate('empty_feed_4')}</Link><br />
-                    <Link to="/welcome">{translate('empty_feed_5')}</Link>
+                    <Link to="/welcome">{translate('empty_feed_4')}</Link><br />
+                    <Link to="/faq.html">{translate('empty_feed_5')}</Link><br />
                 </div>;
                 markNotificationRead = <MarkNotificationRead fields="feed" account={account_name} />
             } else {

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -577,7 +577,7 @@ const en = 	{
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_4: "Read The Quick Start Guide",
 	empty_feed_5: 'Browse The FAQ'
 }
 

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -577,8 +577,8 @@ const en = 	{
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read The Beginner's Guide",
-	empty_feed_5: 'Read The Steemit Welcome Guide'
+	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_5: 'Browse The FAQ'
 }
 
 export { en }

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -474,7 +474,7 @@ const es = 	{
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_4: "Read The Quick Start Guide",
 	empty_feed_5: 'Browse The FAQ'
 }
 

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -474,8 +474,8 @@ const es = 	{
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read The Beginner's Guide",
-	empty_feed_5: 'Read The Steemit Welcome Guide'
+	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_5: 'Browse The FAQ'
 }
 
 export { es }

--- a/app/locales/es_AR.js
+++ b/app/locales/es_AR.js
@@ -474,7 +474,7 @@ const es_AR = 	{
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_4: "Read The Quick Start Guide",
 	empty_feed_5: 'Browse The FAQ'
 }
 

--- a/app/locales/es_AR.js
+++ b/app/locales/es_AR.js
@@ -474,8 +474,8 @@ const es_AR = 	{
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read The Beginner's Guide",
-	empty_feed_5: 'Read The Steemit Welcome Guide'
+	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_5: 'Browse The FAQ'
 }
 
 export { es_AR }

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -474,7 +474,7 @@ const fr = 	{
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_4: "Read The Quick Start Guide",
 	empty_feed_5: 'Browse The FAQ'
 }
 

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -474,8 +474,8 @@ const fr = 	{
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read The Beginner's Guide",
-	empty_feed_5: 'Read The Steemit Welcome Guide'
+	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_5: 'Browse The FAQ'
 }
 
 export { fr }

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -474,7 +474,7 @@ const it = 	{
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_4: "Read The Quick Start Guide",
 	empty_feed_5: 'Browse The FAQ'
 }
 

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -474,8 +474,8 @@ const it = 	{
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read The Beginner's Guide",
-	empty_feed_5: 'Read The Steemit Welcome Guide'
+	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_5: 'Browse The FAQ'
 }
 
 export { it }

--- a/app/locales/jp.js
+++ b/app/locales/jp.js
@@ -473,7 +473,7 @@ const jp = 	{
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_4: "Read The Quick Start Guide",
 	empty_feed_5: 'Browse The FAQ'
 }
 

--- a/app/locales/jp.js
+++ b/app/locales/jp.js
@@ -473,8 +473,8 @@ const jp = 	{
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read The Beginner's Guide",
-	empty_feed_5: 'Read The Steemit Welcome Guide'
+	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_5: 'Browse The FAQ'
 }
 
 export { jp }

--- a/app/locales/ru.js
+++ b/app/locales/ru.js
@@ -584,7 +584,7 @@ const ru = {
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_4: "Read The Quick Start Guide",
 	empty_feed_5: 'Browse The FAQ'
 }
 

--- a/app/locales/ru.js
+++ b/app/locales/ru.js
@@ -584,8 +584,8 @@ const ru = {
 	empty_feed_1: "Looks like you haven't followed anything yet",
 	empty_feed_2: 'If you recently added new users to follow, your personalized feed will populate once new content is available',
 	empty_feed_3: 'Explore Trending Articles',
-	empty_feed_4: "Read The Beginner's Guide",
-	empty_feed_5: 'Read The Steemit Welcome Guide'
+	empty_feed_4: "Read Quick Start Guide",
+	empty_feed_5: 'Browse The FAQ'
 }
 
 export { ru }


### PR DESCRIPTION
When a new user logs in and views their feed and it is empty, it shows links to get them started. This pull request makes the following changes:
1. Renames the 'welcome page' link to the 'quick start guide'.
2. Moves the welcome page / quick start guide link up to be the second link.
3. Replaces the link to the 'the-missing-faq-a-beginners-guide-to-using-steemit' post with a link to the actual FAQ.

![image](https://cloud.githubusercontent.com/assets/20735105/25930437/c784f90c-35cb-11e7-93e2-b8406a1e0293.png)
