### PR TITLE
set google-analytics sample rate to 5, refs #2379

### DIFF
--- a/src/app/utils/JsPlugins.js
+++ b/src/app/utils/JsPlugins.js
@@ -21,7 +21,11 @@ export default function init(config) {
             'https://www.google-analytics.com/analytics.js',
             'ga'
         );
-        ga('create', config.google_analytics_id, 'auto');
+        ga('create', {
+            trackingId:  config.google_analytics_id,
+            cookieDomain: 'auto',
+            sampleRate: 5
+        });
     }
 
     if (config.facebook_app_id) {


### PR DESCRIPTION
fixes: #2379
Documentation for implemented changes:
GA Tracker create method with fields object:
https://developers.google.com/analytics/devguides/collection/analyticsjs/creating-trackers

GA Tracker create method sample rate field:
https://developers.google.com/analytics/devguides/collection/analyticsjs/field-reference#sampleRate