### PR TITLE
Strip php tags from posts, comments, and replies

### DIFF
--- a/src/app/components/cards/Comment.jsx
+++ b/src/app/components/cards/Comment.jsx
@@ -287,10 +287,11 @@ class CommentImpl extends React.Component {
         let controls = null;
 
         if (!this.state.collapsed && !hide_body) {
+            var sanitizedBody = comment.body.replace(/(\<\?{0,}php)/, 'php');
             body = (
                 <MarkdownViewer
                     formId={post + '-viewer'}
-                    text={comment.body}
+                    text={sanitizedBody}
                     noImage={noImage || gray}
                     hideImages={hideImages}
                     jsonMetadata={jsonMetadata}

--- a/src/app/components/cards/PostFull.jsx
+++ b/src/app/components/cards/PostFull.jsx
@@ -428,10 +428,11 @@ class PostFull extends React.Component {
         if (bShowLoading) {
             contentBody = <LoadingIndicator type="circle-strong" />;
         } else {
+            var sanitizedBody = content_body.replace(/(\<\?{0,}php)/, 'php');
             contentBody = (
                 <MarkdownViewer
                     formId={formId + '-viewer'}
-                    text={content_body}
+                    text={sanitizedBody}
                     jsonMetadata={jsonMetadata}
                     large
                     highQualityPost={high_quality_post}
@@ -451,9 +452,6 @@ class PostFull extends React.Component {
                     renderedEditor
                 ) : (
                     <span>
-                        <div className="float-right">
-                            <Voting post={post} flag />
-                        </div>
                         <div className="PostFull__header">
                             {post_header}
                             <TimeAuthorCategoryLarge

--- a/src/app/components/elements/ReplyEditor.jsx
+++ b/src/app/components/elements/ReplyEditor.jsx
@@ -413,6 +413,7 @@ class ReplyEditor extends React.Component {
             ? 'vframe__section--shrink'
             : '';
         const RichTextEditor = this.props.richTextEditor;
+        var sanitizedBody = body.value.replace(/(\<\?{0,}php)/, 'php');
 
         return (
             <div className="ReplyEditor row">
@@ -716,7 +717,7 @@ class ReplyEditor extends React.Component {
                                     <h6>{tt('g.preview')}</h6>
                                     <MarkdownViewer
                                         formId={formId}
-                                        text={body.value}
+                                        text={sanitizedBody}
                                         canEdit
                                         jsonMetadata={jsonMetadata}
                                         large={isStory}


### PR DESCRIPTION
## Issue
https://github.com/steemit/condenser/issues/2266
- Comments/posts that include a `<?php>` tag do not render.

## Solution
Strip the `<?php>` tags from Comment/Post body before rendering with MarkdownViewer

## Summary
If a user submits a post or comment with `<?php` in the body, the entire page will be broken because it will encounter an error in the `xmldom` DOMParser. If we simply strip the `<?php>` tags, the page will load as expected. This pull request implements a simple solution where the `<?` are removed from the tag rendering it safe.

## Screenshots
![screen shot 2018-01-04 at 4 33 07 pm](https://user-images.githubusercontent.com/7006965/34587626-b1af3ebc-f16e-11e7-9cc5-dede84862e01.png)