### PR TITLE
update redux saga to v0.16.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
     "react-timeago": "^3.1.2",
     "redux": "^3.3.1",
     "redux-form": "5.3.4",
-    "redux-saga": "^0.9.5",
+    "redux-saga": "^0.16.0",
     "remarkable": "^1.7.1",
     "sanitize-html": "^1.11.4",
     "sass-loader": "^6.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7056,9 +7056,9 @@ redux-form@5.3.4:
     is-promise "^2.1.0"
     react-lazy-cache "^3.0.1"
 
-redux-saga@^0.9.5:
-  version "0.9.5"
-  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.9.5.tgz#f4bde5896e466932f758f86247b2fa6a4694ec2a"
+redux-saga@^0.16.0:
+  version "0.16.0"
+  resolved "https://registry.yarnpkg.com/redux-saga/-/redux-saga-0.16.0.tgz#0a231db0a1489301dd980f6f2f88d8ced418f724"
 
 redux@^3.3.1:
   version "3.7.2"


### PR DESCRIPTION
There is some debate over the best way to test Redux-Saga.


I have been frustrated with [writing unit tests for them](https://github.com/steemit/condenser/pull/2140/files#diff-5842cb9a8b07e8c503a252d37680ec6b). Updating Redux-saga will let me try a more general integrative approach -
https://github.com/jfairbank/redux-saga-test-plan

As well as allowing for a concise TDD for future Sagas.