### PR TITLE
Add a confirm to broadcast containing private key wifs

### DIFF
--- a/src/app/components/modules/ConfirmTransactionForm.jsx
+++ b/src/app/components/modules/ConfirmTransactionForm.jsx
@@ -10,12 +10,17 @@ class ConfirmTransactionForm extends Component {
         //Steemit
         onCancel: PropTypes.func,
         warning: PropTypes.string,
+        checkbox: PropTypes.string,
         // redux-form
         confirm: PropTypes.oneOfType([PropTypes.string, PropTypes.func]),
         confirmBroadcastOperation: PropTypes.object,
         confirmErrorCallback: PropTypes.func,
         okClick: PropTypes.func,
     };
+    constructor() {
+        super()
+        this.state = {checkboxChecked: false}
+    }
     componentDidMount() {
         document.body.addEventListener('click', this.closeOnOutsideClick);
     }
@@ -35,18 +40,30 @@ class ConfirmTransactionForm extends Component {
         const {okClick, confirmBroadcastOperation} = this.props
         okClick(confirmBroadcastOperation)
     }
+    onCheckbox = (e) => {
+        const checkboxChecked = e.target.checked
+        this.setState({checkboxChecked})
+    }
     render() {
-        const {onCancel, okClick} = this
-        const {confirm, confirmBroadcastOperation, warning} = this.props
+        const {onCancel, okClick, onCheckbox} = this
+        const {confirm, confirmBroadcastOperation, warning, checkbox} = this.props
+        const {checkboxChecked} = this.state
         const conf = typeof confirm === 'function' ? confirm() : confirm
         return (
            <div className="ConfirmTransactionForm">
                <h4>{typeName(confirmBroadcastOperation)}</h4>
                <hr />
                <div>{conf}</div>
-               {warning ? <div style={{paddingTop: 10}} className="error">{warning}</div> : null}
+               {warning ? <div style={{paddingTop: 10, fontWeight: 'bold'}} className="error">{warning}</div> : null}
+               {checkbox ?
+                    <div>
+                        <label htmlFor="checkbox">
+                            <input id="checkbox" type="checkbox" checked={checkboxChecked} onChange={this.onCheckbox} />
+                            {checkbox}
+                        </label>
+                    </div> : null}
                <br />
-               <button className="button" onClick={okClick}>{tt('g.ok')}</button>
+               <button className="button" onClick={okClick} disabled={!(checkbox === undefined || checkboxChecked)}>{tt('g.ok')}</button>
                <button type="button hollow" className="button hollow" onClick={onCancel}>{tt('g.cancel')}</button>
            </div>
        )
@@ -66,11 +83,13 @@ export default connect(
         const confirmErrorCallback = state.transaction.get('confirmErrorCallback')
         const confirm = state.transaction.get('confirm')
         const warning = state.transaction.get('warning')
+        const checkbox = state.transaction.get('checkbox')
         return {
             confirmBroadcastOperation,
             confirmErrorCallback,
             confirm,
-            warning
+            warning,
+            checkbox
         }
     },
     // mapDispatchToProps

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -203,6 +203,10 @@
       "zero": "No Responses",
       "one": "%(count)s Response",
       "other": "%(count)s Responses"
+    },
+    "post_key_warning": {
+        "confirm": "It looks like you are about to post a STEEM private key or master password to the public, are you sure you want to do this?",
+        "warning": "You can loose control of your account and funds by doing this."
     }
   },
   "navigation": {

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -205,8 +205,8 @@
       "other": "%(count)s Responses"
     },
     "post_key_warning": {
-        "confirm": "It looks like you are about to post a STEEM private key or master password to the public, are you sure you want to do this?",
-        "warning": "You can loose control of your account and funds by doing this."
+        "confirm": "You are about to publish a STEEM private key or master password. You will probably lose control of the associated account and all its funds.",
+        "warning": "Legitimate actors, including employees of Steemit Inc., will never ask you for a private key or master password."
     }
   },
   "navigation": {

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -206,7 +206,7 @@
     },
     "post_key_warning": {
         "confirm": "You are about to publish a STEEM private key or master password. You will probably lose control of the associated account and all its funds.",
-        "warning": "Legitimate actors, including employees of Steemit Inc., will never ask you for a private key or master password."
+        "warning": "Legitimate users, including employees of Steemit Inc., will never ask you for a private key or master password."
     }
   },
   "navigation": {

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -206,7 +206,8 @@
     },
     "post_key_warning": {
         "confirm": "You are about to publish a STEEM private key or master password. You will probably lose control of the associated account and all its funds.",
-        "warning": "Legitimate users, including employees of Steemit Inc., will never ask you for a private key or master password."
+        "warning": "Legitimate users, including employees of Steemit Inc., will never ask you for a private key or master password.",
+        "checkbox": "I understand"
     }
   },
   "navigation": {

--- a/src/app/redux/Transaction.js
+++ b/src/app/redux/Transaction.js
@@ -15,12 +15,14 @@ export default createModule({
                 const operation = fromJS(payload.operation)
                 const confirm = payload.confirm
                 const warning = payload.warning
+                const checkbox = payload.checkbox
                 return state.merge({
                     show_confirm_modal: true,
                     confirmBroadcastOperation: operation,
                     confirmErrorCallback: payload.errorCallback,
                     confirm,
-                    warning
+                    warning,
+                    checkbox
                 })
             }
         },

--- a/src/app/redux/TransactionSaga.js
+++ b/src/app/redux/TransactionSaga.js
@@ -169,7 +169,20 @@ function* broadcastOperation({payload:
 }
 
 function hasPrivateKeys(payload) {
-    return /P?5[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{50}/.test(JSON.stringify(payload.operations))
+    const blob = JSON.stringify(payload.operations)
+    let m, re = /P?(5[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{50})/g
+    while (true) {
+        m = re.exec(blob)
+        if (m) {
+            try {
+                PrivateKey.fromWif(m[1]) // performs the base58check
+                return true
+            } catch (e) {}
+        } else {
+            break
+        }
+    }
+    return false
 }
 
 function* broadcastPayload({payload: {operations, keys, username, successCallback, errorCallback}}) {

--- a/src/app/redux/TransactionSaga.js
+++ b/src/app/redux/TransactionSaga.js
@@ -126,9 +126,9 @@ function* error_account_witness_vote({operation: {account, witness, approve}}) {
 
 /** Keys, username, and password are not needed for the initial call.  This will check the login and may trigger an action to prompt for the password / key. */
 function* broadcastOperation({payload:
-    {type, operation, confirm, warning, keys, username, password, successCallback, errorCallback, postUnsafe}
+    {type, operation, confirm, warning, keys, username, password, successCallback, errorCallback, allowPostUnsafe}
 }) {
-    const operationParam = {type, operation, keys, username, password, successCallback, errorCallback, postUnsafe}
+    const operationParam = {type, operation, keys, username, password, successCallback, errorCallback, allowPostUnsafe}
 
     const conf = typeof confirm === 'function' ? confirm() : confirm
     if(conf) {
@@ -136,10 +136,10 @@ function* broadcastOperation({payload:
         return
     }
     const payload = {operations: [[type, operation]], keys, username, successCallback, errorCallback}
-    if (!postUnsafe && hasPrivateKeys(payload)) {
+    if (!allowPostUnsafe && hasPrivateKeys(payload)) {
         const confirm = tt('g.post_key_warning.confirm')
         const warning = tt('g.post_key_warning.warning')
-        operationParam.postUnsafe = true
+        operationParam.allowPostUnsafe = true
         yield put(tr.actions.confirmOperation({confirm, warning, operation: operationParam, errorCallback}))
         return
     }

--- a/src/app/redux/TransactionSaga.js
+++ b/src/app/redux/TransactionSaga.js
@@ -6,6 +6,7 @@ import {findSigningKey} from 'app/redux/AuthSaga'
 import g from 'app/redux/GlobalReducer'
 import user from 'app/redux/User'
 import tr from 'app/redux/Transaction'
+import tt from 'counterpart'
 import getSlug from 'speakingurl'
 import {DEBT_TICKER} from 'app/client_config'
 import {serverApiRecordEvent} from 'app/utils/ServerApiClient'
@@ -125,15 +126,23 @@ function* error_account_witness_vote({operation: {account, witness, approve}}) {
 
 /** Keys, username, and password are not needed for the initial call.  This will check the login and may trigger an action to prompt for the password / key. */
 function* broadcastOperation({payload:
-    {type, operation, confirm, warning, keys, username, password, successCallback, errorCallback}
+    {type, operation, confirm, warning, keys, username, password, successCallback, errorCallback, postUnsafe}
 }) {
-    const operationParam = {type, operation, keys, username, password, successCallback, errorCallback}
+    const operationParam = {type, operation, keys, username, password, successCallback, errorCallback, postUnsafe}
+
     const conf = typeof confirm === 'function' ? confirm() : confirm
     if(conf) {
         yield put(tr.actions.confirmOperation({confirm, warning, operation: operationParam, errorCallback}))
         return
     }
     const payload = {operations: [[type, operation]], keys, username, successCallback, errorCallback}
+    if (!postUnsafe && hasPrivateKeys(payload)) {
+        const confirm = tt('g.post_key_warning.confirm')
+        const warning = tt('g.post_key_warning.warning')
+        operationParam.postUnsafe = true
+        yield put(tr.actions.confirmOperation({confirm, warning, operation: operationParam, errorCallback}))
+        return
+    }
     try {
         if (!keys || keys.length === 0) {
             payload.keys = []
@@ -157,6 +166,10 @@ function* broadcastOperation({payload:
         console.error('TransactionSage', error);
         if(errorCallback) errorCallback(error.toString())
     }
+}
+
+function hasPrivateKeys(payload) {
+    return /P?5[123456789ABCDEFGHJKLMNPQRSTUVWXYZabcdefghijkmnopqrstuvwxyz]{50}/.test(JSON.stringify(payload.operations))
 }
 
 function* broadcastPayload({payload: {operations, keys, username, successCallback, errorCallback}}) {

--- a/src/app/redux/TransactionSaga.js
+++ b/src/app/redux/TransactionSaga.js
@@ -139,8 +139,9 @@ function* broadcastOperation({payload:
     if (!allowPostUnsafe && hasPrivateKeys(payload)) {
         const confirm = tt('g.post_key_warning.confirm')
         const warning = tt('g.post_key_warning.warning')
+        const checkbox = tt('g.post_key_warning.checkbox')
         operationParam.allowPostUnsafe = true
-        yield put(tr.actions.confirmOperation({confirm, warning, operation: operationParam, errorCallback}))
+        yield put(tr.actions.confirmOperation({confirm, warning, checkbox, operation: operationParam, errorCallback}))
         return
     }
     try {


### PR DESCRIPTION
This adds an extra layer of protection to users while still allowing you to post a private key if needed (for examples etc.)

I put it at the broadcast level so you will have to confirm any transaction containing keys, should catch all cases, comments/transaction memos/profile description etc.