### PR TITLE
link directly to comment, not its parent

### DIFF
--- a/src/app/components/cards/PostSummary.jsx
+++ b/src/app/components/cards/PostSummary.jsx
@@ -113,10 +113,6 @@ class PostSummary extends React.Component {
                 '/' +
                 content.get('category') +
                 '/@' +
-                content.get('parent_author') +
-                '/' +
-                content.get('parent_permlink') +
-                '#@' +
                 content.get('author') +
                 '/' +
                 content.get('permlink');


### PR DESCRIPTION
> The page loads on long posts or posts with many replies are a unneeded, and the `#` scrolling on pageload from the URL is unreliable. 