### PR TITLE
Don't SSR a comment if it has more than 10 newlines

### DIFF
--- a/src/app/components/cards/Comment.jsx
+++ b/src/app/components/cards/Comment.jsx
@@ -234,9 +234,19 @@ class CommentImpl extends React.Component {
     render() {
         const { cont } = this.props;
         const dis = cont.get(this.props.content);
+
         if (!dis) {
             return <div>{tt('g.loading')}...</div>;
         }
+
+        // Don't server-side render the comment if it has a certain number of newlines
+        if (
+            global['process'] !== undefined &&
+            (dis.get('body').match(/\r?\n/g) || '').length > 10
+        ) {
+            return <div>{tt('g.loading')}...</div>;
+        }
+
         const comment = dis.toJS();
         if (!comment.stats) {
             console.error('Comment -- missing stats object');

--- a/src/app/components/cards/Comment.jsx
+++ b/src/app/components/cards/Comment.jsx
@@ -242,7 +242,7 @@ class CommentImpl extends React.Component {
         // Don't server-side render the comment if it has a certain number of newlines
         if (
             global['process'] !== undefined &&
-            (dis.get('body').match(/\r?\n/g) || '').length > 10
+            (dis.get('body').match(/\r?\n/g) || '').length > 25
         ) {
             return <div>{tt('g.loading')}...</div>;
         }


### PR DESCRIPTION
react-dom/server does not do well with a lot of dom nodes, and this is a dirty way to make SSR quite a bit faster.

on master:

```
Running 15s test @ http://localhost:8080/blackpanther/@cinemax/black-panther-black-panther-full-movie-2018-free-hdrip-dvdrip-bluray-download
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     0.00us    0.00us   0.00us    -nan%
    Req/Sec     0.00      0.00     0.00    100.00%
  9 requests in 15.02s, 18.81MB read
  Socket errors: connect 0, read 0, write 0, timeout 9
Requests/sec:      0.60
Transfer/sec:      1.25MB
```

cutoff at 100 newlines:

```
Running 15s test @ http://localhost:8080/blackpanther/@cinemax/black-panther-black-panther-full-movie-2018-free-hdrip-dvdrip-bluray-download
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.26s     0.00us   1.26s   100.00%
    Req/Sec     0.96      0.85     2.00     29.63%
  27 requests in 15.02s, 28.07MB read
  Socket errors: connect 0, read 0, write 0, timeout 26
Requests/sec:      1.80
Transfer/sec:      1.87MB
```

cutoff at 10 newlines:

```
Running 15s test @ http://localhost:8080/blackpanther/@cinemax/black-panther-black-panther-full-movie-2018-free-hdrip-dvdrip-bluray-download
  2 threads and 10 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency     1.34s   411.93ms   1.63s   100.00%
    Req/Sec     1.78      1.20     3.00     37.84%
  37 requests in 15.02s, 35.49MB read
  Socket errors: connect 0, read 0, write 0, timeout 35
Requests/sec:      2.46
Transfer/sec:      2.36MB
```

this is obviously a hacky fix, but it can tide us over until we either upgrade to react 16, which has big improvements for server-side rendering, or we implement a render caching system with react 15 similar to https://github.com/alt-j/fast-react-render.