### PR TITLE
add hide url

### DIFF
--- a/src/app/utils/DMCAList.js
+++ b/src/app/utils/DMCAList.js
@@ -47,6 +47,7 @@ export default `
 /cryptocurrency/@kriptonoob/palm-beach-confidential-report-cindicator-125
 /crypto/@medicbtom/palm-beach-confidential-released-their-monthly-pick
 /news/@vaerospace/fire-and-fury-pdf-direct-download-from-ipfs-a-great-giggle
+/blog/@dreamya/korea-bucheon-cartoon-festival-cosplay-card-capture-sakura
 `
     .trim()
     .split('\n');


### PR DESCRIPTION
the author asked for hide this URL.
/blog/@dreamya/korea-bucheon-cartoon-festival-cosplay-card-capture-sakura

author's [request](https://steemit.com/kr/@dreamya/kuzhd) google translate.

After posting to Steamit in April of last year, it is when I did not know that it can not be deleted or modified after payout. I went to the Bucheon Manga Festival event and took a picture of a language and post it. Of course, I was allowed to take pictures, and I was allowed to post them on my blog. After posting, the contents posted via email were sent by e-mail with the link. I received an e-mail saying, "I want to delete the image in the article after a few months or so in September, and it was impossible to delete or edit it already.

I tried to delete it later in various ways, but it has not been deleted yet and I would like to ask for help. Thank you for downloading the link below.

Currently, we do not take portraits and we are doing our best. I hope that this will not happen in the future.