### PR TITLE
Allow toggle nightmode to be used even when the user is not logged in…

### DIFF
--- a/src/app/components/App.jsx
+++ b/src/app/components/App.jsx
@@ -229,9 +229,14 @@ class App extends React.Component {
                             {tt('navigation.change_account_password')}
                         </a>
                     </li>
-                    <li className="last">
+                    <li>
                         <a href="/~witnesses" onClick={this.navigate}>
                             {tt('navigation.vote_for_witnesses')}
+                        </a>
+                    </li>
+                    <li className="last">
+                        <a href="#" onClick={this.props.toggleNightmode}>
+                            {tt('g.toggle_nightmode')}
                         </a>
                     </li>
                 </ul>
@@ -312,6 +317,8 @@ App.propTypes = {
     loginUser: React.PropTypes.func.isRequired,
     depositSteem: React.PropTypes.func.isRequired,
     username:  React.PropTypes.string,
+    nightmodeEnabled: React.PropTypes.bool,
+    toggleNightmode: React.PropTypes.func
 };
 
 export default connect(
@@ -325,7 +332,7 @@ export default connect(
                 !state.offchain.get('account') &&
                 state.offchain.get('new_visit'),
             username: state.user.getIn(['current', 'username']) || state.offchain.get('account') || '',
-            nightmodeEnabled: state.app.getIn(['user_preferences', 'nightmode']),
+            nightmodeEnabled: state.user.getIn(['user_preferences', 'nightmode']) || state.app.getIn(['user_preferences', 'nightmode'])
         };
     },
     dispatch => ({
@@ -337,5 +344,9 @@ export default connect(
             new_window.location = 'https://blocktrades.us/?input_coin_type=btc&output_coin_type=steem&receive_address=' + username;
             //dispatch(g.actions.showDialog({name: 'blocktrades_deposit', params: {outputCoinType: 'VESTS'}}));
         },
+        toggleNightmode: e => {
+            if (e) e.preventDefault();
+            dispatch({ type: 'TOGGLE_NIGHTMODE' });
+        }
     })
 )(App);

--- a/src/app/locales/es.json
+++ b/src/app/locales/es.json
@@ -99,6 +99,7 @@
     "submit_a_story": "Publicar",
     "tag": "Etiqueta",
     "to": "hasta",
+    "toggle_nightmode": "Alternar modo nocturno",
     "all_tags": "All tags",
     "transfer": "Transferir",
     "trending_topics": "Temas Tendencia",

--- a/src/app/locales/fr.json
+++ b/src/app/locales/fr.json
@@ -99,6 +99,7 @@
     "submit_a_story": "Poster",
     "tag": "Mot clé",
     "to": "vers",
+    "toggle_nightmode": "Activer le mode nuit",
     "all_tags": "All tags",
     "transfer": "Transférer",
     "trending_topics": "Sujets en vogue",

--- a/src/app/locales/it.json
+++ b/src/app/locales/it.json
@@ -99,6 +99,7 @@
     "submit_a_story": "Post",
     "tag": "Tag",
     "to": "a",
+    "toggle_nightmode": "Attiva la modalità notturna",
     "all_tags": "All tags",
     "transfer": "Trasferisci",
     "trending_topics": "Trending Topics",

--- a/src/app/locales/ru.json
+++ b/src/app/locales/ru.json
@@ -101,6 +101,7 @@
     "submit_a_story": "Добавить пост",
     "tag": "Тег",
     "to": " к ",
+    "toggle_nightmode": "Переключить ночной режим",
     "all_tags": "All tags",
     "transfer": "Перевод ",
     "trending_topics": "Популярное",


### PR DESCRIPTION
# Issue
Toggle Nightmode button is found in the "users" profile and will not be visible unless a user is logged in.

# Solution
Put a "Toggle Nightmode" function inside the main sidebar menu that is visible to all users. Allow users to be able to toggle nightmode.

# Description
This pull request contains the code required to implement the solution to the issue detailed above. When a user is not logged in and they toggle nightmode, the nightmode theme will be active until the user hard refreshes the page. This means nightmode will persist as long as the user continues navigating thru the normal UI links.

# Screenshots
![screen shot 2017-11-10 at 1 54 15 pm](https://user-images.githubusercontent.com/7006965/32676070-da4fb0a2-c61e-11e7-8d33-020913ff1e06.png)
