### PR TITLE
Fix error message when a user attempts to power down with less than the minimum required amount

### DIFF
--- a/src/app/redux/Transaction.js
+++ b/src/app/redux/Transaction.js
@@ -73,7 +73,7 @@ export default createModule({
                         break;
                     case 'withdraw_vesting':
                         if(/Account registered by another account requires 10x account creation fee worth of Steem Power/.test(errorStr))
-                            errorKey = 'Account requires 10x the account creation fee in Steem Power (approximately 300 SP) before it can power down.'
+                            errorKey = 'Account requires 10x the account creation fee in Steem Power (approximately 2 SP) before it can power down.'
                         break;
                     default:
                         break;


### PR DESCRIPTION
## Issue
When a user with less than the minimum required amount (~2SP) tries to power down it tells them it requires ~300SP to powerdown.

## Solution
Change the error message to represent the current account power down minimum.

## Summary
This is definitely an edge case, but there will be users with less than 2SP that attempt the power down from their account. These users will run into an error telling them it will take about 300SP to be able to begin powering down. Updating the error message is a good solution in removing confusion around the frontend error messages. It would be good to internationalize these error messages.

## Screenshots
![image](https://user-images.githubusercontent.com/7006965/32987987-a35bb1de-ccbf-11e7-936b-e2e6453e95bf.png)
