### PR TITLE
centralize & standardize hash link scroll behavior

### DIFF
--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "react-redux": "^5.0.6",
     "react-router": "^3.0.5",
     "react-router-redux": "^4.0.0",
-    "react-router-scroll": "^0.4.2",
+    "react-router-scroll": "^0.4.4",
     "react-rte-image": "^0.3.1",
     "react-timeago": "^3.1.2",
     "redux": "^3.3.1",

--- a/src/app/components/cards/Comment.jsx
+++ b/src/app/components/cards/Comment.jsx
@@ -10,7 +10,6 @@ import user from 'app/redux/User';
 import TimeAgoWrapper from 'app/components/elements/TimeAgoWrapper';
 import Userpic from 'app/components/elements/Userpic';
 import transaction from 'app/redux/Transaction'
-import {List} from 'immutable'
 import tt from 'counterpart';
 import {parsePayoutAmount} from 'app/utils/ParsersAndFormatters';
 import {Long} from 'bytebuffer';
@@ -156,22 +155,10 @@ class CommentImpl extends React.Component {
     }
 
     componentDidMount() {
-        // Jump to comment via hash (note: comment element's id has a hash(#) in it)
-
         if (window.location.hash == this.props.anchor_link) {
-            const comment_el = document.getElementById(this.props.anchor_link)
-            if (comment_el) {
-                comment_el.scrollIntoView(true)
-                const scrollingEl = document.scrollingElement || document.documentElement;
-                scrollingEl.scrollTop -= 150;
-                this.setState({highlight: true}); // eslint-disable-line react/no-did-mount-set-state
-            }
+            this.setState({highlight: true}); // eslint-disable-line react/no-did-mount-set-state
         }
     }
-
-    //componentWillReceiveProps(np) {
-    //    this._checkHide(np);
-    //}
 
     /**
      * - `hide` is based on author reputation, and will hide the entire post on initial render.

--- a/src/app/components/cards/Comment.jsx
+++ b/src/app/components/cards/Comment.jsx
@@ -157,13 +157,14 @@ class CommentImpl extends React.Component {
 
     componentDidMount() {
         // Jump to comment via hash (note: comment element's id has a hash(#) in it)
+
         if (window.location.hash == this.props.anchor_link) {
             const comment_el = document.getElementById(this.props.anchor_link)
             if (comment_el) {
                 comment_el.scrollIntoView(true)
                 const scrollingEl = document.scrollingElement || document.documentElement;
-                scrollingEl.scrollTop -= 100;
-                this.setState({highlight: true});
+                scrollingEl.scrollTop -= 150;
+                this.setState({highlight: true}); // eslint-disable-line react/no-did-mount-set-state
             }
         }
     }
@@ -355,7 +356,7 @@ class CommentImpl extends React.Component {
             <div className={innerCommentClass}>
                 <div className="Comment__Userpic show-for-medium">
                   <Userpic account={comment.author} />
-                </div>            
+                </div>
               <div className="Comment__header">
                 <div className="Comment__header_collapse">
                   <Voting post={post} flag />

--- a/src/app/components/pages/Post.jsx
+++ b/src/app/components/pages/Post.jsx
@@ -14,6 +14,8 @@ import shouldComponentUpdate from 'app/utils/shouldComponentUpdate';
 import {serverApiRecordEvent} from 'app/utils/ServerApiClient';
 import { INVEST_TOKEN_UPPERCASE } from 'app/client_config';
 
+import { isLoggedIn } from 'app/utils/UserUtil';
+
 class Post extends React.Component {
 
     static propTypes = {
@@ -169,7 +171,7 @@ class Post extends React.Component {
                         <PostFull post={post} cont={content} />
                     </div>
                 </div>
-                {!current_user && <div className="row">
+                {!isLoggedIn() && <div className="row">
                     <div className="column">
                         <div className="Post__promo">
                             {tt('g.next_7_strings_single_block.authors_get_paid_when_people_like_you_upvote_their_post')}.

--- a/src/app/components/pages/Post.jsx
+++ b/src/app/components/pages/Post.jsx
@@ -23,8 +23,7 @@ class Post extends React.Component {
         post: React.PropTypes.string,
         routeParams: React.PropTypes.object,
         location: React.PropTypes.object,
-        signup_bonus: React.PropTypes.string,
-        current_user: React.PropTypes.object,
+        signup_bonus: React.PropTypes.string
     };
     constructor() {
         super();
@@ -36,13 +35,6 @@ class Post extends React.Component {
             window.location = '/pick_account';
         };
         this.shouldComponentUpdate = shouldComponentUpdate(this, 'Post')
-    }
-
-    componentDidMount() {
-        if (window.location.hash.indexOf('comments') !== -1) {
-            const comments_el = document.getElementById('comments');
-            if (comments_el) comments_el.scrollIntoView();
-        }
     }
 
     toggleNegativeReplies = (e) => {
@@ -62,7 +54,7 @@ class Post extends React.Component {
 
     render() {
         const {showSignUp} = this
-        const {current_user, signup_bonus, content} = this.props
+        const {signup_bonus, content} = this.props
         const {showNegativeComments, commentHidden, showAnyway} = this.state
         let post = this.props.post;
         if (!post) {
@@ -181,7 +173,7 @@ class Post extends React.Component {
                         </div>
                     </div>
                 </div>}
-                <div id="comments" className="Post_comments row hfeed">
+                <div id="#comments" className="Post_comments row hfeed">
                     <div className="column large-12">
                         <div className="Post_comments__content">
                             {positiveComments.length ?
@@ -211,8 +203,7 @@ export default connect(state => {
     return {
         content: state.global.get('content'),
         signup_bonus: state.offchain.get('signup_bonus'),
-        current_user,
-        ignoring,
+        ignoring
     }
 }
 )(Post);

--- a/src/app/utils/UserUtil.js
+++ b/src/app/utils/UserUtil.js
@@ -1,0 +1,60 @@
+/**
+ * This file replicates and extends the contents of User.js in branches new-url-scheme && notifications-ui.
+ * Additions here need to be added to ./User.js when those are merged. Imports should pull that file, and this one should be deleted.
+ */
+
+
+let store = false;
+
+export const setStore = (theStore) => {
+    if(!store) {
+        store = theStore;
+    } else {
+        throw Error("Routes.setStore - store has already been set.");
+    }
+}
+
+/**
+ * returns the current user's username *if* there is one.
+ *
+ * later can be modified to return full user object if passed *true* for 1st argument
+ * @returns {boolean}
+ */
+export const currentUser = () => {
+    const state = store.getState();
+    if(state.user) {
+        const current = state.user.getIn(['current']);
+        if(current) {
+            return current;
+        }
+    }
+    return false;
+}
+/**
+ * returns the current user's username *if* there is one.
+ *
+ * later can be modified to return full user object if passed *true* for 1st argument
+ * @returns {boolean}
+ */
+export const currentUsername = () => {
+    const state = store.getState();
+    if(state.user) {
+        const uName = state.user.getIn(['current', 'username']);
+        if(uName) {
+            return uName;
+        }
+    }
+    return false;
+}
+
+export const isOwnAccount = (username) => {
+    return (username === currentUsername());
+}
+
+/**
+ *
+ * @returns {boolean}
+ */
+export const isLoggedIn = () => {
+    return localStorage.getItem('autopost2')? true : false;
+}

