### PR TITLE
pass up an error if something goes wrong during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "steemit.com is the koa web server & middleware and react.js in-browser code for the world's first blockchain content + social media monetization platform!",
   "main": "index.js",
   "scripts": {
-    "build": "NODE_ENV=production webpack --config ./webpack/prod.config.js; rm -rf ./lib; babel src --out-dir lib -Dq",
+    "build": "NODE_ENV=production webpack --config ./webpack/prod.config.js && rm -rf ./lib && babel src --out-dir lib -Dq",
     "test": "jest",
     "eslint": "LIST=`git diff-index --name-only HEAD | grep .*\\.js | grep -v json`; if [ \"$LIST\" ]; then eslint $LIST; fi",
     "fmt": "prettier --config .prettierrc --write 'src/**/*.js*'",


### PR DESCRIPTION
closes #2167

you can test this change by doing

```
git co 65782dc2044d0a7cbf3fa36d6739e602ba678942
```

(this is the commit that caused problems before in #2113)

applying the change:

```diff
diff --git a/package.json b/package.json
index 706d8cf..6f2866b 100644
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "description": "steemit.com is the koa web server & middleware and react.js in-browser code for the world's first blockchain content + social media monetization platform!",
   "main": "index.js",
   "scripts": {
-    "build": "NODE_ENV=production webpack --config ./webpack/prod.config.js; rm -rf ./lib; babel src --out-dir lib -Dq",
+    "build": "NODE_ENV=production webpack --config ./webpack/prod.config.js && rm -rf ./lib && babel src --out-dir lib -Dq",
     "mocha": "NODE_ENV=test mocha ./mocha.setup.js",
     "test": "npm run mocha -- src/app/**/*.test.js src/shared/**/*.test.js",
     "test:watch:all": "npm test -- --watch --watch-extensions jsx",
```

and then `docker build -t="$USER/condenser:$(git rev-parse --abbrev-ref HEAD)" .`ing

it won't build, with this error:

```
npm info ok 
Done in 4.37s.
yarn run v1.3.2
$ NODE_ENV=production webpack --config ./webpack/prod.config.js && rm -rf ./lib && babel src --out-dir lib -Dq
module.js:529
    throw err;
    ^

Error: Cannot find module 'blueimp-file-upload'
    at Function.Module._resolveFilename (module.js:527:15)
    at Function._module2.default._resolveFilename (/var/app/node_modules/require-hacker/babel-transpiled-modules/require hacker.js:442:34)
    at Function.resolve (internal/module.js:18:19)
    at Object.<anonymous> (/var/app/webpack/base.config.js:64:31)
    at Module._compile (module.js:624:30)
    at Object.Module._extensions..js (module.js:635:10)
    at Module.load (module.js:545:32)
    at tryModuleLoad (module.js:508:12)
    at Function.Module._load (module.js:500:3)
    at Module.require (module.js:568:17)
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
The command '/bin/sh -c mkdir tmp &&     yarn test && yarn build' returned a non-zero code: 1
```