### PR TITLE
Add a small search input field next to the search button on the header.

### DIFF
--- a/src/app/components/elements/HorizontalMenu.jsx
+++ b/src/app/components/elements/HorizontalMenu.jsx
@@ -14,22 +14,6 @@ export default class HorizontalMenu extends React.Component {
 
     render() {
         const {items, title, className, hideValue, includeSearch} = this.props;
-        const headerSearchInput = (
-            <li className={"Header__search-input"}>
-                <form className="column"
-                    action="/static/search.html"
-                    method="GET">
-                    <div className="input-group">
-                        <div className="input-group-button">
-                            <button href="/static/search.html" type="submit" title={tt('g.search')}>
-                                <Icon name="search" />
-                            </button>
-                        </div>
-                        <input type="text" placeholder="search" className="input-group-field" name="q" autoComplete="off"></input>
-                    </div>
-                </form>
-            </li>
-        )
         return <ul className={'HorizontalMenu menu' + (className ? ' ' + className : '')}>
             {title && <li className="title">{title}</li>}
             {items.map(i => {
@@ -44,7 +28,6 @@ export default class HorizontalMenu extends React.Component {
                     }
                 </li>
             })}
-            {includeSearch && headerSearchInput}
         </ul>;
     }
 }

--- a/src/app/components/elements/HorizontalMenu.jsx
+++ b/src/app/components/elements/HorizontalMenu.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Link } from 'react-router'
 import Icon from 'app/components/elements/Icon';
