### PR TITLE
Enable auto suggestion for transfer input based off of users own transfer history

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,6 +99,7 @@
     "react": "15.4.2",
     "react-ab-test": "^1.7.0",
     "react-addons-pure-render-mixin": "15.4.2",
+    "react-autocomplete": "^1.7.2",
     "react-copy-to-clipboard": "^4.2.3",
     "react-dom": "15.4.2",
     "react-dropzone": "^3.7.3",

--- a/src/app/components/all.scss
+++ b/src/app/components/all.scss
@@ -48,6 +48,7 @@
 @import "./modules/Powerdown";
 @import "./modules/TopRightMenu";
 @import "./modules/ConfirmTransactionForm";
+@import "./modules/Transfer";
 
 // pages
 @import "./pages/PostsIndex";

--- a/src/app/components/modules/Transfer.jsx
+++ b/src/app/components/modules/Transfer.jsx
@@ -2,6 +2,9 @@ import React, { PropTypes, Component } from 'react';
 import ReactDOM from 'react-dom';
 import reactForm from 'app/utils/ReactForm';
 import { Map } from 'immutable';
+import Autocomplete from 'react-autocomplete';
+import tt from 'counterpart';
+
 import * as transactionActions from 'app/redux/TransactionReducer';
 import * as userActions from 'app/redux/UserReducer';
 import * as globalActions from 'app/redux/GlobalReducer';
@@ -12,7 +15,6 @@ import {
     validate_memo_field,
 } from 'app/utils/ChainValidation';
 import { countDecimals } from 'app/utils/ParsersAndFormatters';
-import tt from 'counterpart';
 import { APP_NAME, LIQUID_TOKEN, VESTING_TOKEN } from 'app/client_config';
 
 /** Warning .. This is used for Power UP too. */
