### PR TITLE
Autocomplete=On For Wallet Transfer "To:" Field

### DIFF
--- a/src/app/components/modules/Transfer.jsx
+++ b/src/app/components/modules/Transfer.jsx
@@ -182,7 +182,7 @@ class TransferForm extends Component {
                                 type="text"
                                 placeholder={tt('transfer_jsx.send_to_account')}
                                 onChange={this.onChangeTo}
-                                autoComplete="off"
+                                autoComplete="on"
                                 autoCorrect="off"
                                 autoCapitalize="off"
                                 spellCheck="false"


### PR DESCRIPTION
Toggle autocomplete on for the Steemit Wallet Transfer "To" Field. This should reduce account impersonation (Randowhale/Randomwhale/Randowale) and unnecessary traffic on the Steemit block-chain slightly from mistaken transfers/returns. On exchanges, this feature also cuts down on lost funds from transfer mistakes/typos.

For additional information:

https://steemit.com/utopian-io/@lexiconical/feature-request-reduce-transfer-fraud-by-quickly-adding-form-autocomplete-support-for-the-steemit-wallet-transfer-to-field