### PR TITLE
Update tag parsing logic in reply editor

### DIFF
--- a/src/app/components/elements/ReplyEditor.jsx
+++ b/src/app/components/elements/ReplyEditor.jsx
@@ -583,8 +583,13 @@ export default formId => connect(
 
             const formCategories = Set(category ? category.trim().replace(/#/g, "").split(/ +/) : [])
             const rootCategory = originalPost && originalPost.category ? originalPost.category : formCategories.first()
-            let allCategories = Set([...formCategories.toJS(), ...rtags.hashtags])
+            let allCategories = Set([...formCategories.toJS()])
             if(/^[-a-z\d]+$/.test(rootCategory)) allCategories = allCategories.add(rootCategory)
+
+            let postHashtags = [...rtags.hashtags]
+            while (allCategories.size < 5 && postHashtags.length > 0) {
+                allCategories = allCategories.add(postHashtags.shift())
+            }
 
             // merge
             const meta = isEdit ? jsonMetadata : {}


### PR DESCRIPTION
Before all #hastags found in the post where added to the post category tags preventing you from posting any #hashtag if you've filled out your categories.

After this hashtags found in the post are only added to the categories if they don't exceed the limit of five.