### PR TITLE
return a message rather than throwing if xmldom cannot parse

### DIFF
--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -110,7 +110,8 @@ export default function(html, { mutate = true, hideImages = false } = {}) {
         };
     } catch (error) {
         // xmldom error is bad
-        return { html: 'rendering error' };
+        console.log('rendering error', { error: error.message, html });
+        return { html: '' };
     }
 }
 

--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -110,7 +110,10 @@ export default function(html, { mutate = true, hideImages = false } = {}) {
         };
     } catch (error) {
         // xmldom error is bad
-        console.log('rendering error', { error: error.message, html });
+        console.log(
+            'rendering error',
+            JSON.stringify({ error: error.message, html })
+        );
         return { html: '' };
     }
 }

--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -110,7 +110,7 @@ export default function(html, { mutate = true, hideImages = false } = {}) {
         };
     } catch (error) {
         // xmldom error is bad
-        throw new Error('HtmlReady: xmldom error');
+        return { html: 'rendering error' };
     }
 }
 

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -9,9 +9,9 @@ describe('htmlready', () => {
         global.$STM_Config = {};
     });
 
-    it('should return a message input cannot be parsed', () => {
+    it('should return an empty string if input cannot be parsed', () => {
         const teststring = 'teststring lol'; // this string causes the xmldom parser to fail & error out
-        expect(HtmlReady(teststring).html).to.equal('rendering error');
+        expect(HtmlReady(teststring).html).to.equal('');
     });
 
     it('should allow links where the text portion and href contains steemit.com', () => {

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -9,11 +9,9 @@ describe('htmlready', () => {
         global.$STM_Config = {};
     });
 
-    it('should throw an error if the input cannot be parsed', () => {
+    it('should return a message input cannot be parsed', () => {
         const teststring = 'teststring lol'; // this string causes the xmldom parser to fail & error out
-        expect(() => HtmlReady(teststring).html).to.throw(
-            'HtmlReady: xmldom error'
-        );
+        expect(HtmlReady(teststring).html).to.equal('rendering error');
     });
 
     it('should allow links where the text portion and href contains steemit.com', () => {


### PR DESCRIPTION
closes #2276

we should log these