@@ -22,22 +24,92 @@ class TransferForm extends Component {
         currentUser: PropTypes.object.isRequired,
         toVesting: PropTypes.bool.isRequired,
         currentAccount: PropTypes.object.isRequired,
+        following: PropTypes.object.isRequired,
     };
 
     constructor(props) {
         super();
         const { transferToSelf } = props;
-        this.state = { advanced: !transferToSelf };
+        this.state = {
+            advanced: !transferToSelf,
+            transferTo: false,
+            autocompleteUsers: [],
+        };
         this.initForm(props);
     }
 
     componentDidMount() {
         setTimeout(() => {
             const { advanced } = this.state;
-            if (advanced) ReactDOM.findDOMNode(this.refs.to).focus();
+            if (advanced) this.to.focus();
             else ReactDOM.findDOMNode(this.refs.amount).focus();
         }, 300);
+
         runTests();
+
+        this.buildTransferAutocomplete();
+    }
+
+    buildTransferAutocomplete() {
+        // Get names for the recent account transfers
+        const labelPreviousTransfers = tt(
+            'transfer_jsx.autocomplete_previous_transfers'
+        );
+        const labelFollowingUser = tt(
+            'transfer_jsx.autocomplete_user_following'
+        );
+
+        const transferToLog = this.props.currentAccount
+            .get('transfer_history')
+            .reduce((acc, cur) => {
+                if (cur.getIn([1, 'op', 0]) === 'transfer') {
+                    const username = cur.getIn([1, 'op', 1, 'to']);
+                    const numTransfers = acc.get(username)
+                        ? acc.get(username).numTransfers + 1
+                        : 1;
+                    return acc.set(username, {
+                        username,
+                        label: `${numTransfers} ${labelPreviousTransfers}`,
+                        numTransfers,
+                    });
+                }
+                return acc;
+            }, Map());
+
+        // Build a combined list of users you follow & have previously transferred to,
+        // and sort it by 1. desc the number of previous transfers 2. username asc.
+        this.setState({
+            autocompleteUsers: this.props.following
+                .toOrderedMap()
+                .map(username => ({
+                    username,
+                    label: labelFollowingUser,
+                    numTransfers: 0,
+                }))
+                .merge(transferToLog)
+                .sortBy(null, (a, b) => {
+                    //prioritize sorting by number of transfers
+                    if (a.numTransfers > b.numTransfers) {
+                        return -1;
+                    }
+                    if (b.numTransfers > a.numTransfers) {
+                        return 1;
+                    }
+                    //if transfer number is the same, sort by username
+                    if (a.username > b.username) {
+                        return 1;
+                    }
+                    if (b.username > a.username) {
+                        return -1;
+                    }
+                    return 0;
+                })
+                .toArray(),
+        });
+    }
+
+    matchAutocompleteUser(item, value) {
+        return item.username.toLowerCase().indexOf(value.toLowerCase()) > -1;
     }
 
     onAdvanced = e => {
@@ -141,9 +213,11 @@ class TransferForm extends Component {
         this.state.amount.props.onChange(this.balanceValue().split(' ')[0]);
     };
 
-    onChangeTo = e => {
-        const { value } = e.target;
+    onChangeTo = value => {
         this.state.to.props.onChange(value.toLowerCase().trim());
+        this.setState({
+            to: { ...this.state.to, value: value.toLowerCase().trim() },
+        });
     };
 
     render() {
@@ -167,6 +241,7 @@ class TransferForm extends Component {
         const { loading, trxError, advanced } = this.state;
         const {
             currentUser,
+            currentAccount,
             toVesting,
             transferToSelf,
             dispatchSubmit,
@@ -175,6 +250,7 @@ class TransferForm extends Component {
         const { submitting, valid, handleSubmit } = this.state.transfer;
         // const isMemoPrivate = memo && /^#/.test(memo.value); -- private memos are not supported yet
         const isMemoPrivate = false;
+
         const form = (
             <form
                 onSubmit={handleSubmit(({ data }) => {
@@ -248,20 +324,58 @@ class TransferForm extends Component {
                                 style={{ marginBottom: '1.25rem' }}
                             >
                                 <span className="input-group-label">@</span>
-                                <input
-                                    className="input-group-field"
-                                    ref="to"
-                                    type="text"
-                                    placeholder={tt(
-                                        'transfer_jsx.send_to_account'
+                                <Autocomplete
+                                    wrapperStyle={{
+                                        display: 'inline-block',
+                                        width: '100%',
+                                    }}
+                                    inputProps={{
+                                        type: 'text',
+                                        className: 'input-group-field',
+                                        autoComplete: 'off',
+                                        autoCorrect: 'off',
+                                        autoCapitalize: 'off',
+                                        spellCheck: 'false',
+                                        disabled: loading,
+                                    }}
+                                    renderMenu={items => (
+                                        <div
+                                            className="react-autocomplete-input"
+                                            children={items}
+                                        />
                                     )}
-                                    onChange={this.onChangeTo}
-                                    autoComplete="off"
-                                    autoCorrect="off"
-                                    autoCapitalize="off"
-                                    spellCheck="false"
-                                    disabled={loading}
-                                    {...to.props}
+                                    ref={el => (this.to = el)}
+                                    getItemValue={item => item.username}
+                                    items={this.state.autocompleteUsers}
+                                    shouldItemRender={
+                                        this.matchAutocompleteUser
+                                    }
+                                    renderItem={(item, isHighlighted) => (
+                                        <div
+                                            className={
+                                                isHighlighted ? 'active' : ''
+                                            }
+                                        >
+                                            {`${item.username} (${item.label})`}
+                                        </div>
+                                    )}
+                                    value={this.state.to.value || ''}
+                                    onChange={e => {
+                                        this.setState({
+                                            to: {
+                                                ...this.state.to,
+                                                value: e.target.value,
+                                            },
+                                        });
+                                    }}
+                                    onSelect={val =>
+                                        this.setState({
+                                            to: {
+                                                ...this.state.to,
+                                                value: val,
+                                            },
+                                        })
+                                    }
                                 />
                             </div>
                             {to.touched && to.blur && to.error ? (
@@ -465,6 +579,12 @@ export default connect(
             currentAccount,
             toVesting,
             transferToSelf,
+            following: state.global.getIn([
+                'follow',
+                'getFollowingAsync',
+                currentUser.get('username'),
+                'blog_result',
+            ]),
             initialValues,
         };
     },

--- a/src/app/components/modules/Transfer.scss
+++ b/src/app/components/modules/Transfer.scss
@@ -1,0 +1,31 @@
+.react-autocomplete-input {
+  overflow-y: scroll;
+  max-height: 16em;
+  background-clip: padding-box;
+  background-color: #fff;
+  border: 1px solid rgba(0,0,0,0.15);
+  bottom: auto;
+  box-shadow: 0 6px 12px rgba(0,0,0,0.175);
+  display: block;
+  font-size: 14px;
+  list-style: none;
+  padding: 1px;
+  position: absolute;
+  text-align: left;
+  z-index: 20000;
+}
+
+.react-autocomplete-input > div {
+  cursor: pointer;
+  padding: 10px;
+  min-width: 100px;
+}
+
+.react-autocomplete-input > .active {
+  background-color: #06D6A9;
+  color: #333;
+  @include themify($themes) {
+    color: theme('textColorPrimary');
+    background-color: themed('textColorAccentHover');
+  }
+}

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -728,7 +728,9 @@
         "asset_currently_collecting":
             "%(asset)s currently collecting %(interest)s%% APR.",
         "beware_of_spam_and_phishing_links":
-            "Beware of spam and phishing links in transfer memos. Do not open links from users you do not trust. Do not provide your private keys to any third party websites."
+            "Beware of spam and phishing links in transfer memos. Do not open links from users you do not trust. Do not provide your private keys to any third party websites.",
+        "autocomplete_previous_transfers": "previous transfers",
+        "autocomplete_user_following": "following"
     },
     "userwallet_jsx": {
         "conversion_complete_tip": "Will complete on",

--- a/webpack/dev.config.js
+++ b/webpack/dev.config.js
@@ -25,9 +25,6 @@ module.exports = {
                 BROWSER: JSON.stringify(true),
                 NODE_ENV: JSON.stringify('development'),
                 VERSION: JSON.stringify(git.long())
-            },
-            global: {
-                TYPED_ARRAY_SUPPORT: JSON.stringify(false)
             }
         }),
         ...baseConfig.plugins,

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -10,9 +10,6 @@ module.exports = {
                 BROWSER: JSON.stringify(true),
                 NODE_ENV: JSON.stringify('production'),
                 VERSION: JSON.stringify(git.long())
-            },
-            global: {
-                TYPED_ARRAY_SUPPORT: JSON.stringify(false)
             }
         }),
         new webpack.optimize.UglifyJsPlugin({

--- a/yarn.lock
+++ b/yarn.lock
@@ -2402,6 +2402,10 @@ dom-helpers@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
+dom-scroll-into-view@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dom-scroll-into-view/-/dom-scroll-into-view-1.0.1.tgz#32abb92f0d8feca6215162aef43e4b449ab8d99c"
+
 dom-serializer@0, dom-serializer@~0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/dom-serializer/-/dom-serializer-0.1.0.tgz#073c697546ce0780ce23be4a28e293e40bc30c82"
@@ -6719,6 +6723,13 @@ react-addons-test-utils@15.4.2:
   dependencies:
     fbjs "^0.8.4"
     object-assign "^4.1.0"
+
+react-autocomplete@^1.7.2:
+  version "1.7.2"
+  resolved "https://registry.yarnpkg.com/react-autocomplete/-/react-autocomplete-1.7.2.tgz#c55a0a4b8a9f4cba911dfccb74ef74f2161c46e0"
+  dependencies:
+    dom-scroll-into-view "1.0.1"
+    prop-types "^15.5.10"
 
 react-copy-to-clipboard@^4.2.3:
   version "4.3.1"


### PR DESCRIPTION
# Issue
Due to the inability to turn on basic autocomplete in the transfer form, users were encountering issues and scams by sending transfers to users with the wrong name. This is largely due to the fact that users had to constantly retype the name of the users they were sending transfers to.

# Solution
As a solution to this issue, I have enabled the ability for condenser to check the users transfer history and suggest accounts based off this information.

# Additional Config Options
This implementation of the autosuggest transfer feature activates only when the first letter of the name is typed and matched with available results. On top of this, the results are limited to 10 matches at a time in an effort to reduce screen disruption.

# Screenshots
![screen shot 2017-11-10 at 9 27 23 pm](https://user-images.githubusercontent.com/7006965/32685856-7d2297dc-c65f-11e7-9dae-c721cb8c4a91.png)

![screen shot 2017-11-10 at 9 33 49 pm](https://user-images.githubusercontent.com/7006965/32685858-83557b74-c65f-11e7-97b0-814e3e418d1e.png)
