### PR TITLE
1586 update blockquote extractor for ExtractContent .desc response attr

### DIFF
--- a/src/app/utils/ExtractContent.js
+++ b/src/app/utils/ExtractContent.js
@@ -76,8 +76,8 @@ export default function extractContent(get, content) {
         // Short description.
         // Remove bold and header, etc.
         // Stripping removes links with titles (so we got the links above)..
-        // Remove block quotes if detected comment preview
-        const body2 = remarkableStripper.render(get(content, 'depth') > 1 ? body.replace(/>([\s\S]*?).*\s*/g,'') : body);
+        // Remove block quotes if detected at beginning of comment preview if comment has a parent
+        const body2 = remarkableStripper.render(get(content, 'depth') > 1 ? body.replace(/(^(\n|\r|\s)*)>([\s\S]*?).*\s*/g, '') : body);
         desc = sanitize(body2, {allowedTags: []})// remove all html, leaving text
         desc = htmlDecode(desc)
 


### PR DESCRIPTION
#1586 The regular expression for removing block quotes from .desc was a little too aggressive.

Assumption in the fix is that we're only concerned with a block quote at the *beginning* of a post (behavior introduced in #928 )

Before:
<img width="595" alt="screen shot 2017-08-24 at 3 23 30 pm" src="https://user-images.githubusercontent.com/599528/29686928-4d5c4802-88e0-11e7-86e9-6819d069aaf9.png">

After:
<img width="385" alt="screen shot 2017-08-24 at 3 22 44 pm" src="https://user-images.githubusercontent.com/599528/29686943-5e102f38-88e0-11e7-844f-323624f5d3ec.png">
