### PR TITLE
update steem js api dependency 0.6.3 -> 0.6.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,7 +127,7 @@
     "sequelize-cli": "^2.3.1",
     "speakingurl": "^9.0.0",
     "sqlite3": "^3.1.8",
-    "steem": "github:steemit/steem-js#5f50ad5",
+    "steem": "^0.6.4",
     "store": "^1.3.20",
     "style-loader": "^0.13.0",
     "svg-inline-loader": "^0.4.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -6696,9 +6696,9 @@ statuses@1, "statuses@>= 1.3.1 < 2", statuses@^1.2.0, statuses@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.3.1.tgz#faf51b9eb74aaef3b3acf4ad5f61abf24cb7b93e"
 
-"steem@github:steemit/steem-js#5f50ad5":
-  version "0.6.3"
-  resolved "https://codeload.github.com/steemit/steem-js/tar.gz/5f50ad5"
+steem@^0.6.4:
+  version "0.6.4"
+  resolved "https://registry.yarnpkg.com/steem/-/steem-0.6.4.tgz#b34915cb90e729be9171721db81c5c1623e8d109"
   dependencies:
     bigi "^1.4.2"
     bluebird "^3.4.6"


### PR DESCRIPTION
resolves a build issue described in
https://github.com/steemit/condenser/pull/1727#issuecomment-331403735
and
https://gist.github.com/bnchdrff/8efb65b6eff4225a72f12fe54896118f