### PR TITLE
hide memos in transfers from users with negative rep, but not 25

### DIFF
--- a/src/app/components/elements/Memo/index.jsx
+++ b/src/app/components/elements/Memo/index.jsx
@@ -5,8 +5,9 @@ import tt from 'counterpart';
 import classnames from 'classnames';
 import { memo } from '@steemit/steem-js';
 import BadActorList from 'app/utils/BadActorList';
+import { repLog10 } from 'app/utils/ParsersAndFormatters';
 
-const MINIMUM_REPUTATION = 10;
+const MINIMUM_REPUTATION = 15;
 
 export class Memo extends React.Component {
     static propTypes = {
@@ -130,13 +131,8 @@ export default connect((state, ownProps) => {
             ? currentUser.getIn(['private_keys', 'memo_private'])
             : null;
     const fromNegativeRepUser =
-        parseInt(
-            state.global.getIn([
-                'accounts',
-                ownProps.fromAccount,
-                'reputation',
-            ]),
-            10
+        repLog10(
+            state.global.getIn(['accounts', ownProps.fromAccount, 'reputation'])
         ) < MINIMUM_REPUTATION;
     return { ...ownProps, memo_private, myAccount, fromNegativeRepUser };
 })(Memo);


### PR DESCRIPTION
closes #2596

We have decreased the threshold (down to 15 from what was effectively 25.0000001) for the bad-rep memo in the transfer history. 