### PR TITLE
fix mentions embedded within naked comment urls

### DIFF
--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -268,7 +268,7 @@ function linkify(content, mutate, hashtags, usertags, images, links) {
     // usertag (mention)
     // Cribbed from https://github.com/twitter/twitter-text/blob/v1.14.7/js/twitter-text.js#L90
     content = content.replace(
-        /(^|[^a-zA-Z0-9_!#$%&*@＠\/]|(^|[^a-zA-Z0-9_+~.-\/]))[@＠]([a-z][-\.a-z\d]+[a-z\d])/gi,
+        /(^|[^a-zA-Z0-9_!#$%&*@＠\/]|(^|[^a-zA-Z0-9_+~.-\/#]))[@＠]([a-z][-\.a-z\d]+[a-z\d])/gi,
         (match, preceeding1, preceeding2, user) => {
             const userLower = user.toLowerCase();
             const valid = validate_account_name(userLower) == null;

--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -281,7 +281,7 @@ function linkify(content, mutate, hashtags, usertags, images, links) {
 
             return valid
                 ? `${preceedings}<a href="/@${userLower}">@${user}</a>`
-                : '@' + user;
+                : `${preceedings}@${user}`;
         }
     );
 

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -158,8 +158,7 @@ describe('htmlready', () => {
         const prefix = '<xml xmlns="http://www.w3.org/1999/xhtml">'
         const suffix = '</xml>'
         const input = prefix + body + suffix;
-        const expected = prefix + '<span>' + body + '</span>' + suffix;
         const result = HtmlReady(input).html;
-        expect(result).toEqual(expected);
+        expect(result).toEqual(input);
     });
 });

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -142,4 +142,14 @@ describe('htmlready', () => {
         const resNoRelativeHttpHttpsOrSteem = HtmlReady(noRelativeHttpHttpsOrSteem).html;
         expect(resNoRelativeHttpHttpsOrSteem).toEqual(cleansedRelativeHttpHttpsOrSteem);
     });
+
+    it('should not munge valid comment urls', () => {
+        const url = 'https://steemit.com/spam/@test-safari/34gfex-december-spam#@test-safari/re-test-safari-34gfex-december-spam-20180110t234627522z'
+        const prefix = '<xml xmlns="http://www.w3.org/1999/xhtml">'
+        const suffix = '</xml>'
+        const input = prefix + url + suffix;
+        const expected = prefix + '<a href="' + url + '">' + url + '</a>' + suffix;
+        const result = HtmlReady(input).html;
+        expect(result).toEqual(expected);
+    });
 });

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -143,12 +143,22 @@ describe('htmlready', () => {
         expect(resNoRelativeHttpHttpsOrSteem).toEqual(cleansedRelativeHttpHttpsOrSteem);
     });
 
-    it('should not munge valid comment urls', () => {
+    it('should not mistake usernames in valid comment urls as mentions', () => {
         const url = 'https://steemit.com/spam/@test-safari/34gfex-december-spam#@test-safari/re-test-safari-34gfex-december-spam-20180110t234627522z'
         const prefix = '<xml xmlns="http://www.w3.org/1999/xhtml">'
         const suffix = '</xml>'
         const input = prefix + url + suffix;
         const expected = prefix + '<a href="' + url + '">' + url + '</a>' + suffix;
+        const result = HtmlReady(input).html;
+        expect(result).toEqual(expected);
+    });
+
+    it('should not modify text when mention contains invalid username', () => {
+        const body = 'valid mention match but invalid username..@usernamewaytoolong'
+        const prefix = '<xml xmlns="http://www.w3.org/1999/xhtml">'
+        const suffix = '</xml>'
+        const input = prefix + body + suffix;
+        const expected = prefix + '<span>' + body + '</span>' + suffix;
         const result = HtmlReady(input).html;
         expect(result).toEqual(expected);
     });

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -148,7 +148,7 @@ describe('htmlready', () => {
         const prefix = '<xml xmlns="http://www.w3.org/1999/xhtml">'
         const suffix = '</xml>'
         const input = prefix + url + suffix;
-        const expected = prefix + '<a href="' + url + '">' + url + '</a>' + suffix;
+        const expected = prefix + '<span><a href="' + url + '">' + url + '</a></span>' + suffix;
         const result = HtmlReady(input).html;
         expect(result).toEqual(expected);
     });


### PR DESCRIPTION
Resolves #2556 (plus another found bug which is the 2nd added test case)

### To reproduce

#### Case 1

Paste the valid comment URL `https://steemit.com/spam/@test-safari/34gfex-december-spam#@test-safari/re-test-safari-34gfex-december-spam-20180110t234627522z` into https://steemit.com/submit.html and see that the resulting URL is munged and the username within it is linked

#### Case 2

Paste `valid mention match but invalid username..@usernamewaytoolong` into https://steemit.com/submit.html and see that one of the period is missing even though the username did not get linked.
