### PR TITLE
change ref from old steemjs lib to new one

### DIFF
--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -39,7 +39,7 @@ export default {
             'react',
             'react-dom',
             'react-router',
-            'steem',
+            '@steemit/steem-js',
             'bytebuffer',
             'immutable',
             'autolinker',


### PR DESCRIPTION
fixes runtime error introduced in #1988 

![screenshot from 2017-11-28 19-28-21](https://user-images.githubusercontent.com/99194/33351797-89e94db8-d473-11e7-8d06-a7581d4a51ae.png)

error occurs in server- and client-side