### PR TITLE
no need for more dependencies, run sequelize with yarn exec

### DIFF
--- a/README.md
+++ b/README.md
@@ -155,11 +155,6 @@ mysql -u root
 
 This is a required step in order for the database to be 'ready' for condenser's use.
 
-Install these modules globally:
-
-```bash
-yarn global add sequelize sequelize-cli pm2 mysql mysql2
-```
 
 Edit the file `src/db/config/config.json` using your favorite command line text editor being sure that the username, password, host, and database name are set correctly and match your newly configured mysql setup.
 
@@ -167,7 +162,7 @@ Run `sequelize db:migrate` in `src/db` directory, like this:
 
 ```bash
 cd src/db
-sequelize db:migrate
+yarn exec sequelize db:migrate
 ```
 
 #### Install Tarantool - Production Only


### PR DESCRIPTION
the current README recommends installing global deps for running sequelize; this isn't necessary, and it works out-of-the-box with already-defined dependencies when you use `yarn exec` -- this makes local dev easier.