### PR TITLE
Show disabled/inactive witnesses in a different style on Witness page

### DIFF
--- a/src/app/components/pages/Witnesses.jsx
+++ b/src/app/components/pages/Witnesses.jsx
@@ -34,6 +34,8 @@ class Witnesses extends React.Component {
         this.onWitnessChange = e => {
             const customUsername = e.target.value;
             this.setState({ customUsername });
+            // Force update to ensure witness vote appears
+            this.forceUpdate();
         };
         this.accountWitnessProxy = e => {
             e.preventDefault();
@@ -76,6 +78,10 @@ class Witnesses extends React.Component {
             const owner = item.get('owner');
             const thread = item.get('url');
             const myVote = witness_votes ? witness_votes.has(owner) : null;
+            const signingKey = item.get('signing_key');
+            const witnessIsDisabled = /STM1111111111111111111111111111111114T1Anm/.test(signingKey);
+            const priceFeed = item.get('sbd_exchange_rate');
+            const noPriceFeed = /0.000 STEEM/.test(priceFeed.get('base'));
             const classUp =
                 'Voting__button Voting__button-up' +
                 (myVote === true ? ' Voting__button--upvoted' : '');
@@ -96,7 +102,9 @@ class Witnesses extends React.Component {
                 }
             }
             return (
-                <tr key={owner}>
+                <tr
+                    key={owner}
+                    style = { witnessIsDisabled || noPriceFeed ? { opacity: '0.4' } : null }>
                     <td width="75">
                         {rank < 10 && '0'}
                         {rank++}
@@ -115,7 +123,7 @@ class Witnesses extends React.Component {
                             </a>
                         </span>
                     </td>
-                    <td>
+                    <td style = { witnessIsDisabled || noPriceFeed ? { textDecoration: 'line-through' } : null }>
                         <Link to={'/@' + owner}>{owner}</Link>
                     </td>
                     <td>{witness_thread}</td>


### PR DESCRIPTION
### Issue
There is no distinction between a disabled and active witness on the witness page.

### Solution
Add a logic check and change the CSS for the name of the witness.

### Summary
If there are disabled witnesses in the top 50, users are unaware because the Condenser witness page does not show any distinction. This pull request contains code that will perform a basic check on the witness price feed and signing key. If the price feed is blank or the signing key is the disabled key, the witness name will be grey and strikethrough.

### Screenshots
- Without CSS
![screen shot 2017-12-26 at 11 08 24 pm](https://user-images.githubusercontent.com/7006965/34371312-b2c15b5c-ea91-11e7-976b-5454e5109afc.png)
- With CSS
![screen shot 2017-12-26 at 11 08 12 pm](https://user-images.githubusercontent.com/7006965/34371317-b7c53858-ea91-11e7-88e9-92900b760329.png)

### Extra Notes
This pull request should also address https://github.com/steemit/condenser/issues/1610 by adding a `forceUpdate` after applying the witness vote. Sometimes a simple `setState` does not properly trigger the `ComponentShouldUpdate`.