### PR TITLE
Primary navigation

### DIFF
--- a/src/app/components/App.scss
+++ b/src/app/components/App.scss
@@ -11,11 +11,11 @@
     }
     /* Medium only */
     @media screen and (min-width: 40em) and (max-width: 63.9375em) {
-        margin-top: 2.75rem;
+        margin-top: 3rem;
     }
     /* Large and above */
     @media screen and (min-width: 64.063em) {
-        margin-top: 2.75rem;
+        margin-top: 3rem;
     }
 }
 

--- a/src/app/components/App.scss
+++ b/src/app/components/App.scss
@@ -7,15 +7,15 @@
     margin-top: 3.5rem;
     /* Small only */
     @media screen and (max-width: 39.9375em) {
-        margin-top: 1.5rem;
+        margin-top: 2.25rem;
     }
     /* Medium only */
     @media screen and (min-width: 40em) and (max-width: 63.9375em) {
-        margin-top: 3.5rem;
+        margin-top: 2.75rem;
     }
     /* Large and above */
     @media screen and (min-width: 64.063em) {
-        margin-top: 3.5rem;
+        margin-top: 2.75rem;
     }
 }
 

--- a/src/app/components/elements/HorizontalMenu.scss
+++ b/src/app/components/elements/HorizontalMenu.scss
@@ -17,7 +17,7 @@
 }
 
 
