### PR TITLE
reduce server-side fs reads, refs #332

### DIFF
--- a/src/server/app_render.jsx
+++ b/src/server/app_render.jsx
@@ -6,31 +6,19 @@ import { serverRender } from '../shared/UniversalRender';
 import models from 'db/models';
 import secureRandom from 'secure-random';
 import ErrorPage from 'server/server-error';
-import fs from 'fs';
 import { determineViewMode } from '../app/utils/Links';
+import { getSupportedLocales } from './utils/misc';
 
 const path = require('path');
 const ROOT = path.join(__dirname, '../..');
 const DB_RECONNECT_TIMEOUT =
     process.env.NODE_ENV === 'development' ? 1000 * 60 * 60 : 1000 * 60 * 10;
 
-function getSupportedLocales() {
-    const locales = [];
-    const files = fs.readdirSync(path.join(ROOT, 'src/app/locales'));
-    for (const filename of files) {
-        const match_res = filename.match(/(\w+)\.json?$/);
-        if (match_res) locales.push(match_res[1]);
-    }
-    return locales;
-}
-
 const supportedLocales = getSupportedLocales();
 
-async function appRender(ctx) {
+async function appRender(ctx, locales = false, resolvedAssets = false) {
     ctx.state.requestTimer.startTimer('appRender_ms');
-
     const store = {};
-
     // This is the part of SSR where we make session-specific changes:
     try {
         let userPreferences = {};
@@ -48,6 +36,7 @@ async function appRender(ctx) {
         if (!userPreferences.locale) {
             let locale = ctx.getLocaleFromHeader();
             if (locale) locale = locale.substring(0, 2);
+            const supportedLocales = locales ? locales : getSupportedLocales();
             const localeIsSupported = supportedLocales.find(l => l === locale);
             if (!localeIsSupported) locale = 'en';
             userPreferences.locale = locale;
@@ -75,7 +64,6 @@ async function appRender(ctx) {
             }
         }
         // ... and that's the end of user-session-related SSR
-
         const initial_state = {
             app: {
                 viewMode: determineViewMode(ctx.request.search),
@@ -91,19 +79,17 @@ async function appRender(ctx) {
             ctx.state.requestTimer
         );
 
-        // Assets name are found in `webpack-stats` file
-        const assets_filename =
-            ROOT +
-            (process.env.NODE_ENV === 'production'
-                ? '/tmp/webpack-stats-prod.json'
-                : '/tmp/webpack-stats-dev.json');
-        const assets = require(assets_filename);
-
-        // Don't cache assets name on dev
-        if (process.env.NODE_ENV === 'development') {
+        let assets;
+        // If resolvedAssets argument parameter is falsey we infer that we are in
+        // development mode and therefore resolve the assets on each render.
+        if (!resolvedAssets) {
+            // Assets name are found in `webpack-stats` file
+            const assets_filename = ROOT + '/tmp/webpack-stats-dev.json';
+            assets = require(assets_filename);
             delete require.cache[require.resolve(assets_filename)];
+        } else {
+            assets = resolvedAssets;
         }
-
         const props = { body, assets, title, meta };
         ctx.status = statusCode;
         ctx.body =

--- a/src/server/utils/misc.js
+++ b/src/server/utils/misc.js
@@ -1,3 +1,5 @@
+import path from 'path';
+import fs from 'fs';
 import { esc } from 'db/models';
 
 const emailRegex = /^([^\x00-\x20\x22\x28\x29\x2c\x2e\x3a-\x3c\x3e\x40\x5b-\x5d\x7f-\xff]+|\x22([^\x0d\x22\x5c\x80-\xff]|\x5c[\x00-\x7f])*\x22)(\x2e([^\x00-\x20\x22\x28\x29\x2c\x2e\x3a-\x3c\x3e\x40\x5b-\x5d\x7f-\xff]+|\x22([^\x0d\x22\x5c\x80-\xff]|\x5c[\x00-\x7f])*\x22))*\x40([^\x00-\x20\x22\x28\x29\x2c\x2e\x3a-\x3c\x3e\x40\x5b-\x5d\x7f-\xff]+|\x5b([^\x0d\x5b-\x5d\x80-\xff]|\x5c[\x00-\x7f])*\x5d)(\x2e([^\x00-\x20\x22\x28\x29\x2c\x2e\x3a-\x3c\x3e\x40\x5b-\x5d\x7f-\xff]+|\x5b([^\x0d\x5b-\x5d\x80-\xff]|\x5c[\x00-\x7f])*\x5d))*$/;
@@ -57,9 +59,22 @@ function checkCSRF(ctx, csrf) {
     return true;
 }
 
+function getSupportedLocales() {
+    const locales = [];
+    const files = fs.readdirSync(
+        path.join(__dirname, '../../..', 'src/app/locales')
+    );
+    for (const filename of files) {
+        const match_res = filename.match(/(\w+)\.json?$/);
+        if (match_res) locales.push(match_res[1]);
+    }
+    return locales;
+}
+
 module.exports = {
     emailRegex,
     getRemoteIp,
     rateLimitReq,
     checkCSRF,
+    getSupportedLocales,
 };


### PR DESCRIPTION
closes https://github.com/steemit/steempunks/issues/332

With the changes in this PR and following profiling commands

I am seeing:
```
232.76 kb/s avg before.
253.1 kb/s avg after.

8.73 % increase in kb/s.

685.3 req/100s before
899 req/100s after

31.24% increase in requests/s
```

Per:
https://gist.github.com/gl2748/5ee5b145ef2f168895cce74a3466f321

This on the parent process as reported by:
```
yarn run build && SDC_DATABASE_URL="mysql://root@localhost/steemit_dev" NODE_ENV=production node --prof --log_timer_events lib/server/index.js
```
So not too bad. I have a hunch that fs reads for translations might also be slowing things down server side.

### See below.