### PR TITLE
ExplorePost: remove steemdata.com from options

### DIFF
--- a/src/app/components/modules/ExplorePost.jsx
+++ b/src/app/components/modules/ExplorePost.jsx
@@ -19,7 +19,6 @@ class ExplorePost extends Component {
         this.Steemd = this.Steemd.bind(this);
         this.Steemdb = this.Steemdb.bind(this);
         this.Busy = this.Busy.bind(this);
-        this.Phist = this.Phist.bind(this);
     }
 
     Steemd() {
@@ -34,10 +33,6 @@ class ExplorePost extends Component {
         serverApiRecordEvent('Busy view', this.props.permlink);
     }
 
-    Phist() {
-        serverApiRecordEvent('PhistView', this.props.permlink);
-    }
-
     onCopy() {
         this.setState({
             copied: true,
@@ -50,8 +45,6 @@ class ExplorePost extends Component {
         const steemdb = 'https://steemdb.com' + link;
         const busy = 'https://busy.org' + link;
         const steemit = 'https://steemit.com' + link;
-        const phist =
-            'https://phist.steemdata.com/history?identifier=steemit.com' + link;
         let text =
             this.state.copied == true
                 ? tt('explorepost_jsx.copied')
@@ -105,16 +98,6 @@ class ExplorePost extends Component {
                             rel="noopener noreferrer"
                         >
                             busy.org <Icon name="extlink" />
-                        </a>
-                    </li>
-                    <li>
-                        <a
-                            href={phist}
-                            onClick={this.Phist}
-                            target="_blank"
-                            rel="noopener noreferrer"
-                        >
-                            phist.steemdata.com <Icon name="extlink" />
                         </a>
                     </li>
                 </ul>


### PR DESCRIPTION

![phist](https://user-images.githubusercontent.com/33018033/39624455-a6d4c71c-4f99-11e8-88df-579a58209abb.png)

phist.steemdata.com was discontinued together with the SteemData.com MongoDB instance on May 1st 2018:
https://steemit.com/steemdata/@furion/steemdata-is-shutting-down-on-may-1st