### PR TITLE
mark "to" field as touched after it is changed

### DIFF
--- a/src/app/components/modules/Transfer.jsx
+++ b/src/app/components/modules/Transfer.jsx
@@ -364,6 +364,7 @@ class TransferForm extends Component {
                                         this.setState({
                                             to: {
                                                 ...this.state.to,
+                                                touched: true,
                                                 value: e.target.value,
                                             },
                                         });
@@ -378,7 +379,7 @@ class TransferForm extends Component {
                                     }
                                 />
                             </div>
-                            {to.touched && to.blur && to.error ? (
+                            {to.touched && to.error ? (
                                 <div className="error">{to.error}&nbsp;</div>
                             ) : (
                                 <p>{toVesting && powerTip3}</p>


### PR DESCRIPTION
closes #2189

when i set up the autocomplete widget i didn't notice some loose couplings between the previous input element & our ReactForm system.