### PR TITLE
remove unneeded HtmlReady test scenario

### DIFF
--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -9,11 +9,6 @@ describe('htmlready', () => {
         global.$STM_Config = {};
     });
 
-    it('should return plain text without html unmolested', () => {
-        const teststring = 'teststring lol';
-        expect(HtmlReady(teststring).html).to.equal(teststring);
-    });
-
     it('should allow links where the text portion and href contains steemit.com', () => {
         const dirty =
             '<xml xmlns="http://www.w3.org/1999/xhtml"><a href="https://steemit.com/signup" xmlns="http://www.w3.org/1999/xhtml">https://steemit.com/signup</a></xml>';


### PR DESCRIPTION
closes #2178 

wheni wrote this test suite i thought this was a needed consideration but it turns out it is not, and the test runner gets a (not-test-fail-causing) error when we run it. because we don't ever pass in a non-html string this test is safe to remove.