### PR TITLE
add placeholder for loading images in blogmode, refs #2459

### DIFF
--- a/src/app/assets/stylesheets/foundation-overrides.scss
+++ b/src/app/assets/stylesheets/foundation-overrides.scss
@@ -109,7 +109,7 @@ tbody tr:nth-child(even) {
 }
 
 .reveal {
-  box-shadow: 2px 2px 2px 0 rgba(0,0,0,0.1), 7px 7px 0 0 $color-teal;   
+  box-shadow: 2px 2px 2px 0 rgba(0,0,0,0.1), 7px 7px 0 0 $color-teal;
   border-radius: 0;
   border: transparent;
   transition: 0.2s all ease-in-out;

--- a/src/app/components/cards/PostSummary.jsx
+++ b/src/app/components/cards/PostSummary.jsx
@@ -315,12 +315,13 @@ class PostSummary extends React.Component {
 
                 thumb = (
                     <span className="articles__feature-img-container">
-                        <picture className="articles__feature-img">
+                        <picture className="articles__feature-img articles__feature-img--placeholder ">
                             <source
+                                className="articles__feature-img--desktop"
                                 srcSet={listSize}
                                 media="(min-width: 1000px)"
                             />
-                            <img srcSet={blogSize} />
+                            <img className="articles__feature-img articles__feature-img--placeholder-item" srcSet={blogSize} />
                         </picture>
                     </span>
                 );

--- a/src/app/components/pages/PostsIndex.scss
+++ b/src/app/components/pages/PostsIndex.scss
@@ -930,3 +930,21 @@ a#changeLayout:focus {
 .articles__resteem-icon path {
     fill: #cacaca;
 }
+
+.articles__feature-img {
+  &--placeholder {
+    display: block;
+    position: relative;
+    height: 0;
+    width: 100%;
+    padding-top: 60%;
+    background: $color-border-light;
+  }
+  &--placeholder-item {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+}


### PR DESCRIPTION
Fixes #2459 

# Before:
![before_slow](https://user-images.githubusercontent.com/3374538/35927720-4e25e9de-0c23-11e8-92d4-5d8f593e6fff.gif)

# After:
![place_holder](https://user-images.githubusercontent.com/3374538/35927714-4b87d886-0c23-11e8-8def-7beeefd93fb6.gif)

