### PR TITLE
add request timing logging to condenser

### DIFF
--- a/server/requesttimings.js
+++ b/server/requesttimings.js
@@ -1,0 +1,12 @@
+module.exports = requestTime;
+
+function requestTime() {
+	return function *requestTime(next) {
+    	let start = Date.now();
+    	yield* next;
+    	let delta = Math.ceil(Date.now() - start);
+    	// log all requests that take longer than 150ms
+    	if(delta > 150)
+    		console.log('Request took too long! ' + delta + 'ms: ' + this.request.method + ' ' + this.request.path);
+  	}
+}

--- a/server/server.js
+++ b/server/server.js
@@ -7,6 +7,7 @@ import Koa from 'koa';
 import mount from 'koa-mount';
 import helmet from 'koa-helmet';
 import koa_logger from 'koa-logger';
+import requestTime from './requesttimings';
 import prod_logger from './prod_logger';
 import favicon from 'koa-favicon';
 import staticCache from 'koa-static-cache';
@@ -39,6 +40,8 @@ app.name = 'Steemit app';
 const env = process.env.NODE_ENV || 'development';
 // cache of a thousand days
 const cacheOpts = { maxAge: 86400000, gzip: true };
+
+app.use(requestTime());
 
 app.keys = [config.get('session_key')];
 


### PR DESCRIPTION
This will log requests that take longer than 150ms to complete and includes the method and path of the request.