### PR TITLE
Critical fix for a possibility of making own "password" or "private key" public by exposing it as a memo

### DIFF
--- a/app/components/all.scss
+++ b/app/components/all.scss
@@ -30,6 +30,7 @@
 @import "./elements/ShareMenu";
 @import "./elements/Author";
 @import "./elements/UserNames";
+@import "./elements/UserKeys";
 @import "./elements/QrKeyView";
 
 // modules

--- a/app/components/elements/UserKeys.jsx
+++ b/app/components/elements/UserKeys.jsx
@@ -91,7 +91,8 @@ class UserKeys extends Component {
             </div>
             <div style={{paddingBottom: 10}} className="column small-12">
                 <Keys account={account} authType="memo" onKey={onKey.Memo} />
-                <span className="secondary">{translate('the_memo_key_is_used_to_create_and_read_memos')}</span>
+                <span className="secondary">{translate('the_memo_key_is_used_to_create_and_read_memos')}</span><br />
+                <span className="UserKeysWarning">{translate('the_memo_key_is_not_required_to_make_a_transfers')}</span>
             </div>
             {/*
             <div className="column small-12">

--- a/app/components/elements/UserKeys.scss
+++ b/app/components/elements/UserKeys.scss
@@ -1,0 +1,4 @@
+.UserKeysWarning{
+    color: rgba(255, 0, 0, 1);
+    font-weight: bold;
+}

--- a/app/locales/en.js
+++ b/app/locales/en.js
@@ -455,6 +455,7 @@ const en = 	{
 	the_owner_key_is_required_to_change_other_keys: 'The owner key is the master key for the account and is required to change the other keys.',
 	the_private_key_or_password_should_be_kept_offline: 'The private key or password for the owner key should be kept offline as much as possible.',
 	the_memo_key_is_used_to_create_and_read_memos: 'The memo key is used to create and read memos.',
+	the_memo_key_is_not_required_to_make_a_transfers: 'The memo key (especially private key) should not be used as memo when you are making a transfer!',
 	previous: 'Previous',
 	next: 'Next',
 	browse: 'Browse',

--- a/app/locales/es.js
+++ b/app/locales/es.js
@@ -432,6 +432,7 @@ const es = 	{
 	the_owner_key_is_required_to_change_other_keys: 'The owner key is the master key for the account and is required to change the other keys.',
 	the_private_key_or_password_should_be_kept_offline: 'The private key or password for the owner key should be kept offline as much as possible.',
 	the_memo_key_is_used_to_create_and_read_memos: 'The memo key is used to create and read memos.',
+	the_memo_key_is_not_required_to_make_a_transfers: 'The memo key (especially private key) should not be used as memo when you are making a transfer!',
 	previous: 'Previous',
 	next: 'Next',
 	browse: 'Browse',

--- a/app/locales/es_AR.js
+++ b/app/locales/es_AR.js
@@ -432,6 +432,7 @@ const es_AR = 	{
 	the_owner_key_is_required_to_change_other_keys: 'The owner key is the master key for the account and is required to change the other keys.',
 	the_private_key_or_password_should_be_kept_offline: 'The private key or password for the owner key should be kept offline as much as possible.',
 	the_memo_key_is_used_to_create_and_read_memos: 'The memo key is used to create and read memos.',
+	the_memo_key_is_not_required_to_make_a_transfers: 'The memo key (especially private key) should not be used as memo when you are making a transfer!',
 	previous: 'Anterior',
 	next: 'Siguiente',
 	browse: 'Navegar',

--- a/app/locales/fr.js
+++ b/app/locales/fr.js
@@ -432,6 +432,7 @@ const fr = 	{
 	the_owner_key_is_required_to_change_other_keys: 'The owner key is the master key for the account and is required to change the other keys.',
 	the_private_key_or_password_should_be_kept_offline: 'The private key or password for the owner key should be kept offline as much as possible.',
 	the_memo_key_is_used_to_create_and_read_memos: 'The memo key is used to create and read memos.',
+	the_memo_key_is_not_required_to_make_a_transfers: 'The memo key (especially private key) should not be used as memo when you are making a transfer!',
 	previous: 'Précédent',
 	next: 'Suivant',
 	browse: 'Browse',

--- a/app/locales/it.js
+++ b/app/locales/it.js
@@ -432,6 +432,7 @@ const it = 	{
 	the_owner_key_is_required_to_change_other_keys: 'L\'owner key è la chiave master dell\'account e viene utilizzata per modificare tutte le altre.',
 	the_private_key_or_password_should_be_kept_offline: 'La private key o la password proprietaria dovrebbero essere tenute offline il più possibile.',
 	the_memo_key_is_used_to_create_and_read_memos: 'La memo key è utilizzata per creare e visualizzare memo.',
+	the_memo_key_is_not_required_to_make_a_transfers: 'The memo key (especially private key) should not be used as memo when you are making a transfer!',
 	previous: 'Precedente',
 	next: 'Prossimo',
 	browse: 'Browse',

--- a/app/locales/jp.js
+++ b/app/locales/jp.js
@@ -431,6 +431,7 @@ const jp = 	{
 	the_owner_key_is_required_to_change_other_keys: 'The owner key is the master key for the account and is required to change the other keys.',
 	the_private_key_or_password_should_be_kept_offline: 'The private key or password for the owner key should be kept offline as much as possible.',
 	the_memo_key_is_used_to_create_and_read_memos: 'The memo key is used to create and read memos.',
+	the_memo_key_is_not_required_to_make_a_transfers: 'The memo key (especially private key) should not be used as memo when you are making a transfer!',
 	previous: '前へ',
 	next: '次',
 	browse: 'ブラウザ',

--- a/app/locales/ru.js
+++ b/app/locales/ru.js
@@ -456,6 +456,7 @@ const ru = {
 	the_owner_key_is_required_to_change_other_keys: 'Ключ владельца это главный ключ ко всему аккаунта, он необходим для изменения других ключей.',
 	the_private_key_or_password_should_be_kept_offline: 'Приватный ключ или пароль должен храниться в оффлайне так часто насколько возможно.',
 	the_memo_key_is_used_to_create_and_read_memos: 'Ключ заметок используется для создания и чтения заметок.',
+	the_memo_key_is_not_required_to_make_a_transfers: 'The memo key (especially private key) should not be used as memo when you are making a transfer!',
 	previous: 'Предыдущий',
 	next: 'Следующий',
 	browse: 'Посмотреть',


### PR DESCRIPTION
We want to prevent such things:

![selection_999 152](https://user-images.githubusercontent.com/201263/26882984-38cb3654-4b9c-11e7-9c02-d46193513def.png)

### FIX:

This fix checks memo against public keys of a user, and prevents a mistake:

![selection_999 148](https://user-images.githubusercontent.com/201263/26883000-43ef7ff4-4b9c-11e7-929f-f79df19b9562.png)

![selection_999 150](https://user-images.githubusercontent.com/201263/26883008-49db3cf0-4b9c-11e7-8a0f-01da81330de6.png)
