### PR TITLE
log stack traces if available

### DIFF
--- a/src/app/Main.js
+++ b/src/app/Main.js
@@ -10,10 +10,9 @@ import ConsoleExports from './utils/ConsoleExports';
 import { serverApiRecordEvent } from 'app/utils/ServerApiClient';
 import * as steem from '@steemit/steem-js';
 import { determineViewMode } from 'app/utils/Links';
+import frontendLogger from 'app/utils/FrontendLogger';
 
-window.onerror = error => {
-    if (window.$STM_csrf) serverApiRecordEvent('client_error', error);
-};
+window.addEventListener('error', frontendLogger);
 
 const CMD_LOG_T = 'log-t';
 const CMD_LOG_TOGGLE = 'log-toggle';

--- a/src/app/utils/FrontendLogger.js
+++ b/src/app/utils/FrontendLogger.js
@@ -1,0 +1,45 @@
+import { serverApiRecordEvent } from 'app/utils/ServerApiClient';
+
+/**
+ * Handles window error events by logging to overseer.
+ *
+ * This function relies on these globals:
+ * - process.env.VERSION
+ * - window.location.href
+ *
+ * @param {ErrorEvent} event
+ */
+export default function frontendLogger(event) {
+    if (window.$STM_csrf) {
+        const report = formatEventReport(
+            event,
+            window.location.href,
+            process.env.VERSION
+        );
+        serverApiRecordEvent('client_error', report);
+    }
+}
+
+/**
+ * Format a browser error event report
+ *
+ * @param {ErrorEvent} event
+ * @param {string} href
+ * @param {string} version
+ *
+ * @return {object}
+ */
+export function formatEventReport(event, href, version) {
+    const trace =
+        typeof event.error === 'object' &&
+        event.error !== null &&
+        typeof event.error.stack === 'string'
+            ? event.error.stack
+            : false;
+    return {
+        trace,
+        message: event.message,
+        href,
+        version,
+    };
+}

--- a/src/app/utils/FrontendLogger.test.js
+++ b/src/app/utils/FrontendLogger.test.js
@@ -1,0 +1,35 @@
+import { formatEventReport } from './FrontendLogger';
+
+describe('formatEventReport', () => {
+    it('should handle modern firefox/chrome errors with a stacktrace', () => {
+        const modernErrorEvent = {
+            error: {
+                stack: 'i am a stacktrace',
+            },
+            message: 'i am a message',
+        };
+
+        const logged = formatEventReport(
+            modernErrorEvent,
+            'location',
+            'version'
+        );
+
+        expect(logged.trace).toEqual('i am a stacktrace');
+        expect(logged.message).toEqual('i am a message');
+        expect(logged.version).toEqual('version');
+        expect(logged.href).toEqual('location');
+    });
+    it('should handle errors from browsers that do not provide a stack trace', () => {
+        const lameErrorEvent = {
+            message: 'i am an old error',
+        };
+
+        const logged = formatEventReport(lameErrorEvent, 'location', 'version');
+
+        expect(logged.trace).toEqual(false);
+        expect(logged.message).toEqual('i am an old error');
+        expect(logged.version).toEqual('version');
+        expect(logged.href).toEqual('location');
+    });
+});

--- a/webpack/prod.config.js
+++ b/webpack/prod.config.js
@@ -34,6 +34,13 @@ module.exports = {
                 comments: false
             }
         }),
-        ...baseConfig.plugins
+        ...baseConfig.plugins,
+        // Fix window.onerror
+        // See https://github.com/webpack/webpack/issues/5681#issuecomment-345861733
+        new webpack.SourceMapDevToolPlugin({
+            module: true,
+            columns: false,
+            moduleFilenameTemplate: info => { return `${info.resourcePath}?${info.loaders}` }
+        })
     ]
 };


### PR DESCRIPTION
closes #2222

related to #2152 

to test this, you need to do a production build -- it will not work when webpack does a development (sourcemaps included) build.

@jnordberg it looks like overseer is OK with an arbitrary object shape being passed as `metadata`, right? https://github.com/steemit/overseer/blob/master/src/server.ts#L61-L64

it'd probably be wise to decide on a format for these logs -- we can look at sentry for inspiration maybe