### PR TITLE
Use a regular popup & share link rather than fb-sdk for facebook sharing

### DIFF
--- a/src/app/components/cards/PostFull.jsx
+++ b/src/app/components/cards/PostFull.jsx
@@ -26,27 +26,6 @@ import userIllegalContent from 'app/utils/userIllegalContent';
 import ImageUserBlockList from 'app/utils/ImageUserBlockList';
 import LoadingIndicator from 'app/components/elements/LoadingIndicator';
 
-// function loadFbSdk(d, s, id) {
-//     return new Promise(resolve => {
-//         window.fbAsyncInit = function () {
-//             window.FB.init({
-//                 appId: $STM_Config.fb_app,
-//                 xfbml: false,
-//                 version: 'v2.6',
-//                 status: true
-//             });
-//             resolve(window.FB);
-//         };
-//
-//         var js, fjs = d.getElementsByTagName(s)[0];
-//         if (d.getElementById(id)) {return;}
-//         js = d.createElement(s);
-//         js.id = id;
-//         js.src = "//connect.facebook.net/en_US/sdk.js";
-//         fjs.parentNode.insertBefore(js, fjs);
-//     });
-// }
-
 function TimeAuthorCategory({ content, authorRepLog10, showTags }) {
     return (
         <span className="PostFull__time_author_category vcard">
@@ -156,18 +135,12 @@ class PostFull extends React.Component {
     fbShare(e) {
         const href = this.share_params.url;
         e.preventDefault();
-        // loadFbSdk(document, 'script', 'facebook-jssdk').then(fb => {
-        window.FB.ui(
-            {
-                method: 'share',
-                href,
-            },
-            response => {
-                if (response && !response.error_message)
-                    serverApiRecordEvent('FbShare', this.share_params.link);
-            }
+        window.open(
+            `https://www.facebook.com/sharer/sharer.php?u=${href}`,
+            'fbshare',
+            'width=600, height=400, scrollbars=no'
         );
-        // });
+        serverApiRecordEvent('FbShare', this.share_params.link);
     }
 
     twitterShare(e) {

--- a/src/app/utils/JsPlugins.js
+++ b/src/app/utils/JsPlugins.js
@@ -27,25 +27,4 @@ export default function init(config) {
             sampleRate: 5
         });
     }
-
-    if (config.facebook_app_id) {
-        window.fbAsyncInit = function() {
-            FB.init({
-                appId: config.facebook_app_id,
-                xfbml: true,
-                version: 'v2.6',
-            });
-        };
-        (function(d, s, id) {
-            var js,
-                fjs = d.getElementsByTagName(s)[0];
-            if (d.getElementById(id)) {
-                return;
-            }
-            js = d.createElement(s);
-            js.id = id;
-            js.src = '//connect.facebook.net/en_US/sdk.js';
-            fjs.parentNode.insertBefore(js, fjs);
-        })(document, 'script', 'facebook-jssdk');
-    }
 }


### PR DESCRIPTION
Closes #1990 

This sharer link on the fb side might stop working someday.

For the record, we'd previously delayed loading of the fb sdk but that made the popup get blocked more frequently (https://github.com/steemit/condenser/pull/1151).