### PR TITLE
Improve mobile experience by not having first tag capitalized

### DIFF
--- a/src/app/components/cards/CategorySelector.jsx
+++ b/src/app/components/cards/CategorySelector.jsx
@@ -72,6 +72,7 @@ class CategorySelector extends React.Component {
                 ref="categoryRef"
                 tabIndex={tabIndex}
                 disabled={disabled}
+                autocapitalize="none"
             />
         );
 


### PR DESCRIPTION
I went to create a post on the mobile website.

My first tag was auto-capitalized, I then went to post, and received feedback that tags cannot be capitalized.

![screenshot_20180130-205337](https://user-images.githubusercontent.com/9503662/35601631-12a0e43a-0602-11e8-8075-28dc88064678.png)


This should fix that.