### PR TITLE
community - Show STEEM breakdown on pending payout. Revert paid payout display.

### DIFF
--- a/src/app/components/elements/Voting.jsx
+++ b/src/app/components/elements/Voting.jsx
@@ -5,7 +5,7 @@ import tt from 'counterpart';
 import CloseButton from 'react-foundation-components/lib/global/close-button';
 import * as transactionActions from 'app/redux/TransactionReducer';
 import Icon from 'app/components/elements/Icon';
-import { DEBT_TOKEN_SHORT, INVEST_TOKEN_SHORT } from 'app/client_config';
+import { DEBT_TOKEN_SHORT, LIQUID_TOKEN_UPPERCASE, INVEST_TOKEN_SHORT } from 'app/client_config';
 import FormattedAsset from 'app/components/elements/FormattedAsset';
 import shouldComponentUpdate from 'app/utils/shouldComponentUpdate';
 import {
@@ -175,6 +175,7 @@ class Voting extends React.Component {
             is_comment,
             post_obj,
             price_per_steem,
+            sbd_print_rate
         } = this.props;
         const { username } = this.props;
         const { votingUp, votingDown, showWeight, weight, myVote } = this.state;
@@ -278,13 +279,13 @@ class Voting extends React.Component {
         const pending_payout_sbd = pending_payout * percent_steem_dollars;
         const pending_payout_sp =
             (pending_payout - pending_payout_sbd) / price_per_steem;
+        const pending_payout_printed_sbd = pending_payout_sbd * sbd_print_rate / 10000;
+        const pending_payout_printed_steem = (pending_payout_sbd - pending_payout_printed_sbd) / price_per_steem;
+
         const promoted = parsePayoutAmount(post_obj.get('promoted'));
         const total_author_payout = parsePayoutAmount(
             post_obj.get('total_payout_value')
         );
-        const author_payout_sbd = total_author_payout * percent_steem_dollars;
-        const author_payout_sp =
-            (total_author_payout - author_payout_sbd) / price_per_steem;
         const total_curator_payout = parsePayoutAmount(
             post_obj.get('curator_payout_value')
         );
@@ -321,10 +322,14 @@ class Voting extends React.Component {
                 payoutItems.push({
                     value:
                         '(' +
-                        formatDecimal(pending_payout_sbd).join('') +
+                        formatDecimal(pending_payout_printed_sbd).join('') +
                         ' ' +
                         DEBT_TOKEN_SHORT +
                         ', ' +
+                        (pending_payout_printed_steem > 0 ? formatDecimal(pending_payout_printed_steem).join('') +
+                        ' ' +
+                        LIQUID_TOKEN_UPPERCASE + 
+                        ', ' : '') +
                         formatDecimal(pending_payout_sp).join('') +
                         ' ' +
                         INVEST_TOKEN_SHORT +
@@ -362,18 +367,6 @@ class Voting extends React.Component {
                 value: tt('voting_jsx.past_payouts_author', {
                     value: formatDecimal(total_author_payout).join(''),
                 }),
-            });
-            payoutItems.push({
-                value:
-                    '(' +
-                    formatDecimal(author_payout_sbd).join('') +
-                    ' ' +
-                    DEBT_TOKEN_SHORT +
-                    ', ' +
-                    formatDecimal(author_payout_sp).join('') +
-                    ' ' +
-                    INVEST_TOKEN_SHORT +
-                    ')',
             });
             payoutItems.push({
                 value: tt('voting_jsx.past_payouts_curators', {
@@ -544,6 +537,8 @@ export default connect(
                 price_per_steem = parseFloat(base.split(' ')[0]);
         }
 
+        const sbd_print_rate = state.global.getIn(['props', 'sbd_print_rate']);
+
         return {
             post: ownProps.post,
             flag: ownProps.flag,
@@ -558,6 +553,7 @@ export default connect(
             loggedin: username != null,
             voting,
             price_per_steem,
+            sbd_print_rate
         };
     },
 

--- a/src/app/components/elements/Voting.jsx
+++ b/src/app/components/elements/Voting.jsx
@@ -5,7 +5,11 @@ import tt from 'counterpart';
 import CloseButton from 'react-foundation-components/lib/global/close-button';
 import * as transactionActions from 'app/redux/TransactionReducer';
 import Icon from 'app/components/elements/Icon';
-import { DEBT_TOKEN_SHORT, LIQUID_TOKEN_UPPERCASE, INVEST_TOKEN_SHORT } from 'app/client_config';
+import {
+    DEBT_TOKEN_SHORT,
+    LIQUID_TOKEN_UPPERCASE,
+    INVEST_TOKEN_SHORT,
+} from 'app/client_config';
 import FormattedAsset from 'app/components/elements/FormattedAsset';
 import shouldComponentUpdate from 'app/utils/shouldComponentUpdate';
 import {
@@ -56,6 +60,7 @@ class Voting extends React.Component {
         net_vesting_shares: React.PropTypes.number,
         voting: React.PropTypes.bool,
         price_per_steem: React.PropTypes.number,
+        sbd_print_rate: React.PropTypes.number,
     };
 
     static defaultProps = {
@@ -175,7 +180,7 @@ class Voting extends React.Component {
             is_comment,
             post_obj,
             price_per_steem,
-            sbd_print_rate
+            sbd_print_rate,
         } = this.props;
         const { username } = this.props;
         const { votingUp, votingDown, showWeight, weight, myVote } = this.state;
@@ -279,8 +284,10 @@ class Voting extends React.Component {
         const pending_payout_sbd = pending_payout * percent_steem_dollars;
         const pending_payout_sp =
             (pending_payout - pending_payout_sbd) / price_per_steem;
-        const pending_payout_printed_sbd = pending_payout_sbd * sbd_print_rate / 10000;
-        const pending_payout_printed_steem = (pending_payout_sbd - pending_payout_printed_sbd) / price_per_steem;
+        const pending_payout_printed_sbd =
+            pending_payout_sbd * sbd_print_rate / 10000;
+        const pending_payout_printed_steem =
+            (pending_payout_sbd - pending_payout_printed_sbd) / price_per_steem;
 
         const promoted = parsePayoutAmount(post_obj.get('promoted'));
         const total_author_payout = parsePayoutAmount(
@@ -326,10 +333,14 @@ class Voting extends React.Component {
                         ' ' +
                         DEBT_TOKEN_SHORT +
                         ', ' +
-                        (pending_payout_printed_steem > 0 ? formatDecimal(pending_payout_printed_steem).join('') +
-                        ' ' +
-                        LIQUID_TOKEN_UPPERCASE + 
-                        ', ' : '') +
+                        (sbd_print_rate != 10000
+                            ? formatDecimal(pending_payout_printed_steem).join(
+                                  ''
+                              ) +
+                              ' ' +
+                              LIQUID_TOKEN_UPPERCASE +
+                              ', '
+                            : '') +
                         formatDecimal(pending_payout_sp).join('') +
                         ' ' +
                         INVEST_TOKEN_SHORT +
@@ -553,7 +564,7 @@ export default connect(
             loggedin: username != null,
             voting,
             price_per_steem,
-            sbd_print_rate
+            sbd_print_rate,
         };
     },
 

--- a/src/app/components/elements/Voting.test.jsx
+++ b/src/app/components/elements/Voting.test.jsx
@@ -1,0 +1,101 @@
+import React from 'react';
+import { IntlProvider } from 'react-intl';
+import { Provider } from 'react-redux';
+import { createStore } from 'redux';
+import { configure, shallow } from 'enzyme';
+import Adapter from 'enzyme-adapter-react-15';
+import { fromJS } from 'immutable';
+import renderer from 'react-test-renderer';
+import rootReducer from 'app/redux/RootReducer';
+
+import Voting from './Voting';
+
+configure({ adapter: new Adapter() });
+
+const store = createStore(rootReducer);
+
+describe('Voting', () => {
+    it('should show all SP if percent_steem_dollars is 0', () => {
+        const post_obj = fromJS({
+            stats: {
+                total_votes: 1,
+            },
+            max_accepted_payout: '999999 SBD',
+            percent_steem_dollars: 0,
+            pending_payout_value: '10 SBD',
+            cashout_time: '2018-03-30T10:00:00Z',
+        });
+        const component = renderer.create(
+            <Provider store={store}>
+                <IntlProvider locale="en">
+                    <Voting
+                        post="Test post"
+                        vote={(w, p) => {}}
+                        post_obj={post_obj}
+                        price_per_steem={1}
+                        sbd_print_rate={10000}
+                    />
+                </IntlProvider>
+            </Provider>
+        );
+        expect(JSON.stringify(component.toJSON())).toContain(
+            '(0.00 SBD, 10.00 SP)'
+        );
+    });
+
+    it('should omit liquid steem if print rate is 10000', () => {
+        const post_obj = fromJS({
+            stats: {
+                total_votes: 1,
+            },
+            max_accepted_payout: '999999 SBD',
+            percent_steem_dollars: 10000,
+            pending_payout_value: '10 SBD',
+            cashout_time: '2018-03-30T10:00:00Z',
+        });
+        const component = renderer.create(
+            <Provider store={store}>
+                <IntlProvider locale="en">
+                    <Voting
+                        post="Test post"
+                        vote={(w, p) => {}}
+                        post_obj={post_obj}
+                        price_per_steem={1}
+                        sbd_print_rate={10000}
+                    />
+                </IntlProvider>
+            </Provider>
+        );
+        expect(JSON.stringify(component.toJSON())).toContain(
+            '(5.00 SBD, 5.00 SP)'
+        );
+    });
+
+    it('should show liquid steem if print rate is < 10000', () => {
+        const post_obj = fromJS({
+            stats: {
+                total_votes: 1,
+            },
+            max_accepted_payout: '999999 SBD',
+            percent_steem_dollars: 10000,
+            pending_payout_value: '10 SBD',
+            cashout_time: '2018-03-30T10:00:00Z',
+        });
+        const component = renderer.create(
+            <Provider store={store}>
+                <IntlProvider locale="en">
+                    <Voting
+                        post="Test post"
+                        vote={(w, p) => {}}
+                        post_obj={post_obj}
+                        price_per_steem={1}
+                        sbd_print_rate={5000}
+                    />
+                </IntlProvider>
+            </Provider>
+        );
+        expect(JSON.stringify(component.toJSON())).toContain(
+            '(2.50 SBD, 2.50 STEEM, 5.00 SP)'
+        );
+    });
+});

--- a/src/app/utils/StateFunctions.js
+++ b/src/app/utils/StateFunctions.js
@@ -7,25 +7,6 @@ import { fromJS } from 'immutable';
 
 export const numberWithCommas = x => x.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
-export function percentLiquidSteemRewards(state) {
-    const { global } = state;
-    const current_sbd_supply = global.getIn(['props', 'current_sbd_supply']);
-    const virtual_supply = global.getIn(['props', 'virtual_supply']);
-    let vests = vesting_shares;
-    if (typeof vesting_shares === 'string') {
-        vests = assetFloat(vesting_shares, VEST_TICKER);
-    }
-    const total_vests = assetFloat(
-        global.getIn(['props', 'total_vesting_shares']),
-        VEST_TICKER
-    );
-    const total_vest_steem = assetFloat(
-        global.getIn(['props', 'total_vesting_fund_steem']),
-        LIQUID_TICKER
-    );
-    return total_vest_steem * (vests / total_vests);
-}
-
 export function vestsToSpf(state, vesting_shares) {
     const { global } = state;
     let vests = vesting_shares;

--- a/src/app/utils/StateFunctions.js
+++ b/src/app/utils/StateFunctions.js
@@ -7,6 +7,25 @@ import { fromJS } from 'immutable';
 
 export const numberWithCommas = x => x.replace(/\B(?=(\d{3})+(?!\d))/g, ',');
 
+export function percentLiquidSteemRewards(state) {
+    const { global } = state;
+    const current_sbd_supply = global.getIn(['props', 'current_sbd_supply']);
+    const virtual_supply = global.getIn(['props', 'virtual_supply']);
+    let vests = vesting_shares;
+    if (typeof vesting_shares === 'string') {
+        vests = assetFloat(vesting_shares, VEST_TICKER);
+    }
+    const total_vests = assetFloat(
+        global.getIn(['props', 'total_vesting_shares']),
+        VEST_TICKER
+    );
+    const total_vest_steem = assetFloat(
+        global.getIn(['props', 'total_vesting_fund_steem']),
+        LIQUID_TICKER
+    );
+    return total_vest_steem * (vests / total_vests);
+}
+
 export function vestsToSpf(state, vesting_shares) {
     const { global } = state;
     let vests = vesting_shares;


### PR DESCRIPTION
Per feedback in #2460  and referenced in #2429 , seems prudent not to show this inaccurate breakdown in the historical payout, so that's done in this pull request. At the very least they'll see it in their historical payouts. Not ideal, but also not inaccurate.

In addition, with the sbd_print_rate changes, I felt we should also show this in the pending payout. This at least seems to be strictly better for the current situation.

I've added some unit tests to capture the changes made here as well.

This is what it looks like:

![payoutsplitchange](https://user-images.githubusercontent.com/34953718/38157074-4a929140-3451-11e8-8fd5-56c3babb1d20.PNG)

You'll note that the right paren is sort of clipped, not sure how to fix that.

