### PR TITLE
filter non-string tags

### DIFF
--- a/src/app/components/elements/TagList.jsx
+++ b/src/app/components/elements/TagList.jsx
@@ -14,6 +14,7 @@ export default ({ post, horizontal, single }) => {
 
     const json = post.json_metadata;
     let tags = [];
+    tags = tags.filter(tag => typeof tag === 'string');
 
     try {
         if (typeof json == 'object') {
@@ -32,10 +33,15 @@ export default ({ post, horizontal, single }) => {
     // Category should always be first.
     tags.unshift(post.category);
 
-    // Uniqueness filter.
-    tags = tags.filter(
-        (value, index, self) => value && self.indexOf(value) === index
-    );
+    tags = tags
+        .filter(
+            // Uniqueness filter.
+            (value, index, self) => value && self.indexOf(value) === index
+        )
+        .filter(
+            // Filter non-strings
+            tag => typeof tag === 'string'
+        );
 
     if (horizontal) {
         // show it as a dropdown in Preview

--- a/src/app/components/pages/TagsIndex.jsx
+++ b/src/app/components/pages/TagsIndex.jsx
@@ -55,6 +55,8 @@ export default class TagsIndex extends React.Component {
         //console.log('-- TagsIndex.render -->', tagsAll.toJS());
         const { order } = this.state;
         let tags = tagsAll;
+        //filter out non-strings
+        tags = tags.filter(tag => typeof tag === 'string');
 
         const rows = tags
             .filter(

--- a/src/app/utils/StateFunctions.js
+++ b/src/app/utils/StateFunctions.js
@@ -163,6 +163,7 @@ export function contentStats(content) {
     // Combine tags+category to check nsfw status
     const json = content.get('json_metadata');
     let tags = [];
+    tags.push(content.get('category'));
     try {
         tags = (json && JSON.parse(json).tags) || [];
         if (typeof tags == 'string') {
@@ -174,7 +175,7 @@ export function contentStats(content) {
     } catch (e) {
         tags = [];
     }
-    tags.push(content.get('category'));
+    tags = tags.filter(tag => typeof tag === 'string');
     const isNsfw = tags.filter(tag => tag && tag.match(/^nsfw$/i)).length > 0;
 
     return {


### PR DESCRIPTION
Fixes #2693

Filtering out non-string based tags.

Examples of pages that break.

https://steemit.com/@ikidnapmyself

https://steemit.com/dngo/@ikidnapmyself/my-awesome-title