### PR TITLE
Fix account not loading error when tags contain an array of arrays

### DIFF
--- a/src/app/utils/StateFunctions.js
+++ b/src/app/utils/StateFunctions.js
@@ -166,6 +166,9 @@ export function contentStats(content) {
         if (typeof tags == 'string') {
             tags = [tags];
         }
+        if (Array.isArray(tags)) {
+            tags = [].concat.apply([], tags);
+        }
         if (!Array.isArray(tags)) {
             tags = [];
         }


### PR DESCRIPTION
Closes #2254 

## Issue
https://github.com/steemit/condenser/issues/2254
When a user submits a comment that has an Array of Arrays for the tags field, Condenser breaks due to expecting a single array.

## Solution
When parsing the tags, concat the arrays together to create a single Array from the multiples if they exist.

## Summary
Due to the fact that users are able to submit arbitrary data in the json_metadata field that Condenser parses, users are able to completely break their own account by submitting improperly formatted tags in the json_metadata. One user in particular `@makafuigdzivenu` encountered this issue and is unable to load any of his pages via Condenser. This pull request contains a quick solution to the problem by just concatenating multiple arrays in the tags field to just a single array.

## Screenshots
### Improperly formatted tags breaking Condenser
![screen shot 2018-01-17 at 1 15 06 pm](https://user-images.githubusercontent.com/7006965/35063429-b3149734-fb8c-11e7-8956-bc8f31f7e341.png)

### Improperly formatted tags concatenated into a single Array works fine
![screen shot 2018-01-17 at 1 42 05 pm](https://user-images.githubusercontent.com/7006965/35063431-b501d390-fb8c-11e7-9799-d5b654c448ea.png)