+import tt from 'counterpart';
 
 export default class HorizontalMenu extends React.Component {
     static propTypes = {
@@ -8,10 +9,27 @@ export default class HorizontalMenu extends React.Component {
         title: React.PropTypes.string,
         className: React.PropTypes.string,
         hideValue: React.PropTypes.string,
+        includeSearch: React.PropTypes.boolean,
     };
 
     render() {
-        const {items, title, className, hideValue} = this.props;
+        const {items, title, className, hideValue, includeSearch} = this.props;
+        const headerSearchInput = (
+            <li className={"Header__search-input"}>
+                <form className="column"
+                    action="/static/search.html"
+                    method="GET">
+                    <div className="input-group">
+                        <div className="input-group-button">
+                            <button href="/static/search.html" type="submit" title={tt('g.search')}>
+                                <Icon name="search" />
+                            </button>
+                        </div>
+                        <input type="text" textAlign="left" placeholder="search" className="input-group-field" name="q" autoComplete="off"></input>
+                    </div>
+                </form>
+            </li>
+        )
         return <ul className={'HorizontalMenu menu' + (className ? ' ' + className : '')}>
             {title && <li className="title">{title}</li>}
             {items.map(i => {
@@ -26,6 +44,7 @@ export default class HorizontalMenu extends React.Component {
                     }
                 </li>
             })}
+            {includeSearch && headerSearchInput}
         </ul>;
     }
 }

--- a/src/app/components/elements/HorizontalMenu.jsx
+++ b/src/app/components/elements/HorizontalMenu.jsx
@@ -9,7 +9,7 @@ export default class HorizontalMenu extends React.Component {
         title: React.PropTypes.string,
         className: React.PropTypes.string,
         hideValue: React.PropTypes.string,
-        includeSearch: React.PropTypes.boolean,
+        includeSearch: React.PropTypes.bool,
     };
 
     render() {
@@ -25,7 +25,7 @@ export default class HorizontalMenu extends React.Component {
                                 <Icon name="search" />
                             </button>
                         </div>
-                        <input type="text" textAlign="left" placeholder="search" className="input-group-field" name="q" autoComplete="off"></input>
+                        <input type="text" placeholder="search" className="input-group-field" name="q" autoComplete="off"></input>
                     </div>
                 </form>
             </li>

--- a/src/app/components/modules/Header.jsx
+++ b/src/app/components/modules/Header.jsx
@@ -211,7 +211,21 @@ class Header extends React.Component {
                                 </li>
                                 <li className="Header__top-steemit show-for-medium noPrint"><Link to={logo_link}><span className="beta fade-in--10">beta</span></Link></li>
                                 {selected_sort_order && <DropdownMenu className="Header__sort-order-menu menu-hide-for-large" items={sort_order_menu} selected={selected_sort_order[1]} el="li" />}
-                                <HorizontalMenu className="show-for-medium" items={sort_order_menu_horizontal} includeSearch={true} />
+                                <HorizontalMenu className="show-for-medium" items={sort_order_menu_horizontal} />
+                                <li className={"hide-for-small-only Header__search-input"}>
+                                    <form className="column"
+                                        action="/static/search.html"
+                                        method="GET">
+                                        <div className="input-group">
+                                            <div className="input-group-button">
+                                                <button href="/static/search.html" type="submit" title={tt('g.search')}>
+                                                    <Icon name="search" />
+                                                </button>
+                                            </div>
+                                            <input type="text" placeholder="search" className="input-group-field" name="q" autoComplete="off"></input>
+                                        </div>
+                                    </form>
+                                </li>
                             </ul>
                         </div>
                         <div className="columns shrink">

--- a/src/app/components/modules/Header.jsx
+++ b/src/app/components/modules/Header.jsx
@@ -211,7 +211,7 @@ class Header extends React.Component {
                                 </li>
                                 <li className="Header__top-steemit show-for-medium noPrint"><Link to={logo_link}><span className="beta fade-in--10">beta</span></Link></li>
                                 {selected_sort_order && <DropdownMenu className="Header__sort-order-menu menu-hide-for-large" items={sort_order_menu} selected={selected_sort_order[1]} el="li" />}
-                                <HorizontalMenu items={sort_order_menu_horizontal} />
+                                <HorizontalMenu items={sort_order_menu_horizontal} includeSearch={true} />
                             </ul>
                         </div>
                         <div className="columns shrink">

--- a/src/app/components/modules/Header.jsx
+++ b/src/app/components/modules/Header.jsx
@@ -211,7 +211,7 @@ class Header extends React.Component {
                                 </li>
                                 <li className="Header__top-steemit show-for-medium noPrint"><Link to={logo_link}><span className="beta fade-in--10">beta</span></Link></li>
                                 {selected_sort_order && <DropdownMenu className="Header__sort-order-menu menu-hide-for-large" items={sort_order_menu} selected={selected_sort_order[1]} el="li" />}
-                                <HorizontalMenu items={sort_order_menu_horizontal} includeSearch={true} />
+                                <HorizontalMenu className="show-for-medium" items={sort_order_menu_horizontal} includeSearch={true} />
                             </ul>
                         </div>
                         <div className="columns shrink">

--- a/src/app/components/modules/Header.scss
+++ b/src/app/components/modules/Header.scss
@@ -91,6 +91,26 @@
           padding: 0 1rem;
       }
   }
+
+  .input-group {
+    margin-bottom: 0;
+  }
+
+  .input-group-button {
+    padding-left: .4rem;
+  }
+
+  input[type='text'] {
+    min-width: 7rem;
+    max-width: 15rem;
+    text-align: left;
+    border-radius: 3px;
+    border: 0px transparent;
+
+    &:hover, &:focus {
+      border-bottom: 1px solid $color-teal;
+    }
+  }
 }
 
 ul > li.Header__top-logo > a {

--- a/src/app/components/modules/Header.scss
+++ b/src/app/components/modules/Header.scss
@@ -94,6 +94,7 @@
 
   .input-group {
     margin-bottom: 0;
+    margin-left: -1.2rem;
   }
 
   .input-group-button {

--- a/src/app/components/modules/TopRightMenu.jsx
+++ b/src/app/components/modules/TopRightMenu.jsx
@@ -52,6 +52,7 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
         ];
         return (
             <ul className={mcn + mcl}>
+                <li className={"show-for-small-only Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>
                 {submit_story}
                 {!vertical && submit_icon}
                 <LinkWithDropdown
@@ -78,6 +79,7 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
     if (probablyLoggedIn) {
         return (
             <ul className={mcn + mcl}>
+                <li className={"show-for-small-only Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>
                 <li className={lcn} style={{paddingTop: 0, paddingBottom: 0}}><LoadingIndicator type="circle" inline /></li>
                 {toggleOffCanvasMenu && <li className="toggle-menu Header__hamburger"><a href="#" onClick={toggleOffCanvasMenu}>
                     <span className="hamburger" />
@@ -87,6 +89,7 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
     }
     return (
         <ul className={mcn + mcl}>
+            <li className={"show-for-small-only Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>
             <li className={lcn}><a href="/pick_account">{tt('g.sign_up')}</a></li>
             <li className={lcn}><a href="/login.html" onClick={showLogin}>{tt('g.login')}</a></li>
             {submit_story}

--- a/src/app/components/modules/TopRightMenu.jsx
+++ b/src/app/components/modules/TopRightMenu.jsx
@@ -52,7 +52,7 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
         ];
         return (
             <ul className={mcn + mcl}>
-                <li className={"show-for-small-only Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>
+                <li className={lcn + " Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>
                 {submit_story}
                 {!vertical && submit_icon}
                 <LinkWithDropdown
@@ -79,7 +79,7 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
     if (probablyLoggedIn) {
         return (
             <ul className={mcn + mcl}>
-                <li className={"show-for-small-only Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>
+                {!vertical && <li className={lcn + " Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>}
                 <li className={lcn} style={{paddingTop: 0, paddingBottom: 0}}><LoadingIndicator type="circle" inline /></li>
                 {toggleOffCanvasMenu && <li className="toggle-menu Header__hamburger"><a href="#" onClick={toggleOffCanvasMenu}>
                     <span className="hamburger" />
@@ -89,7 +89,7 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
     }
     return (
         <ul className={mcn + mcl}>
-            <li className={"show-for-small-only Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>
+            {!vertical && <li className={lcn + " Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>}
             <li className={lcn}><a href="/pick_account">{tt('g.sign_up')}</a></li>
             <li className={lcn}><a href="/login.html" onClick={showLogin}>{tt('g.login')}</a></li>
             {submit_story}

--- a/src/app/components/modules/TopRightMenu.jsx
+++ b/src/app/components/modules/TopRightMenu.jsx
@@ -52,7 +52,6 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
         ];
         return (
             <ul className={mcn + mcl}>
-                <li className={lcn + " Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>
                 {submit_story}
                 {!vertical && submit_icon}
                 <LinkWithDropdown
@@ -79,7 +78,6 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
     if (probablyLoggedIn) {
         return (
             <ul className={mcn + mcl}>
-                {!vertical && <li className="Header__search"><a href="/static/search.html" title={tt_search}><Icon name="search" /></a></li>}
                 <li className={lcn} style={{paddingTop: 0, paddingBottom: 0}}><LoadingIndicator type="circle" inline /></li>
                 {toggleOffCanvasMenu && <li className="toggle-menu Header__hamburger"><a href="#" onClick={toggleOffCanvasMenu}>
                     <span className="hamburger" />
@@ -89,7 +87,6 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
     }
     return (
         <ul className={mcn + mcl}>
-            {!vertical && <li className="Header__search"><a href="/static/search.html" title={tt_search}><Icon name="search" /></a></li>}
             <li className={lcn}><a href="/pick_account">{tt('g.sign_up')}</a></li>
             <li className={lcn}><a href="/login.html" onClick={showLogin}>{tt('g.login')}</a></li>
             {submit_story}

--- a/src/app/components/modules/TopRightMenu.jsx
+++ b/src/app/components/modules/TopRightMenu.jsx
@@ -52,7 +52,7 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
         ];
         return (
             <ul className={mcn + mcl}>
-                <li className={lcn + " Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>
+                <li className={"show-for-small-only Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>
                 {submit_story}
                 {!vertical && submit_icon}
                 <LinkWithDropdown
@@ -79,7 +79,7 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
     if (probablyLoggedIn) {
         return (
             <ul className={mcn + mcl}>
-                {!vertical && <li className={lcn + " Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>}
+                {!vertical && <li className={"show-for-small-only Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>}
                 <li className={lcn} style={{paddingTop: 0, paddingBottom: 0}}><LoadingIndicator type="circle" inline /></li>
                 {toggleOffCanvasMenu && <li className="toggle-menu Header__hamburger"><a href="#" onClick={toggleOffCanvasMenu}>
                     <span className="hamburger" />
@@ -89,7 +89,7 @@ function TopRightMenu({username, showLogin, logout, loggedIn, vertical, navigate
     }
     return (
         <ul className={mcn + mcl}>
-            {!vertical && <li className={lcn + " Header__search"}><a href="/static/search.html" title={tt_search}>{vertical ? <span>{tt_search}</span> : <Icon name="search" />}</a></li>}
+            {!vertical && <li className={"show-for-small-only Header__search"}><a href="/static/search.html" title={tt_search}><Icon name="search" /></a></li>}
             <li className={lcn}><a href="/pick_account">{tt('g.sign_up')}</a></li>
             <li className={lcn}><a href="/login.html" onClick={showLogin}>{tt('g.login')}</a></li>
             {submit_story}


### PR DESCRIPTION
## Issue
Currently users have to click the small search icon to be redirected to the search page. They then have to click the input on the search page, begin typing and press enter to see results.

## Solution
Add a search input field next to the search icon if users prefer to be more direct.

## Summary
At the moment, it is kind of a pain to search the website. We have the solution in place of the google site search link, but it isnt very user friendly. In an effort to approve the end user experience, this pull request adds a small input field next to the search icon on the header. It respects the rules of staying hidden on small screens.

## Screenshots
![screen shot 2017-11-14 at 2 46 33 pm](https://user-images.githubusercontent.com/7006965/32804691-59b90ad8-c94d-11e7-96ef-b1d7724e188c.png)
![screen shot 2017-11-14 at 2 46 13 pm](https://user-images.githubusercontent.com/7006965/32804686-588e30de-c94d-11e7-9565-798e9a6a3668.png)