### PR TITLE
Detect when a user presses escape key on settings update login screen

### DIFF
--- a/src/app/components/modules/Settings.jsx
+++ b/src/app/components/modules/Settings.jsx
@@ -19,6 +19,7 @@ class Settings extends React.Component {
         }
         this.initForm(props);
         this.onNsfwPrefChange = this.onNsfwPrefChange.bind(this);
+        this.escFunction = this.escFunction.bind(this);
     }
 
     initForm(props) {
@@ -44,6 +45,21 @@ class Settings extends React.Component {
         const {accountname} = this.props
         const nsfwPref = (process.env.BROWSER ? localStorage.getItem('nsfwPref-' + accountname) : null) || 'warn'
         this.setState({nsfwPref, oldNsfwPref: nsfwPref})
+    }
+
+    // Handle user pressing escape in form
+    componentDidMount(){
+        document.addEventListener("keydown", this.escFunction, false);
+    }
+
+    componentWillUnmount(){
+        document.removeEventListener("keydown", this.escFunction, false);
+    }
+
+    escFunction(event){
+        if(event.keyCode === 27) {
+            this.setState({loading: false})
+        }
     }
 
     onNsfwPrefChange(e) {


### PR DESCRIPTION
## Issue
When a user hits ESCAPE to cancel settings update, the "update" button never returns and is constantly a loading indicator.

## Solution
Detect when a user presses ESCAPE to cancel updating user settings and reset the loading state to false to unhide the "update" button

## Summary
On the user settings page, things get a bit unfriendly for the user when they dismiss the login modal after pressing "update" using ESCAPE. Dismissing the login modal via ESCAPE is not firing off an event to change the application state for the loading value. This pull request detects when a user presses escape only on the User Settings page due to the loading indicator hiding the submit button.

## Screenshots
![image](https://user-images.githubusercontent.com/7006965/32988580-d42e7c12-cccc-11e7-8e00-6496cd9d5108.png)
