### PR TITLE
Add buildwhale to BadActorList.js

### DIFF
--- a/src/app/utils/BadActorList.js
+++ b/src/app/utils/BadActorList.js
@@ -142,6 +142,7 @@ gopax
 steempay
 steempays
 steemitpay
+buildwhale
 `
     .trim()
     .split('\n');


### PR DESCRIPTION
Add scam account buildwhale to bad actor, account is used to catch misspellings