### PR TITLE
change htmlready to throw error if xmldom throws an error

### DIFF
--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -109,9 +109,8 @@ export default function(html, { mutate = true, hideImages = false } = {}) {
             ...state,
         };
     } catch (error) {
-        // Not Used, parseFromString might throw an error in the future
-        console.error(error.toString());
-        return { html };
+        // xmldom error is bad
+        throw new Error('HtmlReady: xmldom error');
     }
 }
 

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -9,9 +9,11 @@ describe('htmlready', () => {
         global.$STM_Config = {};
     });
 
-    it('should return plain text without html unmolested', () => {
-        const teststring = 'teststring lol';
-        expect(HtmlReady(teststring).html).to.equal(teststring);
+    it('should throw an error if the input cannot be parsed', () => {
+        const teststring = 'teststring lol'; // this string causes the xmldom parser to fail & error out
+        expect(() => HtmlReady(teststring).html).to.throw(
+            'HtmlReady: xmldom error'
+        );
     });
 
     it('should allow links where the text portion and href contains steemit.com', () => {


### PR DESCRIPTION
closes #2178

see https://github.com/steemit/condenser/pull/2192 for discussion

DO NOT MERGE until we (especially @roadscape) take a long hard look!

i did quite a bit of testing and auditing and didn't see any circumstances where we give htmlready known-to-crash-xmldom strings & are expecting the raw html to be returned. if we deploy this PR it should be in tandem with #2152 so we can track any errors if they happen.