--- a/src/shared/UniversalRender.jsx
+++ b/src/shared/UniversalRender.jsx
@@ -88,8 +88,15 @@ async function universalRender({ location, initial_state, offchain, ErrorPage, t
 
         const history = syncHistoryWithStore(browserHistory, store);
 
-        const scroll = useScroll();
-        
+        const scroll = useScroll( (previous, { location }) => {
+            if(location.hash) { //in situations where we have a hash url, and we are navigating forward, we want to abdicate scrolling to Post.jsx (we don't want to scroll here)
+                if((previous === null && location.action === 'POP') || (previous !== null && location.action === 'PUSH') ) {
+                    return false;
+                }
+            }
+            return true;
+        } );
+
         if (process.env.NODE_ENV === 'production') {
             console.log('%c%s', 'color: red; background: yellow; font-size: 24px;', 'WARNING!');
             console.log('%c%s', 'color: black; font-size: 16px;', 'This is a developer console, you must read and understand anything you paste or type here or you could compromise your account and your private keys.');

--- a/src/shared/UniversalRender.jsx
+++ b/src/shared/UniversalRender.jsx
@@ -43,7 +43,7 @@ const calcOffsetRoot = (startEl) => {
 }
 
 //BEGIN: SCROLL CODE
-const SCROLL_TOP_TRIES = 10;
+const SCROLL_TOP_TRIES = 20;
 const SCROLL_TOP_DELAY_MS = 50;
 const SCROLL_TOP_EXTRA_PIXEL_OFFSET = 3;
 

--- a/src/shared/UniversalRender.jsx
+++ b/src/shared/UniversalRender.jsx
@@ -44,7 +44,7 @@ const calcOffsetRoot = (startEl) => {
 
 //BEGIN: SCROLL CODE
 const SCROLL_TOP_TRIES = 20;
-const SCROLL_TOP_DELAY_MS = 50;
+const SCROLL_TOP_DELAY_MS = 100;
 const SCROLL_TOP_EXTRA_PIXEL_OFFSET = 3;
 
 let scrollTopTimeout = null;

--- a/src/shared/UniversalRender.jsx
+++ b/src/shared/UniversalRender.jsx
@@ -92,8 +92,6 @@ const sagaMiddleware = createSagaMiddleware(
     ...marketWatches
 );
 
-const TOP_OFFSET = 70; //this should be declared in a sass file. The way the offset 'happens' currently is via a collection of padding and margin values on different elements; pretty bad. Once that's fixed, we can move this declaration to a central location and have it all work in lockstep.
-
 let middleware;
 
 if (process.env.BROWSER && process.env.NODE_ENV === 'development') {

--- a/src/shared/UniversalRender.jsx
+++ b/src/shared/UniversalRender.jsx
@@ -43,7 +43,7 @@ const calcOffsetRoot = (startEl) => {
 }
 
 //BEGIN: SCROLL CODE
-const SCROLL_TOP_TRIES = 20;
+const SCROLL_TOP_TRIES = 30;
 const SCROLL_TOP_DELAY_MS = 100;
 const SCROLL_TOP_EXTRA_PIXEL_OFFSET = 3;
 
@@ -55,12 +55,13 @@ let scrollTopTimeout = null;
  * @param top - number of pixels to scroll from top of document
  * @param triesRemaining - number of attempts remaining
  */
-const scrollTop = (top, triesRemaining) => {
+const scrollTop = (el, topOffset, triesRemaining) => {
     const currentTop = Math.ceil(document.scrollingElement.scrollTop);
+    const top = calcOffsetRoot(el) + topOffset;
     if(currentTop < top) {
         window.scrollTo(0, top);
         if(triesRemaining > 0) {
-            scrollTopTimeout = setTimeout(() => scrollTop(top, (triesRemaining-1) ), SCROLL_TOP_DELAY_MS);
+            scrollTopTimeout = setTimeout(() => scrollTop(el, topOffset, (triesRemaining-1) ), SCROLL_TOP_DELAY_MS);
         }
     }
 }
@@ -74,8 +75,8 @@ class OffsetScrollBehavior extends ScrollBehavior {
         const el = (typeof target === 'string') ? document.getElementById(target) : false;
         if(el) {
             const header = document.getElementsByTagName('header')[0]; //this dimension ideally would be pulled from a scss file.
-            const top = (calcOffsetRoot(el) - ((header)? header.offsetHeight : 0)) - SCROLL_TOP_EXTRA_PIXEL_OFFSET;
-            scrollTop(top, SCROLL_TOP_TRIES);
+            const topOffset = (((header)? header.offsetHeight : 0) + SCROLL_TOP_EXTRA_PIXEL_OFFSET) * (-1);
+            scrollTop(el, topOffset, SCROLL_TOP_TRIES);
         } else {
             super.scrollToTarget(element, target);
         }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2318,7 +2318,7 @@ dom-helpers@^2.3.0, dom-helpers@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-2.4.0.tgz#9bb4b245f637367b1fa670274272aa28fe06c367"
 
-dom-helpers@^3.0.0, dom-helpers@^3.2.1:
+dom-helpers@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/dom-helpers/-/dom-helpers-3.2.1.tgz#3203e07fed217bd1f424b019735582fc37b2825a"
 
@@ -6594,12 +6594,12 @@ react-router-redux@^4.0.0:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/react-router-redux/-/react-router-redux-4.0.8.tgz#227403596b5151e182377dab835b5d45f0f8054e"
 
-react-router-scroll@^0.4.2:
-  version "0.4.3"
-  resolved "https://registry.yarnpkg.com/react-router-scroll/-/react-router-scroll-0.4.3.tgz#40d8bdac2a7a4fc859e02e3f25fcb7f722a1b728"
+react-router-scroll@^0.4.4:
+  version "0.4.4"
+  resolved "https://registry.yarnpkg.com/react-router-scroll/-/react-router-scroll-0.4.4.tgz#4d7b71c75b45ff296e4adca1e029a86e898a155d"
   dependencies:
     prop-types "^15.6.0"
-    scroll-behavior "^0.9.3"
+    scroll-behavior "^0.9.5"
     warning "^3.0.0"
 
 react-router@^3.0.5:
@@ -7157,12 +7157,12 @@ scmp@0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/scmp/-/scmp-0.0.3.tgz#3648df2d7294641e7f78673ffc29681d9bad9073"
 
-scroll-behavior@^0.9.3:
-  version "0.9.3"
-  resolved "https://registry.yarnpkg.com/scroll-behavior/-/scroll-behavior-0.9.3.tgz#e48bcc8af364f3f07176e8dbca3968bd5e71557b"
+scroll-behavior@^0.9.5:
+  version "0.9.5"
+  resolved "https://registry.yarnpkg.com/scroll-behavior/-/scroll-behavior-0.9.5.tgz#41da30b559da004eb48450f6cff6068c7696ff23"
   dependencies:
-    dom-helpers "^3.0.0"
-    invariant "^2.2.1"
+    dom-helpers "^3.2.1"
+    invariant "^2.2.2"
 
 scss-tokenizer@^0.2.3:
   version "0.2.3"


### PR DESCRIPTION
Closes #1946 
Page scrolling on hash navigation and on 'cold landing' has been, spread across multiple files, difficult to maintain and not meeting user expectations.

This pr moves all scrolling behavior into UniversalRender, within a class dedicated to the purpose.
Header-height is determined in one location, and scrolling is done by a scrolling middleware that's called at the correct times by Router, rather than ad-hock native access as was previously done in Comment and Post .jsx files.
   
Elimination of some ui-jumping in the post page was a part of this process.