### PR TITLE
Add Ability To Burn Author Rewards Via UI

### DIFF
--- a/src/app/components/elements/ReplyEditor.jsx
+++ b/src/app/components/elements/ReplyEditor.jsx
@@ -653,7 +653,7 @@ class ReplyEditor extends React.Component {
                                         onChange={this.onPayoutTypeChange}
                                         style={{
                                             color:
-                                                this.state.payoutType == '0%'
+                                                ['0%','nullburn'].indexOf(this.state.payoutType) >= 0
                                                     ? 'orange'
                                                     : '',
                                         }}
@@ -663,6 +663,9 @@ class ReplyEditor extends React.Component {
                                         </option>
                                         <option value="50%">
                                             {tt('reply_editor.default_50_50')}
+                                        </option>
+                                        <option value="nullburn">
+                                            {tt('reply_editor.nullburn')}
                                         </option>
                                         <option value="0%">
                                             {tt('reply_editor.decline_payout')}
@@ -960,6 +963,11 @@ export default formId =>
                         case '100%': // 100% steem power payout
                             __config.comment_options = {
                                 percent_steem_dollars: 0, // 10000 === 100% (of 50%)
+                            };
+                            break;
+                        case 'nullburn': // Burn Author Rewards
+                            __config.comment_options = {
+                                extensions: [[0, {beneficiaries: [{ account: 'null', weight: 10000 }]}]]
                             };
                             break;
                         default: // 50% steem power, 50% sd+steem


### PR DESCRIPTION
### Issue
Currently the only option to denying a payout is to burn ALL rewards. This means curators do not get paid, and the rewards are simply redistributed to the rewards pool.

### Proposal
Add the "Burn Author Rewards" comment option. This option will burn all author rewards to `null` via a beneficiary channel.

### Summary
Since some users are not really dependent on their post earnings, they might wish to burn the author rewards. One reason for this action would be to ensure those rewards are not added to the available supply of STEEM. Burning this STEEM results in decreased supply with an unaffected demand, therefore likely higher market prices.

## Screenshots
![screen shot 2017-12-22 at 7 34 04 pm](https://user-images.githubusercontent.com/7006965/34316092-b55eade2-e753-11e7-9321-327545fa7ecd.png)
![screen shot 2017-12-22 at 7 54 22 pm](https://user-images.githubusercontent.com/7006965/34316094-b6f926f0-e753-11e7-87ad-c0ae44f9861c.png)
![screen shot 2017-12-22 at 7 58 52 pm](https://user-images.githubusercontent.com/7006965/34316095-b82f2786-e753-11e7-871d-607d4adddc4a.png)