### PR TITLE
1946 handle even more cases of delayed document loading (scrollHeight…

### DIFF
--- a/src/app/utils/UserUtil.js
+++ b/src/app/utils/UserUtil.js
@@ -21,11 +21,13 @@ export const setStore = (theStore) => {
  * @returns {boolean}
  */
 export const currentUser = () => {
-    const state = store.getState();
-    if(state.user) {
-        const current = state.user.getIn(['current']);
-        if(current) {
-            return current;
+    if (store) {
+        const state = store.getState();
+        if (state.user) {
+            const current = state.user.getIn(['current']);
+            if (current) {
+                return current;
+            }
         }
     }
     return false;
@@ -37,11 +39,13 @@ export const currentUser = () => {
  * @returns {boolean}
  */
 export const currentUsername = () => {
-    const state = store.getState();
-    if(state.user) {
-        const uName = state.user.getIn(['current', 'username']);
-        if(uName) {
-            return uName;
+    if (store) {
+        const state = store.getState();
+        if (state.user) {
+            const uName = state.user.getIn(['current', 'username']);
+            if (uName) {
+                return uName;
+            }
         }
     }
     return false;

--- a/src/app/utils/UserUtil.js
+++ b/src/app/utils/UserUtil.js
@@ -5,6 +5,7 @@
 
 
 let store = false;
+const MSG_STORE_NOT_SET = 'store is not set';
 
 export const setStore = (theStore) => {
     if(!store) {
@@ -29,6 +30,8 @@ export const currentUser = () => {
                 return current;
             }
         }
+    } else {
+        console.warn(MSG_STORE_NOT_SET);
     }
     return false;
 }
@@ -47,6 +50,8 @@ export const currentUsername = () => {
                 return uName;
             }
         }
+    } else {
+        console.warn(MSG_STORE_NOT_SET);
     }
     return false;
 }


### PR DESCRIPTION
Closes #1946 ...even more
… change) in a generic way

This update handles instances where the browser incorrectly sticks the viewport to the bottom of the page, or does not hold the scroll position at the correct element when images take longer to load.