### PR TITLE
fix EN grammar, add JP switch

### DIFF
--- a/src/app/components/modules/Settings.jsx
+++ b/src/app/components/modules/Settings.jsx
@@ -326,6 +326,9 @@ class Settings extends React.Component {
                                             <option value="ko">
                                                 Korean 한국어
                                             </option>
+                                            <option value="ja">
+                                                Japanese 日本語
+                                            </option>
                                             <option value="pl">Polish</option>
                                             <option value="zh">
                                                 Chinese 简体中文

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -746,7 +746,7 @@
         "to_comment_and_reward_others": " to comment and reward others.",
         "signup_button": "Sign up now to earn ",
         "signup_button_emphasis": "FREE STEEM!",
-        "sign_up_get_steem": "Sign up. Get STEEM",
+        "sign_up_get_steem": "Sign up. Get STEEM!",
         "returning_users": "Returning Users: ",
         "join_our": "Join our"
     },


### PR DESCRIPTION
 - JP was added in #2675 but had no switch
 - fix awkward missing punctuation:
    ![image](https://user-images.githubusercontent.com/5168676/38941773-e45b4fd8-42f2-11e8-8bb8-9d4a9e376b77.png)