### PR TITLE
Fixes tiny text field bug on small screens

### DIFF
--- a/src/app/components/modules/PromotePost.jsx
+++ b/src/app/components/modules/PromotePost.jsx
@@ -75,7 +75,7 @@ class PromotePost extends Component {
                        <p>{tt('promote_post_jsx.spend_your_DEBT_TOKEN_to_advertise_this_post', {DEBT_TOKEN})}.</p>
                        <hr />
                        <div className="row">
-                           <div className="column small-6 large-4">
+                           <div className="column small-7 medium-5 large-4">
                                <label>{tt('g.amount')}</label>
                                <div className="input-group">
                                    <input className="input-group-field" type="text" placeholder={tt('g.amount')} value={amount} ref="amount" autoComplete="off" disabled={loading} onChange={this.amountChange} />

--- a/src/app/components/modules/PromotePost.jsx
+++ b/src/app/components/modules/PromotePost.jsx
@@ -75,7 +75,7 @@ class PromotePost extends Component {
                        <p>{tt('promote_post_jsx.spend_your_DEBT_TOKEN_to_advertise_this_post', {DEBT_TOKEN})}.</p>
                        <hr />
                        <div className="row">
-                           <div className="column small-4">
+                           <div className="column small-6 large-4">
                                <label>{tt('g.amount')}</label>
                                <div className="input-group">
                                    <input className="input-group-field" type="text" placeholder={tt('g.amount')} value={amount} ref="amount" autoComplete="off" disabled={loading} onChange={this.amountChange} />


### PR DESCRIPTION
Fix for issue: #1520 ( and it's duplicate #1930 )

Changes I made:
- modified the grid CSS classes for promotion popup from `small-4` to `small-6 large-4`

So that the amount section has it's width set to 50% on small screens, but on large screens the width will remain as it is now.

Here is how it looks with this change on different screen sizes:

### 360px
![promote-360px](https://user-images.githubusercontent.com/32915194/32755455-ae97dc3c-c8d5-11e7-8d7d-061fb3177164.png)

### 480px
![promote-480px](https://user-images.githubusercontent.com/32915194/32755456-aeafe764-c8d5-11e7-887a-e9e34dd47b05.png)


### 800px
![promote-800px](https://user-images.githubusercontent.com/32915194/32755457-aec9a73a-c8d5-11e7-900f-bd0775b617d4.png)

### 1024px
![promote-1024px](https://user-images.githubusercontent.com/32915194/32755458-aee79f4c-c8d5-11e7-8b19-fae077f20451.png)