### PR TITLE
Update Vote Slider Threshold

### DIFF
--- a/app/components/elements/Voting.jsx
+++ b/app/components/elements/Voting.jsx
@@ -23,7 +23,7 @@ const ABOUT_FLAG = <div>
 </div>;
 
 const MAX_VOTES_DISPLAY = 20;
-const VOTE_WEIGHT_DROPDOWN_THRESHOLD = 1.0 * 1000.0 * 1000.0;
+const VOTE_WEIGHT_DROPDOWN_THRESHOLD = 0.25 * 1000.0 * 1000.0;
 
 class Voting extends React.Component {
 


### PR DESCRIPTION
This pull request updates the vote slider threshold from 1.0 MV to 0.25 MV. This is 1/4 the SP needed to use the slider, since 100% votes are now 4x as strong.

I did tests with a user that had 120 SP (a little less that .25 MV), and they were able to upvote some posts with 1%, while near full voting power. After they have depleted some of their voting power they will start to get a _"Voting weight is too small, please accumulate more voting power or steem power."_ error. They can either increase their voting weight to 2% and continue voting, or buy more SP. They can continue with 2% votes until they get to around 50% voting power and then they will need to up to 3%.

[Edit] Link to Steemit discussion post: https://steemit.com/voting/@timcliff/condenser-pull-request-submitted-minnow-vote-slider-vote-slider-threshold-update-to-125-sp