### PR TITLE
Update wallet with new BlockTrades options

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -227,7 +227,7 @@ class App extends React.Component {
                         </a>
                     </li>
                     <li>
-                        <a href="https://blocktrades.us" target="_blank" rel="noopener noreferrer">
+                        <a href="https://blocktrades.us/unregistered_trade/btc/steem" target="_blank" rel="noopener noreferrer">
                             {translate("buy_LIQUID_TOKEN")}
                         </a>
                     </li>

--- a/app/components/modules/UserWallet.jsx
+++ b/app/components/modules/UserWallet.jsx
@@ -32,21 +32,40 @@ class UserWallet extends React.Component {
             // this.setState({showDeposit: !this.state.showDeposit, depositType: 'STEEM'})
             const new_window = window.open();
             new_window.opener = null;
-            new_window.location = 'https://blocktrades.us';
+            new_window.location = 'https://blocktrades.us/unregistered_trade/btc/steem';
+        };
+        this.onShowWithdrawSteem = (e) => {
+            e.preventDefault();
+            const new_window = window.open();
+            new_window.opener = null;
+            new_window.location = 'https://blocktrades.us/unregistered_trade/steem/btc';
         };
         this.onShowDepositPower = (e) => {
             e.preventDefault();
             // this.setState({showDeposit: !this.state.showDeposit, depositType: 'VESTS'})
             const new_window = window.open();
             new_window.opener = null;
-            new_window.location = 'https://blocktrades.us';
+            new_window.location = 'https://blocktrades.us/unregistered_trade/btc/steem_power';
+        };
+        this.onShowDepositSBD = (e) => {
+            e.preventDefault();
+            const new_window = window.open();
+            new_window.opener = null;
+            new_window.location = 'https://blocktrades.us/unregistered_trade/btc/sbd';
+        };
+        this.onShowWithdrawSBD = (e) => {
+            e.preventDefault();
+            const new_window = window.open();
+            new_window.opener = null;
+            new_window.location = 'https://blocktrades.us/unregistered_trade/sbd/btc';
         };
         // this.onShowDeposit = this.onShowDeposit.bind(this)
         this.shouldComponentUpdate = shouldComponentUpdate(this, 'UserWallet');
     }
     render() {
         const {state: {showDeposit, depositType, toggleDivestError},
-            onShowDeposit, onShowDepositSteem, onShowDepositPower} = this;
+            onShowDeposit, onShowDepositSteem, onShowWithdrawSteem,
+            onShowDepositSBD, onShowWithdrawSBD, onShowDepositPower} = this;
         const {convertToSteem, price_per_steem, savings_withdraws, account,
             current_user, open_orders} = this.props;
         const gprops = this.props.gprops.toJS();
@@ -174,21 +193,24 @@ class UserWallet extends React.Component {
         let power_menu = [
             { value: 'Power Down', link: '#', onClick: powerDown.bind(this, false) }
         ]
-        if(isMyAccount) {
-            steem_menu.push({ value: 'Buy', link: '#', onClick: onShowDepositSteem });
-            steem_menu.push({ value: 'Market', link: '/market' });
-            power_menu.push({ value: 'Buy', link: '#', onClick: onShowDepositPower })
-        }
-        if( divesting ) {
-            power_menu.push( { value: 'Cancel Power Down', link:'#', onClick: powerDown.bind(this,true) } );
-        }
-
         let dollar_menu = [
             { value: 'Transfer', link: '#', onClick: showTransfer.bind( this, 'SBD', 'Transfer to Account' ) },
             { value: 'Transfer to Savings', link: '#', onClick: showTransfer.bind( this, 'SBD', 'Transfer to Savings' ) },
             { value: 'Market', link: '/market' },
             { value: 'Convert to STEEM', link: '#', onClick: convertToSteem },
         ]
+        if(isMyAccount) {
+            steem_menu.push({ value: 'Buy', link: '#', onClick: onShowDepositSteem });
+            steem_menu.push({ value: 'Sell', link: '#', onClick: onShowWithdrawSteem });
+            steem_menu.push({ value: 'Market', link: '/market' });
+            power_menu.push({ value: 'Buy', link: '#', onClick: onShowDepositPower })
+            dollar_menu.push({ value: 'Buy', link: '#', onClick: onShowDepositSBD });
+            dollar_menu.push({ value: 'Sell', link: '#', onClick: onShowWithdrawSBD });
+        }
+        if( divesting ) {
+            power_menu.push( { value: 'Cancel Power Down', link:'#', onClick: powerDown.bind(this,true) } );
+        }
+
         const isWithdrawScheduled = new Date(account.get('next_vesting_withdrawal') + 'Z').getTime() > Date.now()
         const depositReveal = showDeposit && <div>
             <Reveal onHide={onShowDeposit} show={showDeposit}>


### PR DESCRIPTION
- Updates the existing STEEM and SP "Buy" links to prepopulate the BlockTrades "Send" and "Receive" coin types with the appropriate coins ({BTC}, {STEEM, STEEM POWER}) depending on which link is clicked. 
![image](https://user-images.githubusercontent.com/20735105/27351698-d7047868-55c3-11e7-9642-249bf69bb88a.png)
- Adds a "Sell" option for STEEM.
![image](https://user-images.githubusercontent.com/20735105/27351793-23427f22-55c4-11e7-9a78-4e89ff70754c.png)
- Adds a "Buy" and "Sell" link for SBD.
![image](https://user-images.githubusercontent.com/20735105/27351819-3478fe9c-55c4-11e7-8346-ea2f5b97b2e7.png)

[Edit] link to Steemit discussion post: https://steemit.com/steemdev/@timcliff/condenser-pull-request-submitted-new-blocktrades-buy-sell-options-via-the-steemit-com-wallet