### PR TITLE
Remove reputation protection from downvote post hide

### DIFF
--- a/src/app/utils/StateFunctions.js
+++ b/src/app/utils/StateFunctions.js
@@ -124,7 +124,7 @@ export function contentStats(content) {
     const hasPendingPayout = parsePayoutAmount(content.get('pending_payout_value')) >= 0.02
     const authorRepLog10 = repLog10(content.get('author_reputation'))
 
-    const gray = !hasPendingPayout && (authorRepLog10 < 1 || (authorRepLog10 < 65 && meetsGrayThreshold))
+    const gray = !hasPendingPayout && (authorRepLog10 < 1 || meetsGrayThreshold)
     const hide = !hasPendingPayout && (authorRepLog10 < 0) // rephide
 
     // Combine tags+category to check nsfw status


### PR DESCRIPTION
There is logic in condenser that prevents a users post from being hidden if they have reputation > 65. This prevents a high reputation user's posts from being hidden if their account is compromised. This PR removes the high reputation protection, so that any users posts can be hidden if they receive sufficient downvotes.