### PR TITLE
Add account to bad actor list

### DIFF
--- a/app/utils/BadActorList.js
+++ b/app/utils/BadActorList.js
@@ -24,6 +24,7 @@ bttrex
 btrex
 bttrex
 ittrex
+bittrex-deposit
 poloiex
 poloinex
 polomiex


### PR DESCRIPTION
Name of exchange deposit address on a different platform. User could use this by mistake thinking the same name is used here.