### PR TITLE
Update Steemit API Links URL

### DIFF
--- a/src/app/components/App.jsx
+++ b/src/app/components/App.jsx
@@ -257,7 +257,7 @@ class App extends React.Component {
                         </a>
                     </li>
                     <li className="last">
-                        <a href="https://steemit.github.io/steemit-docs/" target="_blank" rel="noopener noreferrer">
+                        <a href="https://developers.steem.io/" target="_blank" rel="noopener noreferrer">
                             {tt('navigation.api_docs')}&nbsp;<Icon name="extlink" />
                         </a>
                     </li>


### PR DESCRIPTION
Currently the "Steemit API Links" URL is pointing to `https://steemit.github.io/steemit-docs/`. Update it to point to the new Dev Portal: `https://developers.steem.io/`