### PR TITLE
Fetch accounts involved in transfers & clickwall their memos

### DIFF
--- a/src/app/components/cards/TransferHistoryRow.jsx
+++ b/src/app/components/cards/TransferHistoryRow.jsx
@@ -6,7 +6,6 @@ import TimeAgoWrapper from 'app/components/elements/TimeAgoWrapper';
 // import Icon from 'app/components/elements/Icon';
 import Memo from 'app/components/elements/Memo';
 import { numberWithCommas, vestsToSp } from 'app/utils/StateFunctions';
-import BadActorList from 'app/utils/BadActorList';
 
 class TransferHistoryRow extends React.Component {
     render() {
@@ -27,9 +26,11 @@ class TransferHistoryRow extends React.Component {
         /*  all transfers involve up to 2 accounts, context and 1 other. */
         let description_start = '';
         let other_account = null;
+        let from_account = null;
         let description_end = '';
 
         if (type === 'transfer_to_vesting') {
+            from_account = data.from;
             if (data.from === context) {
                 if (data.to === '') {
                     description_start +=
@@ -67,6 +68,7 @@ class TransferHistoryRow extends React.Component {
                 type
             )
         ) {
+            from_account = data.from;
             // transfer_to_savings
             const fromWhere =
                 type === 'transfer_to_savings'
@@ -204,9 +206,7 @@ class TransferHistoryRow extends React.Component {
                     <Memo
                         text={data.memo}
                         username={context}
-                        isFromBadActor={
-                            BadActorList.indexOf(other_account) > -1
-                        }
+                        fromAccount={from_account}
                     />
                 </td>
             </tr>

--- a/src/app/components/cards/TransferHistoryRow.scss
+++ b/src/app/components/cards/TransferHistoryRow.scss
@@ -1,17 +1,21 @@
-.Memo--badActor {
-  .bad-actor-caution {
-    color: darken($color-red, 20%);
+.Memo--badActor,
+.Memo--fromNegativeRepUser {
+  .bad-actor-caution,
+  .from-negative-rep-user-caution {
+    color: darken($color-red, 10%);
     font-size: 75%;
     font-weight: bold;
     text-transform: uppercase;
     letter-spacing: 1px;
   }
-  .bad-actor-explained {
+  .bad-actor-explained,
+  .from-negative-rep-user-explained {
     opacity: .5;
     font-size: 75%;
     max-width: 30em;
   }
-  .bad-actor-reveal-memo {
+  .bad-actor-reveal-memo,
+  .from-negative-rep-user-reveal-memo {
     opacity: .5;
     font-size: 75%;
     text-decoration: underline;

--- a/src/app/components/elements/Memo/Memo.test.jsx
+++ b/src/app/components/elements/Memo/Memo.test.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { configure, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+
+import { Memo } from './index';
+
+configure({ adapter: new Adapter() });
+
+describe('Memo', () => {
+    it('should return an empty span if no text is provided', () => {
+        const wrapper = shallow(<Memo fromNegativeRepUser={false} />);
+        expect(wrapper.html()).toEqual('<span></span>');
+    });
+
+    it('should render a plain ol memo', () => {
+        const wrapper = shallow(
+            <Memo fromNegativeRepUser={false} text={'hi dude'} />
+        );
+        expect(wrapper.html()).toEqual('<span class="Memo">hi dude</span>');
+    });
+
+    it('should deal with a memo from a user with bad reputation', () => {
+        const wrapper = shallow(
+            <Memo fromNegativeRepUser={true} text={'sorry charlie'} />
+        );
+
+        expect(wrapper.html()).toEqual(
+            '<span class="Memo Memo--fromNegativeRepUser"><div class="from-negative-rep-user-warning"><div class="from-negative-rep-user-caution">missing translation: en.transferhistoryrow_jsx.from_negative_rep_user_caution</div><div class="from-negative-rep-user-explained">missing translation: en.transferhistoryrow_jsx.from_negative_rep_user_explained</div><div class="ptc from-negative-rep-user-reveal-memo" role="button">missing translation: en.transferhistoryrow_jsx.from_negative_rep_user_reveal_memo</div></div></span>'
+        );
+
+        wrapper
+            .find('div.ptc')
+            .simulate('click', { preventDefault: () => true });
+        expect(wrapper.html()).toEqual(
+            '<span class="Memo Memo--fromNegativeRepUser">sorry charlie</span>'
+        );
+    });
+});

--- a/src/app/components/elements/Memo/index.jsx
+++ b/src/app/components/elements/Memo/index.jsx
@@ -4,22 +4,26 @@ import shouldComponentUpdate from 'app/utils/shouldComponentUpdate';
 import tt from 'counterpart';
 import classnames from 'classnames';
 import { memo } from '@steemit/steem-js';
+import BadActorList from 'app/utils/BadActorList';
 
-class Memo extends React.Component {
+const MINIMUM_REPUTATION = 10;
+
+export class Memo extends React.Component {
     static propTypes = {
         text: PropTypes.string,
         username: PropTypes.string,
-        isFromBadActor: PropTypes.bool.isRequired,
+        fromAccount: PropTypes.string,
         // redux props
         myAccount: PropTypes.bool,
         memo_private: PropTypes.object,
+        fromNegativeRepUser: PropTypes.bool.isRequired,
     };
 
     constructor() {
         super();
         this.shouldComponentUpdate = shouldComponentUpdate(this, 'Memo');
         this.state = {
-            revealBadActorMemo: false,
+            revealMemo: false,
         };
     }
 
@@ -32,19 +36,30 @@ class Memo extends React.Component {
         }
     }
 
-    onRevealBadActorMemo = e => {
+    onRevealMemo = e => {
         e.preventDefault();
-        this.setState({ revealBadActorMemo: true });
+        this.setState({ revealMemo: true });
     };
 
     render() {
         const { decodeMemo } = this;
-        const { memo_private, text, myAccount, isFromBadActor } = this.props;
+        const {
+            memo_private,
+            text,
+            myAccount,
+            fromAccount,
+            fromNegativeRepUser,
+        } = this.props;
         const isEncoded = /^#/.test(text);
+
+        const isFromBadActor = BadActorList.indexOf(fromAccount) > -1;
+
+        if (!text || text.length < 1) return <span />;
 
         const classes = classnames({
             Memo: true,
             'Memo--badActor': isFromBadActor,
+            'Memo--fromNegativeRepUser': fromNegativeRepUser,
             'Memo--private': memo_private,
         });
 
@@ -58,7 +73,7 @@ class Memo extends React.Component {
                 : tt('g.login_to_see_memo');
         }
 
-        if (isFromBadActor && !this.state.revealBadActorMemo) {
+        if (isFromBadActor && !this.state.revealMemo) {
             renderText = (
                 <div className="bad-actor-warning">
                     <div className="bad-actor-caution">
@@ -70,9 +85,33 @@ class Memo extends React.Component {
                     <div
                         className="ptc bad-actor-reveal-memo"
                         role="button"
-                        onClick={this.onRevealBadActorMemo}
+                        onClick={this.onRevealMemo}
                     >
                         {tt('transferhistoryrow_jsx.bad_actor_reveal_memo')}
+                    </div>
+                </div>
+            );
+        } else if (fromNegativeRepUser && !this.state.revealMemo) {
+            renderText = (
+                <div className="from-negative-rep-user-warning">
+                    <div className="from-negative-rep-user-caution">
+                        {tt(
+                            'transferhistoryrow_jsx.from_negative_rep_user_caution'
+                        )}
+                    </div>
+                    <div className="from-negative-rep-user-explained">
+                        {tt(
+                            'transferhistoryrow_jsx.from_negative_rep_user_explained'
+                        )}
+                    </div>
+                    <div
+                        className="ptc from-negative-rep-user-reveal-memo"
+                        role="button"
+                        onClick={this.onRevealMemo}
+                    >
+                        {tt(
+                            'transferhistoryrow_jsx.from_negative_rep_user_reveal_memo'
+                        )}
                     </div>
                 </div>
             );
@@ -90,5 +129,14 @@ export default connect((state, ownProps) => {
         myAccount && currentUser
             ? currentUser.getIn(['private_keys', 'memo_private'])
             : null;
-    return { ...ownProps, memo_private, myAccount };
+    const fromNegativeRepUser =
+        parseInt(
+            state.global.getIn([
+                'accounts',
+                ownProps.fromAccount,
+                'reputation',
+            ]),
+            10
+        ) < MINIMUM_REPUTATION;
+    return { ...ownProps, memo_private, myAccount, fromNegativeRepUser };
 })(Memo);

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -601,7 +601,12 @@
         "bad_actor_caution": "Caution",
         "bad_actor_explained":
             "This is from an account that looks fraudulent. If you wish, you may temporarily reveal this memo which may contain dangerous links.",
-        "bad_actor_reveal_memo": "I understand the risk; show anyway."
+        "bad_actor_reveal_memo": "I understand the risk; show anyway.",
+        "from_negative_rep_user_caution": "Caution",
+        "from_negative_rep_user_explained":
+            "This memo is from an account that has a bad reputation. If you wish, you may temporarily reveal this memo which may contain dangerous links.",
+        "from_negative_rep_user_reveal_memo":
+            "I understand the risk; show anyway."
     },
     "savingswithdrawhistory_jsx": {
         "cancel_this_withdraw_request": "Cancel this withdraw request?",

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -604,7 +604,7 @@
         "bad_actor_reveal_memo": "I understand the risk; show anyway.",
         "from_negative_rep_user_caution": "Caution",
         "from_negative_rep_user_explained":
-            "This memo is from an account that has a bad reputation. If you wish, you may temporarily reveal this memo which may contain dangerous links.",
+            "This is from an account with a bad reputation. If you wish, you may temporarily reveal this memo which may contain dangerous links.",
         "from_negative_rep_user_reveal_memo":
             "I understand the risk; show anyway."
     },

--- a/src/app/redux/GlobalReducer.test.js
+++ b/src/app/redux/GlobalReducer.test.js
@@ -90,6 +90,71 @@ describe('Global reducer', () => {
         ).toEqual(OrderedMap(payload.account.beOrderedMap));
     });
 
+    it('should return correct state for a RECEIVE_ACCOUNTS action', () => {
+        // Arrange
+        const payload = {
+            accounts: [
+                {
+                    name: 'foo',
+                    witness_votes: 99,
+                    beList: ['alice', 'bob', 'claire'],
+                    beorderedMap: { foo: 'barman' },
+                },
+                {
+                    name: 'bar',
+                    witness_votes: 12,
+                    beList: ['james', 'billy', 'samantha'],
+                    beOrderedMap: { kewl: 'snoop' },
+                },
+            ],
+        };
+
+        const initState = Map({
+            status: {},
+            seagull: Map({ result: 'fulmar', error: 'stuka' }),
+            accounts: Map({
+                sergei: Map({
+                    name: 'sergei',
+                    witness_votes: 666,
+                    beList: List(['foo', 'carl', 'hanna']),
+                    beorderedMap: OrderedMap({ foo: 'cramps' }),
+                }),
+            }),
+        });
+
+        const initial = reducer(initState);
+
+        const expected = Map({
+            status: {},
+            accounts: Map({
+                sergei: Map({
+                    name: 'sergei',
+                    witness_votes: 666,
+                    beList: List(['foo', 'carl', 'hanna']),
+                    beorderedMap: OrderedMap({
+                        foo: 'cramps',
+                    }),
+                }),
+                foo: Map({
+                    name: 'foo',
+                    witness_votes: 99,
+                    beList: List(['alice', 'bob', 'claire']),
+                    beorderedMap: OrderedMap({ foo: 'barman' }),
+                }),
+                bar: Map({
+                    name: 'bar',
+                    witness_votes: 12,
+                    beList: List(['james', 'billy', 'samantha']),
+                    beOrderedMap: OrderedMap({ kewl: 'snoop' }),
+                }),
+            }),
+        });
+        // Act
+        const actual = reducer(initial, globalActions.receiveAccounts(payload));
+        // Assert
+        expect(actual.get('accounts')).toEqual(expected.get('accounts'));
+    });
+
     it('should return correct state for a RECEIVE_COMMENT action', () => {
         // Arrange
         const payload = {


### PR DESCRIPTION
closes #2397
closes #2306 

when loading the transfers route, fetch accounts involved in `from` transfers so their reputation can be considered, as well as fetch the user account again so their reputation can be reflected in the header.

also improve the logic in Memo/TransactionHistoryRow a bit, and lighten the caution message red color a little for improved contrast.

![screenshot from 2018-03-01 08-09-31](https://user-images.githubusercontent.com/99194/36862618-6028f994-1d55-11e8-8c1e-752012403636.png)
