### PR TITLE
Adjust right margin on user profile for wallet and settings link

### DIFF
--- a/src/app/components/pages/UserProfile.jsx
+++ b/src/app/components/pages/UserProfile.jsx
@@ -368,7 +368,7 @@ export default class UserProfile extends React.Component {
                 </ul>
             </div>
             <div className="columns shrink">
-                <ul className="menu" style={{flexWrap: "wrap"}}>
+                <ul className="menu" style={{marginRight: "55px", flexWrap: "wrap"}}>
                     <li>
                         <a href={`/@${accountname}/transfers`} className={walletClass} onClick={e => { e.preventDefault(); browserHistory.push(e.target.pathname); return false; }}>
                             {tt('g.wallet')} {isMyAccount && <NotifiCounter fields="send,receive,account_update" />}


### PR DESCRIPTION
## Issue
There is a minor "issue" on the User Profile page where the wallet and settings links are not properly aligned with the post container.

## Solution
This pull request contains the code necessary to resolve this issue by helping to properly align the wallet and settings links on the user profile page.

## Screenshots
![screen shot 2017-11-11 at 10 40 41 pm](https://user-images.githubusercontent.com/7006965/32696020-b468a7c2-c731-11e7-8526-966b1020e6d9.png)
![screen shot 2017-11-11 at 10 40 53 pm](https://user-images.githubusercontent.com/7006965/32696021-b63a1a0e-c731-11e7-82e3-e9a10523df54.png)