### PR TITLE
Check delegation when determining SP for showing vote bar Fixes #1441

### DIFF
--- a/app/components/elements/Voting.jsx
+++ b/app/components/elements/Voting.jsx
@@ -239,7 +239,7 @@ class Voting extends React.Component {
                 <div className="Voting__adjust_weight">
                     <a href="#" onClick={this.voteUp} className="confirm_weight" title="Upvote"><Icon size="2x" name="chevron-up-circle" /></a>
                     <div className="weight-display">{weight}%</div>
-                    <Slider min={100} max={10000} step={100} value={weight} onChange={this.handleWeightChange} />
+                    <Slider min={100} max={10000} step={100} value={weight / 100} onChange={this.handleWeightChange} />
                     <CloseButton className="Voting__adjust_weight_close" onClick={() => this.setState({showWeight: false})} />
                 </div>
             </FoundationDropdown>;

--- a/app/components/elements/Voting.jsx
+++ b/app/components/elements/Voting.jsx
@@ -238,8 +238,8 @@ class Voting extends React.Component {
             dropdown = <FoundationDropdown show={showWeight} onHide={() => this.setState({showWeight: false})}>
                 <div className="Voting__adjust_weight">
                     <a href="#" onClick={this.voteUp} className="confirm_weight" title="Upvote"><Icon size="2x" name="chevron-up-circle" /></a>
-                    <div className="weight-display">{weight}%</div>
-                    <Slider min={100} max={10000} step={100} value={weight / 100} onChange={this.handleWeightChange} />
+                    <div className="weight-display">{weight / 100}%</div>
+                    <Slider min={100} max={10000} step={100} value={weight} onChange={this.handleWeightChange} />
                     <CloseButton className="Voting__adjust_weight_close" onClick={() => this.setState({showWeight: false})} />
                 </div>
             </FoundationDropdown>;

--- a/app/components/elements/Voting.jsx
+++ b/app/components/elements/Voting.jsx
@@ -42,7 +42,7 @@ class Voting extends React.Component {
         active_votes: React.PropTypes.object,
         loggedin: React.PropTypes.bool,
         post_obj: React.PropTypes.object,
-        vesting_shares: React.PropTypes.number,
+        net_vesting_shares: React.PropTypes.number,
         voting: React.PropTypes.bool,
     };
 
@@ -72,7 +72,7 @@ class Voting extends React.Component {
             this.setState({votingUp: up, votingDown: !up});
             const {myVote} = this.state;
             const {author, permlink, username, is_comment} = this.props;
-            if (this.props.vesting_shares > VOTE_WEIGHT_DROPDOWN_THRESHOLD) {
+            if (this.props.net_vesting_shares > VOTE_WEIGHT_DROPDOWN_THRESHOLD) {
                 localStorage.setItem('voteWeight' + (up ? '' : 'Down') + '-'+username+(is_comment ? '-comment' : ''),
                     this.state.weight);
             }
@@ -126,7 +126,7 @@ class Voting extends React.Component {
     }
 
     render() {
-        const {active_votes, showList, voting, flag, vesting_shares, is_comment, post_obj} = this.props;
+        const {active_votes, showList, voting, flag, net_vesting_shares, is_comment, post_obj} = this.props;
         const {username} = this.props;
         const {votingUp, votingDown, showWeight, weight, myVote} = this.state;
         // console.log('-- Voting.render -->', myVote, votingUp, votingDown);
@@ -142,7 +142,7 @@ class Voting extends React.Component {
 
             // myVote === current vote
             const dropdown = <FoundationDropdown show={showWeight} onHide={() => this.setState({showWeight: false})} className="Voting__adjust_weight_down">
-                {(myVote == null || myVote === 0) && vesting_shares > VOTE_WEIGHT_DROPDOWN_THRESHOLD &&
+                {(myVote == null || myVote === 0) && net_vesting_shares > VOTE_WEIGHT_DROPDOWN_THRESHOLD &&
                     <div>
                         <div className="weight-display">- {weight / 100}%</div>
                         <Slider min={100} max={10000} step={100} value={weight} onChange={this.handleWeightChange} />
@@ -233,12 +233,12 @@ class Voting extends React.Component {
 
         let voteUpClick = this.voteUp;
         let dropdown = null;
-        if (myVote <= 0 && vesting_shares > VOTE_WEIGHT_DROPDOWN_THRESHOLD) {
+        if (myVote <= 0 && net_vesting_shares > VOTE_WEIGHT_DROPDOWN_THRESHOLD) {
             voteUpClick = this.toggleWeightUp;
             dropdown = <FoundationDropdown show={showWeight} onHide={() => this.setState({showWeight: false})}>
                 <div className="Voting__adjust_weight">
                     <a href="#" onClick={this.voteUp} className="confirm_weight" title="Upvote"><Icon size="2x" name="chevron-up-circle" /></a>
-                    <div className="weight-display">{weight / 100}%</div>
+                    <div className="weight-display">{weight}%</div>
                     <Slider min={100} max={10000} step={100} value={weight} onChange={this.handleWeightChange} />
                     <CloseButton className="Voting__adjust_weight_close" onClick={() => this.setState({showWeight: false})} />
                 </div>
@@ -272,13 +272,16 @@ export default connect(
         const current_account = state.user.get('current')
         const username = current_account ? current_account.get('username') : null;
         const vesting_shares = current_account ? current_account.get('vesting_shares') : 0.0;
+        const delegated_vesting_shares = current_account ? current_account.get('delegated_vesting_shares') : 0.0;
+        const received_vesting_shares = current_account ? current_account.get('received_vesting_shares') : 0.0;
+        const net_vesting_shares = vesting_shares - delegated_vesting_shares + received_vesting_shares;
         const voting = state.global.get(`transaction_vote_active_${author}_${permlink}`)
 
         return {
             post: ownProps.post,
             flag: ownProps.flag,
             showList: ownProps.showList,
-            author, permlink, username, active_votes, vesting_shares, is_comment,
+            author, permlink, username, active_votes, net_vesting_shares, is_comment,
             post_obj: post,
             loggedin: username != null,
             voting

--- a/app/redux/User.js
+++ b/app/redux/User.js
@@ -85,6 +85,8 @@ export default createModule({
             reducer: (state, {payload}) => {
                 // console.log('SET_USER')
                 if (payload.vesting_shares) payload.vesting_shares = parseFloat(payload.vesting_shares);
+                if (payload.delegated_vesting_shares) payload.delegated_vesting_shares = parseFloat(payload.delegated_vesting_shares);
+                if (payload.received_vesting_shares) payload.received_vesting_shares = parseFloat(payload.received_vesting_shares);
                 return state.mergeDeep({ current: payload, show_login_modal: false, loginBroadcastOperation: undefined, loginDefault: undefined, logged_out: undefined })
             }
         },

--- a/app/redux/UserSaga.js
+++ b/app/redux/UserSaga.js
@@ -249,9 +249,13 @@ function* usernamePasswordLogin2({payload: {username, password, saveLogin,
     if(!operationType || saveLogin) {
         // Keep the posting key in RAM but only when not signing an operation.
         // No operation or the user has checked: Keep me logged in...
-        yield put(user.actions.setUser({username, private_keys, login_owner_pubkey, vesting_shares: account.get('vesting_shares')}))
+        yield put(user.actions.setUser({username, private_keys, login_owner_pubkey, vesting_shares: account.get('vesting_shares'),
+         received_vesting_shares: account.get('received_vesting_shares'),
+         delegated_vesting_shares: account.get('delegated_vesting_shares')}))
     } else {
-        yield put(user.actions.setUser({username, vesting_shares: account.get('vesting_shares')}))
+        yield put(user.actions.setUser({username, vesting_shares: account.get('vesting_shares'), 
+         received_vesting_shares: account.get('received_vesting_shares'),
+         delegated_vesting_shares: account.get('delegated_vesting_shares')}))
     }
 
     if (!autopost && saveLogin)


### PR DESCRIPTION
The current vote slider checks the amount of SP a user has, but it does not take into account delegation. This PR changes it to look at the net SP balance (vesting_shares - delegated_vesting_shares + received_vesting_shares).
