### PR TITLE
Show payout options on comments

### DIFF
--- a/src/app/components/elements/ReplyEditor.jsx
+++ b/src/app/components/elements/ReplyEditor.jsx
@@ -645,52 +645,51 @@ class ReplyEditor extends React.Component {
                                         {tt('g.clear')}
                                     </button>
                                 )}
-                            {isStory &&
-                                !isEdit && (
-                                    <div className="ReplyEditor__options float-right text-right">
-                                        {tt('g.rewards')} &nbsp;
-                                        <select
-                                            value={this.state.payoutType}
-                                            onChange={this.onPayoutTypeChange}
-                                            style={{
-                                                color:
-                                                    this.state.payoutType ==
-                                                    '0%'
-                                                        ? 'orange'
-                                                        : '',
-                                            }}
-                                        >
-                                            <option value="100%">
-                                                {tt(
-                                                    'reply_editor.power_up_100'
-                                                )}
-                                            </option>
-                                            <option value="50%">
-                                                {tt(
-                                                    'reply_editor.default_50_50'
-                                                )}
-                                            </option>
-                                            <option value="0%">
-                                                {tt(
-                                                    'reply_editor.decline_payout'
-                                                )}
-                                            </option>
-                                        </select>
-                                        <br />
-                                        <label
-                                            title={tt(
-                                                'reply_editor.check_this_to_auto_upvote_your_post'
+                            {!isEdit && (
+                                <div className="ReplyEditor__options float-right text-right">
+                                    {tt('g.rewards')} &nbsp;
+                                    <select
+                                        value={this.state.payoutType}
+                                        onChange={this.onPayoutTypeChange}
+                                        style={{
+                                            color:
+                                                this.state.payoutType ==
+                                                '0%'
+                                                    ? 'orange'
+                                                    : '',
+                                        }}
+                                    >
+                                        <option value="100%">
+                                            {tt(
+                                                'reply_editor.power_up_100'
                                             )}
-                                        >
-                                            {tt('g.upvote_post')} &nbsp;
-                                            <input
-                                                type="checkbox"
-                                                checked={autoVote.value}
-                                                onChange={autoVoteOnChange}
-                                            />
-                                        </label>
-                                    </div>
-                                )}
+                                        </option>
+                                        <option value="50%">
+                                            {tt(
+                                                'reply_editor.default_50_50'
+                                            )}
+                                        </option>
+                                        <option value="0%">
+                                            {tt(
+                                                'reply_editor.decline_payout'
+                                            )}
+                                        </option>
+                                    </select>
+                                    <br />
+                                    <label
+                                        title={tt(
+                                            'reply_editor.check_this_to_auto_upvote_your_post'
+                                        )}
+                                    >
+                                        {tt('g.upvote_post')} &nbsp;
+                                        <input
+                                            type="checkbox"
+                                            checked={autoVote.value}
+                                            onChange={autoVoteOnChange}
+                                        />
+                                    </label>
+                                </div>
+                            )}
                         </div>
                         {!loading &&
                             !rte &&


### PR DESCRIPTION
# Issue
Users want the ability to be able to power up 100% on comments. Maybe they will also want to decline payout.

# Solution
Enable the comment payout editor on comments as well as posts.

# Screenshots
- declined payout
![screen shot 2017-11-09 at 4 52 23 pm](https://user-images.githubusercontent.com/7006965/32634194-13df2686-c570-11e7-8c54-a5211839a67a.png)
- 100% power up comment
![screen shot 2017-11-09 at 4 52 55 pm](https://user-images.githubusercontent.com/7006965/32634195-13f345c6-c570-11e7-985e-cb279550bfd0.png)
- 0% payout comment
![screen shot 2017-11-09 at 4 53 03 pm](https://user-images.githubusercontent.com/7006965/32634196-1406cf88-c570-11e7-9b76-cfa6b4deb70b.png)
