### PR TITLE
Fix repaint of modal post on scroll

### DIFF
--- a/app/components/cards/PostsList.scss
+++ b/app/components/cards/PostsList.scss
@@ -49,6 +49,7 @@
   background-color: $white;
   margin: 1rem auto;
   padding: 2rem 0.9rem 0 0.9rem;
+  transform: translateZ(0);
   .PostFull {
     background-color: $white;
   }


### PR DESCRIPTION
When a post is shown as a modal webkit redraws the entire post body on scroll, making it incredibly sluggish for longer posts with many photos. This fixes that by forcing the post container into layer backing with a null transform.