### PR TITLE
Community - Fix "Account not found" but when using usernames with role suffixes

### DIFF
--- a/src/app/redux/AuthSaga.js
+++ b/src/app/redux/AuthSaga.js
@@ -132,6 +132,11 @@ export function* findSigningKey({ opType, username, password }) {
     username = username || currentUsername;
     if (!username) return null;
 
+    if (username.indexOf('/') > -1) {
+        // "alice/active" will login only with Alices active key
+        username = username.split('/')[0];
+    }
+
     const private_keys =
         currentUsername === username ? currentUser.get('private_keys') : Map();
 


### PR DESCRIPTION
Fixes #2593  assuming it has to do with a role-suffix on the user name when doing the login flow.

Description of Problem:
When using eonwarped/active and corresponding password to login while performing a transaction operation such as powering up or transfering funds, or in the case of the referenced issue, changing the account profile, you would get an error like this:

![erroraccountnotfound](https://user-images.githubusercontent.com/34953718/38837758-2cdc8c70-41a1-11e8-9025-6c8feeba3b61.PNG)

The reason was because of the suffix role, and it simply needs to be stripped. That's what's in this pull request.