### PR TITLE
Allow users the ability to upload a secondary mobile cover image

### DIFF
--- a/src/app/components/modules/Settings.jsx
+++ b/src/app/components/modules/Settings.jsx
@@ -25,11 +25,12 @@ class Settings extends React.Component {
         reactForm({
             instance: this,
             name: 'accountSettings',
-            fields: ['profile_image', 'cover_image', 'name', 'about', 'location', 'website'],
+            fields: ['profile_image', 'cover_image', 'cover_image_mobile', 'name', 'about', 'location', 'website'],
             initialValues: props.profile,
             validation: values => ({
                 profile_image: values.profile_image && !/^https?:\/\//.test(values.profile_image) ? tt('settings_jsx.invalid_url') : null,
                 cover_image: values.cover_image && !/^https?:\/\//.test(values.cover_image) ? tt('settings_jsx.invalid_url') : null,
+                cover_image_mobile: values.cover_image_mobile && !/^https?:\/\//.test(values.cover_image_mobile) ? tt('settings_jsx.invalid_url') : null,
                 name: values.name && values.name.length > 20 ? tt('settings_jsx.name_is_too_long') : values.name && /^\s*@/.test(values.name) ? tt('settings_jsx.name_must_not_begin_with') : null,
                 about: values.about && values.about.length > 160 ? tt('settings_jsx.about_is_too_long') : null,
                 location: values.location && values.location.length > 30 ? tt('settings_jsx.location_is_too_long') : null,
@@ -58,11 +59,12 @@ class Settings extends React.Component {
         if(!metaData.profile) metaData.profile = {}
         delete metaData.user_image; // old field... cleanup
 
-        const {profile_image, cover_image, name, about, location, website} = this.state
+        const {profile_image, cover_image, cover_image_mobile, name, about, location, website} = this.state
 
         // Update relevant fields
         metaData.profile.profile_image = profile_image.value
         metaData.profile.cover_image = cover_image.value
+        metaData.profile.cover_image_mobile = cover_image_mobile.value
         metaData.profile.name = name.value
         metaData.profile.about = about.value
         metaData.profile.location = location.value
@@ -71,6 +73,7 @@ class Settings extends React.Component {
         // Remove empty keys
         if(!metaData.profile.profile_image) delete metaData.profile.profile_image;
         if(!metaData.profile.cover_image) delete metaData.profile.cover_image;
+        if(!metaData.profile.cover_image_mobile) delete metaData.profile.cover_image_mobile;
         if(!metaData.profile.name) delete metaData.profile.name;
         if(!metaData.profile.about) delete metaData.profile.about;
         if(!metaData.profile.location) delete metaData.profile.location;
@@ -123,7 +126,7 @@ class Settings extends React.Component {
         const {submitting, valid, touched} = this.state.accountSettings
         const disabled = !props.isOwnAccount || state.loading || submitting || !valid || !touched
 
-        const {profile_image, cover_image, name, about, location, website} = this.state
+        const {profile_image, cover_image, cover_image_mobile, name, about, location, website} = this.state
 
         const {follow, account, isOwnAccount, user_preferences} = this.props
         const following = follow && follow.getIn(['getFollowingAsync', account.name]);
@@ -158,6 +161,12 @@ class Settings extends React.Component {
                         <input type="url" {...cover_image.props} autoComplete="off" />
                     </label>
                     <div className="error">{cover_image.blur && cover_image.touched && cover_image.error}</div>
+
+                    <label>
+                        {tt('settings_jsx.cover_image_url_mobile')}
+                        <input type="url" {...cover_image_mobile.props} autoComplete="off" />
+                    </label>
+                    <div className="error">{cover_image_mobile.blur && cover_image_mobile.touched && cover_image_mobile.error}</div>
 
                     <label>
                         {tt('settings_jsx.profile_name')}

--- a/src/app/components/pages/UserProfile.jsx
+++ b/src/app/components/pages/UserProfile.jsx
@@ -42,6 +42,16 @@ export default class UserProfile extends React.Component {
         this.loadMore = this.loadMore.bind(this);
     }
 
+    componentDidMount() {
+        window.addEventListener("resize", this.resize.bind(this));
+        this.resize();
+    }
+
+    resize() {
+        this.setState({showMobileCover: window.innerWidth <= 639});
+        this.forceUpdate();
+    }
+
     shouldComponentUpdate(np) {
         const {follow} = this.props;
         const {follow_count} = this.props;
@@ -434,7 +444,7 @@ export default class UserProfile extends React.Component {
             </div>
          </div>;
 
-        const {name, location, about, website, cover_image} = normalizeProfile(account);
+        const {name, location, about, website, cover_image, cover_image_mobile} = normalizeProfile(account);
         const website_label = website ? website.replace(/^https?:\/\/(www\.)?/, '').replace(/\/$/, '') : null
 
         let cover_image_style = {}
@@ -442,12 +452,19 @@ export default class UserProfile extends React.Component {
             cover_image_style = {backgroundImage: "url(" + proxifyImageUrl(cover_image, '2048x512') + ")"}
         }
 
+        let cover_image_mobile_style = {}
+        if(cover_image_mobile) {
+            cover_image_mobile_style = {backgroundImage: "url(" + proxifyImageUrl(cover_image_mobile, '640x512') + ")"}
+        }
+
+        const showMobileCover = this.state.showMobileCover;
+
         return (
             <div className="UserProfile">
 
                 <div className="UserProfile__banner row expanded">
 
-                    <div className="column" style={cover_image_style}>
+                    <div className="column" style={showMobileCover ? cover_image_mobile_style : cover_image_style}>
                         <div style={{position: "relative"}}>
                             <div className="UserProfile__buttons hide-for-small-only">
                                 <Follow follower={username} following={accountname} />

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -592,6 +592,7 @@
     "update": "Update",
     "profile_image_url": "Profile picture url",
     "cover_image_url": "Cover image url",
+    "cover_image_url_mobile": "Cover image url - mobile",
     "profile_name": "Display Name",
     "profile_about": "About",
     "profile_location": "Location",

--- a/src/app/utils/NormalizeProfile.js
+++ b/src/app/utils/NormalizeProfile.js
@@ -35,7 +35,7 @@ export default function normalizeProfile(account) {
     }
 
     // Read & normalize
-    let {name, about, location, website, profile_image, cover_image} = profile
+    let {name, about, location, website, profile_image, cover_image, cover_image_mobile} = profile
 
     name = truncate(name, 20)
     about = truncate(about, 160)
@@ -56,6 +56,7 @@ export default function normalizeProfile(account) {
 
     if(profile_image && !/^https?:\/\//.test(profile_image)) profile_image = null;
     if(cover_image && !/^https?:\/\//.test(cover_image)) cover_image = null;
+    if(cover_image_mobile && !/^https?:\/\//.test(cover_image_mobile)) cover_image_mobile = null;
 
     return {
         name,
@@ -64,5 +65,6 @@ export default function normalizeProfile(account) {
         website,
         profile_image,
         cover_image,
+        cover_image_mobile,
     };
 }


### PR DESCRIPTION
## Issue
Due to the fact that cover images are recommended to be sized and set for 2048px, they end up looking horrible on mobile (if even visible).

## Solution
Instead of some magic with trying to resize the image and position it depending on screen size, allow users the ability to set a mobile cover image that will be displayed automatically when the screen size is mobile size.

## Summary
Users get a lot of pride about differentiating their profiles from others. Unfortunately, they are running into issues trying to size an image that has a happy medium between to drastically different screen resolutions. This pull request is very unobtrusive to the UI and allows users to have more freedom over their own profile page customization. This is an easy win for an greatly improved end user experience on condenser.

## Screenshots
![screen shot 2017-11-14 at 1 12 42 am](https://user-images.githubusercontent.com/7006965/32767417-f4ee80a2-c8d8-11e7-8194-63c1a90b804d.png)
![screen shot 2017-11-14 at 1 12 34 am](https://user-images.githubusercontent.com/7006965/32767419-f707077e-c8d8-11e7-985c-f501b8f2d9ac.png)
![screen shot 2017-11-14 at 1 12 20 am](https://user-images.githubusercontent.com/7006965/32767421-f8263666-c8d8-11e7-83c2-c7cff24ca2c0.png)