### PR TITLE
Fix error message when a user attempts to power down with less than t…

### DIFF
--- a/src/app/redux/TransactionReducer.js
+++ b/src/app/redux/TransactionReducer.js
@@ -85,7 +85,7 @@ export default function reducer(state = defaultState, action) {
                             )
                         )
                             errorKey =
-                                'Account requires 10x the account creation fee in Steem Power (approximately 300 SP) before it can power down.';
+                                'Account requires 10x the account creation fee in Steem Power (approximately 30 SP) before it can power down.';
                         break;
                     default:
                         break;


### PR DESCRIPTION
…he minimum required amount. 2SP

Per slack discussion minimum SP required is 30.

Supercedes : #2029