### PR TITLE
remove rate limit from create_user endpoint

### DIFF
--- a/src/server/api/general.js
+++ b/src/server/api/general.js
@@ -277,18 +277,17 @@ export default function useGeneralApi(app) {
      *   secret
      */
     router.post('/create_user', koaBody, function*() {
-        if (rateLimitReq(this, this.req)) return;
-
         const { name, email, owner_key, secret } =
             typeof this.request.body === 'string'
                 ? JSON.parse(this.request.body)
                 : this.request.body;
 
+        if (secret !== process.env.CREATE_USER_SECRET)
+            throw new Error('invalid secret');
+
         logRequest('create_user', this, { name, email, owner_key });
 
         try {
-            if (secret !== process.env.CREATE_USER_SECRET)
-                throw new Error('invalid secret');
             if (!emailRegex.test(email.toLowerCase()))
                 throw new Error('not valid email: ' + email);
             const existingUser = yield findUser({


### PR DESCRIPTION
closes #2509

nginx will still apply a higher rate limit so we are still protected.

also a request will get denied quickly if it doesn't supply the correct secret.

i moved the secret check above the logger line so that we can't get logspammed.