### PR TITLE
Add vote strength % to voter dropdown

### DIFF
--- a/app/components/elements/VerticalMenu.jsx
+++ b/app/components/elements/VerticalMenu.jsx
@@ -30,6 +30,7 @@ export default class VerticalMenu extends React.Component {
                 return <li key={i.value} onClick={this.closeMenu}>
                     {i.link ? <Link to={i.link} onClick={i.onClick}>
                         {i.icon && <Icon name={i.icon} />}{i.label ? i.label : i.value}
+                        {i.data && <span>{i.data}</span>}
                         &nbsp; {i.addon}
                     </Link> :
                     <span>

--- a/app/components/elements/Voting.jsx
+++ b/app/components/elements/Voting.jsx
@@ -223,7 +223,8 @@ class Voting extends React.Component {
                 const {percent, voter} = avotes[v]
                 const sign = Math.sign(percent)
                 if(sign === 0) continue
-                voters.push({value: (sign > 0 ? '+ ' : '- ') + voter, link: '/@' + voter})
+                const voterPercent= percent / 100 + '%';
+                voters.push({value: (sign > 0 ? '+ ' : '- ') + voter, link: '/@' + voter, data: voterPercent})
             }
             if (total_votes > voters.length) {
                 voters.push({value: <span>&hellip; and {(total_votes - voters.length)} more</span>});

--- a/app/components/elements/Voting.scss
+++ b/app/components/elements/Voting.scss
@@ -147,6 +147,10 @@
     display: block;
     color: #666;
   }
+  li > a > span {
+    position: absolute;
+    right: 15px;
+  }
 }
 
 .Voting__inner {


### PR DESCRIPTION
As per issue https://github.com/steemit/condenser/issues/1337 (!), I've made the required changes to display vote % in the voter dropdown menu and verified they work on my own local fork of steemit with no errors.


![image](https://cloud.githubusercontent.com/assets/1692203/26228165/9bf679a4-3c7a-11e7-95af-ac6f16ef829b.png)
