### PR TITLE
fix video embed hides text bug

### DIFF
--- a/src/app/utils/Links.js
+++ b/src/app/utils/Links.js
@@ -44,6 +44,7 @@ export default {
     imageFile: imageFile(),
     youTube: youTube(),
     youTubeId: /(?:(?:youtube.com\/watch\?v=)|(?:youtu.be\/)|(?:youtube.com\/embed\/))([A-Za-z0-9\_\-]+)/i,
+    vimeo: /https?:\/\/(?:vimeo.com\/|player.vimeo.com\/video\/)([0-9]+)\/*/,
     vimeoId: /(?:vimeo.com\/|player.vimeo.com\/video\/)([0-9]+)/,
     // simpleLink: new RegExp(`<a href="(.*)">(.*)<\/a>`, 'ig'),
     ipfsPrefix: /(https?:\/\/.*)?\/ipfs/i,

--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -227,8 +227,8 @@ function linkifyNode(child, state) {
 
         const { mutate } = state;
         if (!child.data) return;
-        if (embedYouTubeNode(child, state.links, state.images)) return;
-        if (embedVimeoNode(child, state.links, state.images)) return;
+        child = embedYouTubeNode(child, state.links, state.images);
+        child = embedVimeoNode(child, state.links, state.images);
 
         const data = XMLSerializer.serializeToString(child);
         const content = linkify(
@@ -300,20 +300,20 @@ function linkify(content, mutate, hashtags, usertags, images, links) {
 
 function embedYouTubeNode(child, links, images) {
     try {
-        if (!child.data) return false;
+        if (!child.data) return child;
         const data = child.data;
         const yt = youTubeId(data);
-        if (!yt) return false;
+        if (!yt) return child;
 
-        const v = DOMParser.parseFromString(`~~~ embed:${yt.id} youtube ~~~`);
-        child.parentNode.replaceChild(v, child);
+        child.data = data.replace(yt.url, `~~~ embed:${yt.id} youtube ~~~`);
+
         if (links) links.add(yt.url);
         if (images)
             images.add('https://img.youtube.com/vi/' + yt.id + '/0.jpg');
-        return true;
+        return child;
     } catch (error) {
         console.log(error);
-        return false;
+        return child;
     }
 }
 
@@ -334,28 +334,29 @@ function youTubeId(data) {
 
 function embedVimeoNode(child, links /*images*/) {
     try {
-        if (!child.data) return false;
+        if (!child.data) return child;
         const data = child.data;
 
-        let id;
+        let id, fullMatchUrl;
         {
-            const m = data.match(linksRe.vimeoId);
+            const m = data.match(linksRe.vimeo);
             id = m && m.length >= 2 ? m[1] : null;
+            fullMatchUrl = m && m.length >= 2 ? m[0] : null;
         }
-        if (!id) return false;
+        if (!id) return child;
+
+        child.data = data.replace(fullMatchUrl, `~~~ embed:${id} vimeo ~~~`);
 
         const url = `https://player.vimeo.com/video/${id}`;
-        const v = DOMParser.parseFromString(`~~~ embed:${id} vimeo ~~~`);
-        child.parentNode.replaceChild(v, child);
         if (links) links.add(url);
 
         // Preview image requires a callback.. http://stackoverflow.com/questions/1361149/get-img-thumbnails-from-vimeo
         // if(images) images.add('https://.../vi/' + id + '/0.jpg')
 
-        return true;
+        return child;
     } catch (error) {
         console.log(error);
-        return false;
+        return child;
     }
 }
 

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -128,4 +128,22 @@ describe('htmlready', () => {
         const res = HtmlReady(nameinsidelinkmiddle).html;
         expect(res).toEqual(htmlified);
     });
+
+    it('should not omit text on same line as youtube link', () => {
+        const testString =
+            '<html><p>before text https://www.youtube.com/watch?v=NrS9vvNgx7I after text</p></html>';
+        const htmlified =
+            '<html xmlns="http://www.w3.org/1999/xhtml"><p>before text ~~~ embed:NrS9vvNgx7I youtube ~~~ after text</p></html>';
+        const res = HtmlReady(testString).html;
+        expect(res).toEqual(htmlified);
+    });
+
+    it('should not omit text on same line as vimeo link', () => {
+        const testString =
+            '<html><p>before text https://vimeo.com/193628816/ after text</p></html>';
+        const htmlified =
+            '<html xmlns="http://www.w3.org/1999/xhtml"><p>before text ~~~ embed:193628816 vimeo ~~~ after text</p></html>';
+        const res = HtmlReady(testString).html;
+        expect(res).toEqual(htmlified);
+    });
 });


### PR DESCRIPTION
fixes #2576 

When a video link is on the same line as some other text, the text gets stripped by `HtmlReady`. I fixed this by replacing the video link with the embed code instead of replacing the whole dom node with the embed code.