### PR TITLE
Added portuguese tag in Faq

### DIFF
--- a/src/app/help/en/faq.md
+++ b/src/app/help/en/faq.md
@@ -622,7 +622,7 @@ Language-specific groups include:
 - Korean = kr
 - Russian = ru
 - French = fr
-- Portuguese = portuguese
+- Portuguese = portugues
 
 <a href="/faq.html#Table_of_Contents_Posting">^</a>
 <a class="anchor" name="Can_I_delete_something_I_posted"></a>

--- a/src/app/help/en/faq.md
+++ b/src/app/help/en/faq.md
@@ -622,7 +622,7 @@ Language-specific groups include:
 - Korean = kr
 - Russian = ru
 - French = fr
-- Portuguese = portugues
+- Portuguese = pt
 
 <a href="/faq.html#Table_of_Contents_Posting">^</a>
 <a class="anchor" name="Can_I_delete_something_I_posted"></a>

--- a/src/app/help/en/faq.md
+++ b/src/app/help/en/faq.md
@@ -622,6 +622,7 @@ Language-specific groups include:
 - Korean = kr
 - Russian = ru
 - French = fr
+- Portuguese = portuguese
 
 <a href="/faq.html#Table_of_Contents_Posting">^</a>
 <a class="anchor" name="Can_I_delete_something_I_posted"></a>


### PR DESCRIPTION
We came to the conclusion of using the tag 'portugues' to gather all speakers of the Portuguese language