-@media screen and (min-width: 54.5em) { 
+@media screen and (min-width: 52.5em) { 
   ul.HorizontalMenu.menu {
     display: flex;
     padding-left: 0.5em;
@@ -31,7 +31,7 @@
 
 
 
-@media print, screen and (min-width: 54.5em) {  
+@media print, screen and (min-width: 52.5em) {  
   .menu-hide-for-large {
     display: none !important; 
   }

--- a/src/app/components/elements/HorizontalMenu.scss
+++ b/src/app/components/elements/HorizontalMenu.scss
@@ -1,4 +1,5 @@
 .HorizontalMenu {
+  display: none;
   .active > a {
     background: none;
     color: $black;
@@ -12,5 +13,26 @@
   }
   > li:last-child > a {
     padding-right: 0;
+  }
+}
+
+
+@media screen and (min-width: 54.5em) { 
+  ul.HorizontalMenu.menu {
+    display: flex;
+    padding-left: 0.5em;
+
+    li > a {
+      padding-left: 0.5em;
+      padding-right: 0.5em;  
+    }
+  }
+}
+
+
+
+@media print, screen and (min-width: 54.5em) {  
+  .menu-hide-for-large {
+    display: none !important; 
   }
 }

--- a/src/app/components/modules/Header.jsx
+++ b/src/app/components/modules/Header.jsx
@@ -154,9 +154,9 @@ class Header extends React.Component {
         const topic_link = topic ? <Link to={`/${this.last_sort_order || 'trending'}/${topic}`}>{topic}</Link> : null;
 
         const sort_orders = [
+            ['trending', tt('main_menu.trending')],        
             ['created', tt('g.new')],
             ['hot', tt('main_menu.hot')],
-            ['trending', tt('main_menu.trending')],
             ['promoted', tt('g.promoted')]
         ];
         // if (current_account_name) sort_orders.unshift(['home', tt('header_jsx.home')]);
@@ -164,9 +164,9 @@ class Header extends React.Component {
         const selected_sort_order = sort_orders.find(so => so[0] === sort_order);
 
         const sort_orders_horizontal = [
+            ['trending', tt('main_menu.trending')],        
             ['created', tt('g.new')],
             ['hot', tt('main_menu.hot')],
-            ['trending', tt('main_menu.trending')],
             ['promoted', tt('g.promoted')]
         ];
         // if (current_account_name) sort_orders_horizontal.unshift(['home', tt('header_jsx.home')]);
@@ -188,22 +188,18 @@ class Header extends React.Component {
                                     </Link>
                                 </li>
                                 <li className="Header__top-steemit show-for-medium noPrint"><Link to={logo_link}>steemit<span className="beta">beta</span></Link></li>
-                                {(topic_link || user_name || page_name) && <li className="delim show-for-medium">|</li>}
-                                {topic_link && <li className="Header__top-topic">{topic_link}</li>}
-                                {user_name && <li><Link to={`/@${user_name}`}>@{user_name}</Link></li>}
-                                {page_name && <li><span>{page_name}</span></li>}
+                                <li className="delim show-for-medium">|</li>
+                                
+                                
+                                
                                 {(topic_link || user_name || page_name) && sort_order && <li className="delim show-for-small-only">|</li>}
-                                {selected_sort_order && <DropdownMenu className="Header__sort-order-menu hide-for-large" items={sort_order_menu} selected={selected_sort_order[1]} el="li" />}
+                                {selected_sort_order && <DropdownMenu className="Header__sort-order-menu menu-hide-for-large" items={sort_order_menu} selected={selected_sort_order[1]} el="li" />}
+                                <HorizontalMenu items={sort_order_menu_horizontal} />
                             </ul>
                         </div>
                         <div className="columns shrink">
                             <TopRightMenu {...this.props} />
                         </div>
-                    </div>
-                </div>
-                <div className={'Header__sub-nav expanded show-for-medium row' + (this.state.subheader_hidden ? ' hidden' : '')}>
-                    <div className="columns">
-                        <HorizontalMenu items={sort_order_menu_horizontal} />
                     </div>
                 </div>
             </header>

--- a/src/app/components/modules/Header.jsx
+++ b/src/app/components/modules/Header.jsx
@@ -159,7 +159,7 @@ class Header extends React.Component {
             ['trending', tt('main_menu.trending')],
             ['promoted', tt('g.promoted')]
         ];
-        if (current_account_name) sort_orders.unshift(['home', tt('header_jsx.home')]);
+        // if (current_account_name) sort_orders.unshift(['home', tt('header_jsx.home')]);
         const sort_order_menu = sort_orders.filter(so => so[0] !== sort_order).map(so => ({link: sortOrderToLink(so[0], topic, current_account_name), value: so[1]}));
         const selected_sort_order = sort_orders.find(so => so[0] === sort_order);
 
@@ -169,7 +169,7 @@ class Header extends React.Component {
             ['trending', tt('main_menu.trending')],
             ['promoted', tt('g.promoted')]
         ];
-        if (current_account_name) sort_orders_horizontal.unshift(['home', tt('header_jsx.home')]);
+        // if (current_account_name) sort_orders_horizontal.unshift(['home', tt('header_jsx.home')]);
         const sort_order_menu_horizontal = sort_orders_horizontal.map((so) => {
             let active = (so[0] === sort_order);
             if (so[0] === 'home' && sort_order === 'home' && !home_account) active = false;
@@ -193,7 +193,7 @@ class Header extends React.Component {
                                 {user_name && <li><Link to={`/@${user_name}`}>@{user_name}</Link></li>}
                                 {page_name && <li><span>{page_name}</span></li>}
                                 {(topic_link || user_name || page_name) && sort_order && <li className="delim show-for-small-only">|</li>}
-                                {selected_sort_order && <DropdownMenu className="Header__sort-order-menu show-for-small-only" items={sort_order_menu} selected={selected_sort_order[1]} el="li" />}
+                                {selected_sort_order && <DropdownMenu className="Header__sort-order-menu hide-for-large" items={sort_order_menu} selected={selected_sort_order[1]} el="li" />}
                             </ul>
                         </div>
                         <div className="columns shrink">

--- a/src/app/components/modules/Header.jsx
+++ b/src/app/components/modules/Header.jsx
@@ -189,9 +189,7 @@ class Header extends React.Component {
                                 </li>
                                 <li className="Header__top-steemit show-for-medium noPrint"><Link to={logo_link}>steemit<span className="beta">beta</span></Link></li>
                                 <li className="delim show-for-medium">|</li>
-                                
-                                
-                                
+                    
                                 {(topic_link || user_name || page_name) && sort_order && <li className="delim show-for-small-only">|</li>}
                                 {selected_sort_order && <DropdownMenu className="Header__sort-order-menu menu-hide-for-large" items={sort_order_menu} selected={selected_sort_order[1]} el="li" />}
                                 <HorizontalMenu items={sort_order_menu_horizontal} />

--- a/src/app/components/modules/Header.scss
+++ b/src/app/components/modules/Header.scss
@@ -39,7 +39,7 @@
   border-bottom: 1px solid $light-gray;
   padding: 0.25rem 0;
   transition: all 0.3s ease-out;
-  @media print, screen and (min-width: 54.5em) {
+  @media print, screen and (min-width: 52.5em) {
     padding: 0.75rem 0;
   }
   ul > li.Header__top-logo {

--- a/src/app/components/modules/Header.scss
+++ b/src/app/components/modules/Header.scss
@@ -6,6 +6,7 @@
   width: 100%;
   z-index: 100;
   background-color: $white;
+  box-shadow: 0 2px 4px 0 rgba(0,0,0,0.05);
   h3 {
     padding-left: 1rem;
     margin-bottom: 0;
@@ -36,6 +37,11 @@
 .Header__top {
   background-color: $white;
   border-bottom: 1px solid $light-gray;
+  padding: 0.25rem 0;
+  transition: all 0.3s ease-out;
+  @media print, screen and (min-width: 54.5em) {
+    padding: 0.75rem 0;
+  }
   ul > li.Header__top-logo {
     padding: .35rem 0 .35rem 0;
   }

--- a/src/app/components/modules/TopRightMenu.scss
+++ b/src/app/components/modules/TopRightMenu.scss
@@ -1,6 +1,6 @@
 .sub-menu {
     li {
-        padding: .7rem 1rem;
+        padding: .7rem 0.5rem;
         a {
             padding: 0px;
         }
@@ -45,7 +45,23 @@ div.Header__top
             padding-left: 0.25rem;
         }
         > a {
-            padding: 14px;
+            padding: 14px 0 14px 14px;
         }
     }
 }
+
+
+// li.submit-story {
+//     padding: 0;
+//     > a {
+//         background: #1A5099;
+//         padding: 10px 30px;
+//         margin: 0 2px;
+//         color: white;
+//         transition: all 0.3s ease-in-out;
+//         border-radius: 4px;
+//         &:hover {
+//             background: blue;
+//         }
+//     }
+// }

--- a/src/app/components/modules/TopRightMenu.scss
+++ b/src/app/components/modules/TopRightMenu.scss
@@ -50,18 +50,16 @@ div.Header__top
     }
 }
 
-
-// li.submit-story {
-//     padding: 0;
-//     > a {
-//         background: #1A5099;
-//         padding: 10px 30px;
-//         margin: 0 2px;
-//         color: white;
-//         transition: all 0.3s ease-in-out;
-//         border-radius: 4px;
-//         &:hover {
-//             background: blue;
-//         }
-//     }
-// }
+li.submit-story {
+    padding: 0;
+    > a {
+        background: #1A5099;
+        padding: 8px 24px;
+        margin: 0 6px;
+        color: white;
+        transition: all 0.3s ease-in-out;
+        &:hover {
+            background: #236CCC;
+        }
+    }
+}

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -95,7 +95,7 @@
     "since": "since",
     "submit": "Submit",
     "power_up": "Power Up",
-    "submit_a_story": "Submit a Story",
+    "submit_a_story": "Post",
     "tag": "Tag",
     "to": " to ",
     "topics": "Topics",

--- a/src/app/locales/es.json
+++ b/src/app/locales/es.json
@@ -95,7 +95,7 @@
     "since": "since",
     "submit": "Submit",
     "power_up": "Power Up",
-    "submit_a_story": "Submit a Story",
+    "submit_a_story": "Post",
     "tag": "Tag",
     "to": " to ",
     "topics": "Topics",


### PR DESCRIPTION
I made some changes to the primary navigation and removed some elements. As I'm new to the condenser code base, please review to make sure I haven't broken anything. @valzav 

![screen shot 2017-09-29 at 6 11 19 pm](https://user-images.githubusercontent.com/1121139/31037924-a88ec90c-a541-11e7-86b2-acf4f73ec33e.png)

– Increased primary navigation height on large screens (allows for a larger future logo)
– Removal of subnavigation (integrating it with the primary nav)
– Removing titles within the primary nav for people's names and topics 
   (future designs will place titles more clearly above the feed on the page)
– Renamed 'Submit a story' to 'Post' inside a button to place more weight on this element.
   
By removing the dynamic width elements from the navigation, it becomes less fragile and prone to overlapping elements when there are long topics or names.