### PR TITLE
Assume development environment unless explicitly set to production

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "fmt": "prettier --config .prettierrc --write 'src/**/*.js*'",
     "precommit": "lint-staged",
     "production": "NODE_ENV=production node lib/server/index.js",
-    "start": "NODE_ENV=development babel-node ./webpack/dev-server.js",
+    "start": "babel-node ./webpack/dev-server.js",
     "webpush": "node ./scripts/webpush_notify.js",
     "checktranslations": "node scripts/check_translations.js"
   },

--- a/src/app/Main.js
+++ b/src/app/Main.js
@@ -20,7 +20,7 @@ const CMD_LOG_TOGGLE = 'log-toggle';
 const CMD_LOG_O = 'log-on';
 
 try {
-    if (process.env.NODE_ENV === 'development') {
+    if(process.env.NODE_ENV !== 'production') {
         // Adds some object refs to the global window object
         ConsoleExports.init(window);
     }

--- a/src/app/ResolveRoute.js
+++ b/src/app/ResolveRoute.js
@@ -34,8 +34,8 @@ export default function resolveRoute(path) {
     if (path === '/support.html') {
         return { page: 'Support' };
     }
-    if (path === '/xss/test' && process.env.NODE_ENV === 'development') {
-        return { page: 'XSSTest' };
+    if (path === '/xss/test' && process.env.NODE_ENV !== 'production') {
+        return {page: 'XSSTest'};
     }
     if (path.match(/^\/tags\/?/)) {
         return { page: 'Tags' };

--- a/src/app/RootRoute.js
+++ b/src/app/RootRoute.js
@@ -34,10 +34,7 @@ export default {
             //require.ensure([], (require) => {
             cb(null, [require('app/components/pages/Support')]);
             //});
-        } else if (
-            route.page === 'XSSTest' &&
-            process.env.NODE_ENV === 'development'
-        ) {
+        } else if (route.page === 'XSSTest' && process.env.NODE_ENV !== 'production') {
             //require.ensure([], (require) => {
             cb(null, [require('app/components/pages/XSS')]);
             //});

--- a/src/app/components/pages/XSS.jsx
+++ b/src/app/components/pages/XSS.jsx
@@ -3,7 +3,7 @@ import MarkdownViewer from 'app/components/cards/MarkdownViewer';
 
 class XSS extends React.Component {
     render() {
-        if (!process.env.NODE_ENV === 'development') return <div />;
+        if (!process.env.NODE_ENV !== 'production') return <div />;
         let tests = xss.map((test, i) => (
             <div key={i}>
                 <h2>Test {i}</h2>

--- a/src/db/models/index.js
+++ b/src/db/models/index.js
@@ -31,7 +31,7 @@ Object.keys(db).forEach(function(modelName) {
 db.sequelize = sequelize;
 db.Sequelize = Sequelize;
 
-if (env === 'development') {
+if(env !== 'production') {
     // in dev, sync all table schema automatically for convenience
     sequelize.sync();
 }

--- a/src/server/api/oauth.js
+++ b/src/server/api/oauth.js
@@ -21,7 +21,7 @@ function logErrorAndRedirect(ctx, where, error) {
             ctx.req.headers['user-agent']
         }: ${msg}`
     );
-    if (process.env.NODE_ENV === 'development') console.log(error.stack);
+    if (process.env.NODE_ENV !== 'production') console.log(error.stack);
     ctx.flash = { alert: `${where} error: ${msg}` };
     ctx.redirect('/');
     return null;

--- a/src/server/app_render.jsx
+++ b/src/server/app_render.jsx
@@ -12,8 +12,9 @@ import { determineViewMode } from '../app/utils/Links';
 
 const path = require('path');
 const ROOT = path.join(__dirname, '../..');
+//HERE IAIN
 const DB_RECONNECT_TIMEOUT =
-    process.env.NODE_ENV === 'development' ? 1000 * 60 * 60 : 1000 * 60 * 10;
+    process.env.NODE_ENV !== 'production' ? 1000 * 60 * 60 : 1000 * 60 * 10;
 
 function getSupportedLocales() {
     const locales = [];
@@ -166,7 +167,7 @@ async function appRender(ctx) {
         const assets = require(assets_filename);
 
         // Don't cache assets name on dev
-        if (process.env.NODE_ENV === 'development') {
+        if (process.env.NODE_ENV !== 'production') {
             delete require.cache[require.resolve(assets_filename)];
         }
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -259,7 +259,7 @@ app.use(
     )
 );
 // Proxy asset folder to webpack development server in development mode
-if (env === 'development') {
+if (env !== 'production') {
     const webpack_dev_port = process.env.PORT
         ? parseInt(process.env.PORT) + 1
         : 8081;

--- a/src/shared/UniversalRender.jsx
+++ b/src/shared/UniversalRender.jsx
@@ -200,7 +200,7 @@ const sagaMiddleware = createSagaMiddleware(
 
 let middleware;
 
-if (process.env.BROWSER && process.env.NODE_ENV === 'development') {
+if (process.env.BROWSER && process.env.NODE_ENV !== 'production') {
     const composeEnhancers =
         window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose; // eslint-disable-line no-underscore-dangle
     middleware = composeEnhancers(applyMiddleware(sagaMiddleware));

--- a/webpack/dev-server.js
+++ b/webpack/dev-server.js
@@ -3,7 +3,6 @@ if(!fs.existsSync('tmp'))
     fs.mkdirSync('tmp');
 
 process.env.BABEL_ENV = 'browser';
-process.env.NODE_ENV = 'development';
 
 const Koa = require('koa');
 const webpack = require('webpack');

--- a/webpack/utils/start-koa.js
+++ b/webpack/utils/start-koa.js
@@ -18,7 +18,7 @@ const startServer = () => {
     };
 
     // merge env for the new process
-    const env = {...process.env, NODE_ENV: 'development', BABEL_ENV: 'server'};
+    const env = {...process.env, BABEL_ENV: 'server'};
     // start the server procress
     server = cp.fork(KOA_PATH, {env});
     // when server is `online`


### PR DESCRIPTION
This allows for multiple custom development environments. Very useful to have a set of non-versioned `config/something.json` configs and start with `NODE_ENV=something yarn run start` to test.

Also standardizes the production check, now we check everywhere for `==/!= 'production'`