### PR TITLE
during docker build, use our yarn.lock

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN npm install -g yarn
 
 WORKDIR /var/app
 RUN mkdir -p /var/app
-ADD package.json /var/app/package.json
+ADD package.json yarn.lock /var/app/
 RUN yarn install --non-interactive --frozen-lockfile
 
 COPY . /var/app


### PR DESCRIPTION
closes #2352

this ensures that a build will fail if yarn.lock is not in sync with package.json