### PR TITLE
Fix Bug Where Comment sorting changes don't apply until refresh

### DIFF
--- a/src/app/components/App.jsx
+++ b/src/app/components/App.jsx
@@ -103,6 +103,7 @@ class App extends React.Component {
         const n = nextProps;
         return (
             p.location.pathname !== n.location.pathname ||
+            p.location.query !== n.location.query ||
             p.new_visitor !== n.new_visitor ||
             p.flash !== n.flash ||
             this.state.open !== nextState.open ||


### PR DESCRIPTION
fixes #2264 

The problem here is App doesn't update when `props.location.query` changes. This leaves Post with an out of date location prop. I added another check to `App.shouldComponentUpdate` which solves the problem. However this seems to add lag when sorting since the App component has to update.

## Other Possible Fixes would be
- Grab the location from `window`.
- Subscribe to react-router outside of the parent component, if that's possible.
- Add local state to keep track of the selected sort value.