### PR TITLE
BlockTrades "Buy" Links - Update to use the currently logged in user's account name

### DIFF
--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -130,7 +130,7 @@ class App extends React.Component {
 
     render() {
         const {location, params, children, flash, new_visitor,
-            depositSteem, signup_bonus} = this.props;
+            depositSteem, signup_bonus, username} = this.props;
         const lp = false; //location.pathname === '/';
         const miniHeader = location.pathname === '/create_account' || location.pathname === '/pick_account';
         const params_keys = Object.keys(params);
@@ -227,8 +227,8 @@ class App extends React.Component {
                         </a>
                     </li>
                     <li>
-                        <a href="https://blocktrades.us/unregistered_trade/btc/steem" target="_blank" rel="noopener noreferrer">
-                            {translate("buy_LIQUID_TOKEN")}
+                        <a onClick={() => depositSteem(username)}>
+                             {translate("buy_LIQUID_TOKEN")}
                         </a>
                     </li>
                     <li>
@@ -313,6 +313,7 @@ App.propTypes = {
     signup_bonus: React.PropTypes.string,
     loginUser: React.PropTypes.func.isRequired,
     depositSteem: React.PropTypes.func.isRequired,
+    username:  React.PropTypes.string,
 };
 
 export default connect(
@@ -324,14 +325,20 @@ export default connect(
             new_visitor: !state.user.get('current') &&
                 !state.offchain.get('user') &&
                 !state.offchain.get('account') &&
-                state.offchain.get('new_visit')
+                state.offchain.get('new_visit'),
+            username: state.user.getIn(['current', 'username']) || state.offchain.get('account') || ''
         };
     },
     dispatch => ({
         loginUser: () =>
             dispatch(user.actions.usernamePasswordLogin()),
-        depositSteem: () => {
-            dispatch(g.actions.showDialog({name: 'blocktrades_deposit', params: {outputCoinType: 'VESTS'}}));
+        depositSteem: (username) => {
+            let receive_address = username;
+
+            const new_window = window.open();
+            new_window.opener = null;
+            new_window.location = 'https://blocktrades.us/?input_coin_type=btc&output_coin_type=steem&receive_address=' + username;
+            //dispatch(g.actions.showDialog({name: 'blocktrades_deposit', params: {outputCoinType: 'VESTS'}}));
         },
     })
 )(App);

--- a/app/components/App.jsx
+++ b/app/components/App.jsx
@@ -228,7 +228,7 @@ class App extends React.Component {
                     </li>
                     <li>
                         <a onClick={() => depositSteem(username)}>
-                             {translate("buy_LIQUID_TOKEN")}
+                            {translate("buy_LIQUID_TOKEN")}
                         </a>
                     </li>
                     <li>
@@ -333,8 +333,6 @@ export default connect(
         loginUser: () =>
             dispatch(user.actions.usernamePasswordLogin()),
         depositSteem: (username) => {
-            let receive_address = username;
-
             const new_window = window.open();
             new_window.opener = null;
             new_window.location = 'https://blocktrades.us/?input_coin_type=btc&output_coin_type=steem&receive_address=' + username;

--- a/app/components/modules/UserWallet.jsx
+++ b/app/components/modules/UserWallet.jsx
@@ -27,12 +27,12 @@ class UserWallet extends React.Component {
         super();
         this.state = {};
         this.onShowDeposit = () => {this.setState({showDeposit: !this.state.showDeposit})};
-        this.onShowDepositSteem = (e) => {
+        this.onShowDepositSteem = (current_user_name, e) => {
             e.preventDefault();
             // this.setState({showDeposit: !this.state.showDeposit, depositType: 'STEEM'})
             const new_window = window.open();
             new_window.opener = null;
-            new_window.location = 'https://blocktrades.us/unregistered_trade/btc/steem';
+            new_window.location = 'https://blocktrades.us/?input_coin_type=btc&output_coin_type=steem&receive_address=' + current_user_name;
         };
         this.onShowWithdrawSteem = (e) => {
             e.preventDefault();
@@ -40,18 +40,18 @@ class UserWallet extends React.Component {
             new_window.opener = null;
             new_window.location = 'https://blocktrades.us/unregistered_trade/steem/btc';
         };
-        this.onShowDepositPower = (e) => {
+        this.onShowDepositPower = (current_user_name, e) => {
             e.preventDefault();
             // this.setState({showDeposit: !this.state.showDeposit, depositType: 'VESTS'})
             const new_window = window.open();
             new_window.opener = null;
-            new_window.location = 'https://blocktrades.us/unregistered_trade/btc/steem_power';
+            new_window.location = 'https://blocktrades.us/?input_coin_type=btc&output_coin_type=steem_power&receive_address=' + current_user_name;
         };
-        this.onShowDepositSBD = (e) => {
+        this.onShowDepositSBD = (current_user_name, e) => {
             e.preventDefault();
             const new_window = window.open();
             new_window.opener = null;
-            new_window.location = 'https://blocktrades.us/unregistered_trade/btc/sbd';
+            new_window.location = 'https://blocktrades.us/?input_coin_type=btc&output_coin_type=sbd&receive_address=' + current_user_name;
         };
         this.onShowWithdrawSBD = (e) => {
             e.preventDefault();
@@ -200,11 +200,11 @@ class UserWallet extends React.Component {
             { value: 'Convert to STEEM', link: '#', onClick: convertToSteem },
         ]
         if(isMyAccount) {
-            steem_menu.push({ value: 'Buy', link: '#', onClick: onShowDepositSteem });
+            steem_menu.push({ value: 'Buy', link: '#', onClick: onShowDepositSteem.bind( this, current_user.get('username') )  });
             steem_menu.push({ value: 'Sell', link: '#', onClick: onShowWithdrawSteem });
             steem_menu.push({ value: 'Market', link: '/market' });
-            power_menu.push({ value: 'Buy', link: '#', onClick: onShowDepositPower })
-            dollar_menu.push({ value: 'Buy', link: '#', onClick: onShowDepositSBD });
+            power_menu.push({ value: 'Buy', link: '#', onClick: onShowDepositPower.bind( this, current_user.get('username') ) })
+            dollar_menu.push({ value: 'Buy', link: '#', onClick: onShowDepositSBD.bind( this, current_user.get('username') ) });
             dollar_menu.push({ value: 'Sell', link: '#', onClick: onShowWithdrawSBD });
         }
         if( divesting ) {


### PR DESCRIPTION
This pull request updates the STEEM, SP, and SBD "Buy" links to pre-populate the "Your receive address" value on the BlockTrades interface with the account name of the currently logged in user. 

For the main menu link, it will use an empty-string value if the user is not currently logged in.

![image](https://user-images.githubusercontent.com/20735105/27764502-a7f6ad52-5e60-11e7-9367-ffdc709dfa0a.png)
