### PR TITLE
Enable a check on the transfer form to ensure users are not sending transfers to themselves

### DIFF
--- a/src/app/components/modules/Transfer.jsx
+++ b/src/app/components/modules/Transfer.jsx
@@ -72,7 +72,9 @@ class TransferForm extends Component {
             initialValues: props.initialValues,
             validation: values => ({
                 to:
-                    ! values.to ? tt('g.required') : validate_account_name(values.to, values.memo),
+                    ! values.to ? tt('g.required') :
+                    values.to === props.currentUser.get('username') ? tt('transfer_jsx.transfer_to_own_account') :
+                    validate_account_name(values.to, values.memo),
                 amount:
                     ! values.amount ? 'Required' :
                     ! /^\d+(\.\d+)?$/.test(values.amount) ? tt('transfer_jsx.amount_is_in_form') :

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -613,7 +613,8 @@
     "from": "From",
     "to": "To",
     "asset_currently_collecting": "%(asset)s currently collecting %(interest)s%% APR.",
-    "beware_of_spam_and_phishing_links": "Beware of spam and phishing links in transfer memos. Do not open links from users you do not trust. Do not provide your private keys to any third party websites."
+    "beware_of_spam_and_phishing_links": "Beware of spam and phishing links in transfer memos. Do not open links from users you do not trust. Do not provide your private keys to any third party websites.",
+    "transfer_to_own_account": "You are sending a transfer to your currently logged in account."
   },
   "userwallet_jsx": {
     "conversion_complete_tip": "Will complete on",


### PR DESCRIPTION
## Issue
Users are able to send a transfer to their own account through the wallet

## Solution
When a user attempts to send a transfer to their own account, display a warning and disable the send button.

## Summary
Right now, STEEM can be a very confusing places for users. Due to this, I believe it is a good idea to let the frontend provide as much assistance as possible while educating the user. If a user has multiple accounts, they will often need to send transfers between them. On condenser, a user has the ability to send a transfer to the account they are currently logged in as. While not very damaging, it is still confusing and might result in some users not getting their funds to where they were hoping.

## Screenshots
![screen shot 2017-11-18 at 11 28 23 pm](https://user-images.githubusercontent.com/7006965/32987715-efd82c92-ccb8-11e7-80fc-f64bbf2f87e4.png)
![screen shot 2017-11-18 at 11 28 28 pm](https://user-images.githubusercontent.com/7006965/32987711-dcb29e5e-ccb8-11e7-8a75-136ae4b76932.png)
