### PR TITLE
1455 market depth chart y axis

### DIFF
--- a/src/app/components/elements/DepthChart.jsx
+++ b/src/app/components/elements/DepthChart.jsx
@@ -74,7 +74,7 @@ class DepthChart extends React.Component {
             return null;
         }
         const depth_chart_config = generateDepthChart(bids, asks);
-
+        console.log(depth_chart_config)
         return (
             <div className="DepthChart"><ReactHighcharts ref="depthChart" config={depth_chart_config} /></div>
         );
@@ -163,10 +163,10 @@ function generateDepthChart(bidsArray, asksArray) {
             lineWidth: 2,
             labels: {
                 align: "left",
-                formatter: function () {
-                    let value = this.value / precision;
-                    return '$' + (value > 10e6 ? (value / 10e6).toFixed(2) + "M" :
-                        value > 10000 ? (value / 10e3).toFixed(2) + "k" :
+                formatter: function() {
+                    const value = this.value / precision;
+                    return '$' + (value > 10e5 ? (value / 10e5).toFixed(2) + "M" :
+                        value > 10000 ? (value / 10e2).toFixed(0) + "k" :
                         value);
                 }
             },

--- a/src/app/components/elements/DepthChart.jsx
+++ b/src/app/components/elements/DepthChart.jsx
@@ -164,8 +164,8 @@ function generateDepthChart(bidsArray, asksArray) {
                 align: "left",
                 formatter: function() {
                     const value = this.value / precision;
-                    return '$' + (value > 10e5 ? (value / 10e5).toFixed(3) + "M" :
-                        value > 10000 ? (value / 10e2).toFixed(0) + "k" :
+                    return '$' + (value > 1e6 ? (value / 1e6).toFixed(3) + "M" :
+                        value > 10000 ? (value / 1e3).toFixed(0) + "k" :
                         value);
                 }
             },

--- a/src/app/components/elements/DepthChart.jsx
+++ b/src/app/components/elements/DepthChart.jsx
@@ -74,7 +74,6 @@ class DepthChart extends React.Component {
             return null;
         }
         const depth_chart_config = generateDepthChart(bids, asks);
-        console.log(depth_chart_config)
         return (
             <div className="DepthChart"><ReactHighcharts ref="depthChart" config={depth_chart_config} /></div>
         );

--- a/src/app/components/elements/DepthChart.jsx
+++ b/src/app/components/elements/DepthChart.jsx
@@ -164,7 +164,7 @@ function generateDepthChart(bidsArray, asksArray) {
                 align: "left",
                 formatter: function() {
                     const value = this.value / precision;
-                    return '$' + (value > 10e5 ? (value / 10e5).toFixed(2) + "M" :
+                    return '$' + (value > 10e5 ? (value / 10e5).toFixed(3) + "M" :
                         value > 10000 ? (value / 10e2).toFixed(0) + "k" :
                         value);
                 }


### PR DESCRIPTION
https://github.com/steemit/condenser/issues/1455

fix bad exponents in highcharts yaxis label formatter. Keep numeric precision at increments of 1000 above 10k.

Before:
<img width="296" alt="screen shot 2017-08-25 at 10 57 23 am" src="https://user-images.githubusercontent.com/599528/29728076-1ff16804-899c-11e7-8ae0-256c428133ed.png">

After:
<img width="374" alt="screen shot 2017-08-25 at 10 56 32 am" src="https://user-images.githubusercontent.com/599528/29728082-28149ff6-899c-11e7-84f2-8f5579e33cca.png">
