### PR TITLE
ignore hoek vulnerability

### DIFF
--- a/.nsprc
+++ b/.nsprc
@@ -1,0 +1,3 @@
+{
+    "exceptions": ["https://nodesecurity.io/advisories/566"]
+}

--- a/package.json
+++ b/package.json
@@ -58,7 +58,6 @@
     "file-loader": "0.11.2",
     "foundation-sites": "git+https://github.com/steemit/foundation-sites.git#e8e32c715bbc4c822b80b555345f61337269ca78",
     "git-rev-sync": "1.9.1",
-    "grant-koa": "3.8.0",
     "highcharts": "4.2.7",
     "humanize-number": "0.0.2",
     "imports-loader": "0.7.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2809,10 +2809,6 @@ dedent@^0.7.0:
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/dedent/-/dedent-0.7.0.tgz#2495ddbaf6eb874abb0e1be9df22d2e5a544326c"
 
-deep-copy@^1.2.0:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/deep-copy/-/deep-copy-1.4.2.tgz#0622719257e4bd60240e401ea96718211c5c4697"
-
 deep-equal@^1.0.0, deep-equal@^1.0.1, deep-equal@~1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/deep-equal/-/deep-equal-1.0.1.tgz#f5d260292b660e084eff4cdbc9f08ad3247448b5"
@@ -4154,21 +4150,6 @@ globule@^1.0.0:
 graceful-fs@4.1.11, graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.4, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
-
-grant-koa@3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/grant-koa/-/grant-koa-3.8.0.tgz#21e9c7a9b6cf747e6150f2cb44ca07c2d412ed70"
-  dependencies:
-    grant "3.8.0"
-    thunkify "2.1.2"
-
-grant@3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/grant/-/grant-3.8.0.tgz#c3133f864d11838b5ebeac2d7c882d976884df44"
-  dependencies:
-    deep-copy "^1.2.0"
-    qs "6.4.0"
-    request "2.81.0"
 
 growly@^1.3.0:
   version "1.3.0"
@@ -7411,10 +7392,6 @@ qs@2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-2.3.3.tgz#e9e85adbe75da0bbe4c8e0476a086290f863b404"
 
-qs@6.4.0, qs@~6.4.0:
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
-
 qs@6.5.1, qs@^6.1.0, qs@^6.4.0, qs@^6.5.1, qs@~6.5.1:
   version "6.5.1"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.1.tgz#349cdf6eef89ec45c12d7d5eb3fc0c870343a6d8"
@@ -7422,6 +7399,10 @@ qs@6.5.1, qs@^6.1.0, qs@^6.4.0, qs@^6.5.1, qs@~6.5.1:
 qs@~6.3.0:
   version "6.3.2"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.3.2.tgz#e75bd5f6e268122a2a0e0bda630b2550c166502c"
+
+qs@~6.4.0:
+  version "6.4.0"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.4.0.tgz#13e26d28ad6b0ffaa91312cd3bf708ed351e7233"
 
 query-string@^4.1.0, query-string@^4.2.2:
   version "4.3.4"
@@ -9114,10 +9095,6 @@ throat@^4.0.0:
 through@^2.3.6, through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-
-thunkify@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/thunkify/-/thunkify-2.1.2.tgz#faa0e9d230c51acc95ca13a361ac05ca7e04553d"
 
 time-stamp@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
closes #2527

none of our dependencies which depend on hoek have updated to fix this issue

luckily the issue is not relevant to any of our runtime code -- the vulnerable version of hoek is used by babel-cli, node-sass, sqlite3, and webpack -- none of these are runtime deps

(well webpack is sorta runtime but its usage of hoek is only during dev usage (watchpack))

also this PR removes grant-koa -- its usage was removed in 135578eaa8216e5843f0b107f1ab0117bf6183eb