### PR TITLE
Update to bad actor list coinpayments is not coinpayments.net

### DIFF
--- a/app/utils/BadActorList.js
+++ b/app/utils/BadActorList.js
@@ -76,6 +76,7 @@ changely
 shapeshif
 shapeshift
 randomwhale
+coinpayments
 `.trim().split('\n');
 
 export default list;


### PR DESCRIPTION
The coinpayments.net payment gateway uses the 'coinpayments.net' account. Some users have been sending coins to coinpayments by mistake.