### PR TITLE
fix form validate debounce regression

### DIFF
--- a/src/app/utils/ChainValidation.js
+++ b/src/app/utils/ChainValidation.js
@@ -57,20 +57,23 @@ export function validate_memo_field(value, username, memokey) {
     let suffix;
     value = value.split(' ').filter(v => v != '');
     for (var w in value) {
-        if (PrivateKey.isWif(value[w])) {
-            return (suffix = 'Do not use private keys in memos. ');
-        }
-        if (
-            memokey ===
-            PrivateKey.fromSeed(username + 'memo' + value[w])
-                .toPublicKey()
-                .toString()
-        ) {
-            return (suffix = 'Do not use passwords in memos. ');
-        }
-        if (/5[HJK]\w{40,45}/i.test(value[w])) {
-            return (suffix =
-                'Please do not include what appears to be a private key or password. ');
+        // Only perform key tests if it might be a key, i.e. it is a long string.
+        if (value[w].length >= 39) {
+            if (/5[HJK]\w{40,45}/i.test(value[w])) {
+                return (suffix =
+                    'Please do not include what appears to be a private key or password. ');
+            }
+            if (PrivateKey.isWif(value[w])) {
+                return (suffix = 'Do not use private keys in memos. ');
+            }
+            if (
+                memokey ===
+                PrivateKey.fromSeed(username + 'memo' + value[w])
+                    .toPublicKey()
+                    .toString()
+            ) {
+                return (suffix = 'Do not use passwords in memos. ');
+            }
         }
     }
     return null;

--- a/src/app/utils/ReactForm.js
+++ b/src/app/utils/ReactForm.js
@@ -5,8 +5,6 @@
     @arg {object} initialValues required for checkboxes {save: false, ...}
     @arg {function} validation - values => ({ username: ! values.username ? 'Required' : null, ... })
 */
-const USER_INPUT_DEBOUNCE_MS = 400;
-
 export default function reactForm({
     name,
     instance,
@@ -14,7 +12,6 @@ export default function reactForm({
     initialValues,
     validation = () => {},
 }) {
-    let debounce = { timeout: null };
     if (typeof instance !== 'object')
         throw new TypeError('instance is a required object');
     if (!Array.isArray(fields))
@@ -124,13 +121,7 @@ export default function reactForm({
             }
 
             instance.setState({ [fieldName]: v }, () => {
-                setFormStateDebounce(
-                    name,
-                    instance,
-                    fields,
-                    validation,
-                    debounce
-                );
+                setFormState(name, instance, fields, validation);
             });
         };
 
@@ -141,13 +132,6 @@ export default function reactForm({
             instance.setState({ [fieldName]: v });
         };
     }
-}
-
-function setFormStateDebounce(name, instance, fields, validation, debounce) {
-    clearTimeout(debounce.timeout);
-    debounce.timeout = setTimeout(function() {
-        setFormState(name, instance, fields, validation);
-    }, USER_INPUT_DEBOUNCE_MS);
 }
 
 function setFormState(name, instance, fields, validation) {


### PR DESCRIPTION
closes #2387 
re-closes #2282 

reverts the debounced setState which caused user frustration (#2387)

i came up with a different way of solving #2282 -- instead of testing if every word in the memo field might be a private key, it only runs the expensive "is this a private key" tests if the word is at least the size of a what private key would be.