### PR TITLE
Show the image upload helper on all replies, even comments

### DIFF
--- a/src/app/components/elements/ReplyEditor.jsx
+++ b/src/app/components/elements/ReplyEditor.jsx
@@ -389,13 +389,11 @@ class ReplyEditor extends React.Component {
                                                   autoComplete="off"
                                                   tabIndex={2} />
                                     </Dropzone>
-                                {type === 'submit_story' &&
                                 <p className="drag-and-drop">
                                     {tt('reply_editor.insert_images_by_dragging_dropping')}
                                     {noClipboardData ? '' : tt('reply_editor.pasting_from_the_clipboard')}
                                     {tt('reply_editor.or_by')} <a onClick={this.onOpenClick}>{tt('reply_editor.selecting_them')}</a>.
                                 </p>
-                                }
                                 {progress.message && <div className="info">{progress.message}</div>}
                                 {progress.error && <div className="error">{tt('reply_editor.image_upload')} : {progress.error}</div>}
                                 </span>


### PR DESCRIPTION
## Issue
Users want to be able to use the image upload helper that they see on posts when replying to comments. Many users are browsing SteemIt on mobile and trying to upload images any other way is a PAIN!

## Solution
Show the image upload helper at the bottom of the reply box for comments as well as posts.

## Summary
Due to the fact that a large number of users are browsing the SteemIt website on mobile devices, it would be wise to enable the image upload helper on all reply boxes. Often times users wish to be able to upload memes or whatever they want in comments. Restricting such features will only serve to frustrate users familiar with other forms of social media.

## Screenshots
- Original - ![screen shot 2017-11-12 at 9 19 11 pm](https://user-images.githubusercontent.com/7006965/32708633-af837e5c-c7f0-11e7-8082-4ed782c319aa.png)
- Image helper - ![screen shot 2017-11-12 at 9 17 35 pm](https://user-images.githubusercontent.com/7006965/32708634-b1b2746c-c7f0-11e7-8c36-975bc2e11b44.png)
- File selector - ![screen shot 2017-11-12 at 9 17 55 pm](https://user-images.githubusercontent.com/7006965/32708637-b2f2c7f0-c7f0-11e7-8963-0159f0ac4c4a.png)