### PR TITLE
Add flags list to full post page with dropdown

### DIFF
--- a/src/app/components/cards/PostFull.jsx
+++ b/src/app/components/cards/PostFull.jsx
@@ -336,7 +336,7 @@ class PostFull extends React.Component {
                 <TimeAuthorCategory content={content} authorRepLog10={authorRepLog10} />
                 <Voting post={post} />
               </div>
-              <div className="RightShare__Menu small-11 medium-5 large-5 columns text-right">
+              <div className="RightShare__Menu small-10 medium-4 large-4 columns text-right">
                 {!readonly && <Reblog author={author} permlink={permlink} />}
                 <span className="PostFull__reply">
                   {showReplyOption && <a onClick={onShowReply}>{tt('g.reply')}</a>}

--- a/src/app/components/elements/Voting.jsx
+++ b/src/app/components/elements/Voting.jsx
@@ -215,6 +215,7 @@ class Voting extends React.Component {
         </DropdownMenu>;
 
         let voters_list = null;
+        let all_flags = [];
         if (showList && total_votes > 0 && active_votes) {
             const avotes = active_votes.toJS();
             avotes.sort((a, b) => Math.abs(parseInt(a.rshares)) > Math.abs(parseInt(b.rshares)) ? -1 : 1)
@@ -222,13 +223,31 @@ class Voting extends React.Component {
             for( let v = 0; v < avotes.length && voters.length < MAX_VOTES_DISPLAY; ++v ) {
                 const {percent, voter} = avotes[v]
                 const sign = Math.sign(percent)
-                if(sign === 0) continue
-                voters.push({value: (sign > 0 ? '+ ' : '- ') + voter, link: '/@' + voter})
+                if (sign === 0) {
+                    continue
+                } else if (sign > 0) {
+                    voters.push({value: '+ ' + voter, link: '/@' + voter})
+                } else if (sign < 0) {
+                    voters.push({value: '- ' + voter, link: '/@' + voter})
+                    all_flags.push({value: 'flag_' + voter, link: '/@' + voter, label: '- ' + voter})
+                }
             }
             if (total_votes > voters.length) {
                 voters.push({value: <span>&hellip; {tt('voting_jsx.and_more', {count: total_votes - voters.length})}</span>});
             }
             voters_list = <DropdownMenu selected={tt('voting_jsx.votes_plural', {count: total_votes})} className="Voting__voters_list" items={voters} el="div" />;
+        }
+
+        let flags_list = null;
+        if (showList && all_flags.length > 0) {
+            let flags = [];
+            for( let v = 0; v < all_flags.length; ++v && flags < MAX_VOTES_DISPLAY) {
+                flags.push(all_flags[v]);
+            }
+            if( all_flags.length > flags.length ) {
+                flags.push({value: <span>&hellip; {tt('voting_jsx.and_more', {count: all_flags - flags.length})}</span>});
+            }
+            flags_list = <DropdownMenu selected={tt('voting_jsx.flags_plural', {count: flags.length})} className="Voting__flags_list" items={flags} el="div" />;
         }
 
         let voteUpClick = this.voteUp;
@@ -254,6 +273,7 @@ class Voting extends React.Component {
                     {payoutEl}
                 </span>
                 {voters_list}
+                {flags_list}
             </span>
         );
     }

--- a/src/app/components/elements/Voting.scss
+++ b/src/app/components/elements/Voting.scss
@@ -177,7 +177,7 @@
   }
 }
 
-.DropdownMenu.Voting__voters_list ul {
+.DropdownMenu.Voting__voters_list ul, .DropdownMenu.Voting__flaggers_list ul {
   li > a {
     //font-weight: 200;
   }

--- a/src/app/components/elements/Voting.scss
+++ b/src/app/components/elements/Voting.scss
@@ -177,7 +177,7 @@
   }
 }
 
-.DropdownMenu.Voting__voters_list ul, .DropdownMenu.Voting__flaggers_list ul {
+.DropdownMenu.Voting__voters_list ul, .DropdownMenu.Voting__flags_list ul {
   li > a {
     //font-weight: 200;
   }

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -397,6 +397,10 @@
     "votes_plural": {
       "one": "%(count)s vote",
       "other": "%(count)s votes"
+    },
+    "flags_plural": {
+      "one": "%(count)s flag",
+      "other": "%(count)s flags"
     }
   },
   "witnesses_jsx": {


### PR DESCRIPTION
## Issue
Users want the ability to see a list of their downvoters on the PostFull page.

## Solution
This pull request contains the code necessary to enable the downvoters list on the PostFull page. The code utilizes the same behavior that the voters dropdown uses to keep a consistency between the UI.

## Screenshots
![screen shot 2017-11-12 at 5 19 45 pm](https://user-images.githubusercontent.com/7006965/32704671-6fe3a67c-c7ce-11e7-9492-dc1e03e63372.png)
![screen shot 2017-11-12 at 5 21 14 pm](https://user-images.githubusercontent.com/7006965/32704673-71f34648-c7ce-11e7-86a1-033ca0133dc7.png)