### PR TITLE
wrap a root-level iframe in html tags to avoid xmldom error

### DIFF
--- a/src/app/components/cards/MarkdownViewer.jsx
+++ b/src/app/components/cards/MarkdownViewer.jsx
@@ -87,6 +87,11 @@ class MarkdownViewer extends Component {
 
         let renderedText = html ? text : remarkable.render(text);
 
+        // If content is a bare iframe, wrap it in html tags
+        if (renderedText.match(/^<iframe([\S\s]*)<\/iframe>$/)) {
+            renderedText = '<html>' + renderedText + '</html>';
+        }
+
         // Embed videos, link mentions and hashtags, etc...
         if (renderedText)
             renderedText = HtmlReady(renderedText, { hideImages }).html;


### PR DESCRIPTION
closes #2246 

i'm not really sure why all these assumptions are made in [MarkdownViewer](https://github.com/steemit/condenser/blob/dcdad264d8cbf39e6c3d5344b26fadfe82169b50/src/app/components/cards/MarkdownViewer.jsx#L72-L80).

this is a hack; it will get us by until we get a chance to overhaul this html sanitizing/rendering pipeline.
