### PR TITLE
add request metrics to server-side render, and refactor

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "sequelize-cli": "3.2.0",
     "speakingurl": "9.0.0",
     "sqlite3": "3.1.13",
+    "statsd-client": "0.4.2",
     "store": "1.3.20",
     "style-loader": "0.18.2",
     "svg-inline-loader": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -127,7 +127,6 @@
     "sequelize-cli": "3.2.0",
     "speakingurl": "9.0.0",
     "sqlite3": "3.1.13",
-    "statsd-client": "0.4.2",
     "store": "1.3.20",
     "style-loader": "0.18.2",
     "svg-inline-loader": "0.8.0",

--- a/src/app/Main.js
+++ b/src/app/Main.js
@@ -6,7 +6,7 @@ import { VIEW_MODE_WHISTLE, PARAM_VIEW_MODE } from 'shared/constants';
 import './assets/stylesheets/app.scss';
 import plugins from 'app/utils/JsPlugins';
 import Iso from 'iso';
-import universalRender from 'shared/UniversalRender';
+import { clientRender } from 'shared/UniversalRender';
 import ConsoleExports from './utils/ConsoleExports';
 import { serverApiRecordEvent } from 'app/utils/ServerApiClient';
 import * as steem from '@steemit/steem-js';
@@ -112,10 +112,13 @@ function runApp(initial_state) {
     const location = `${window.location.pathname}${window.location.search}${
         window.location.hash
     }`;
-    universalRender({ history, location, initial_state }).catch(error => {
+
+    try {
+        clientRender(initial_state);
+    } catch (error) {
         console.error(error);
         serverApiRecordEvent('client_error', error);
-    });
+    }
 }
 
 if (!window.Intl) {

--- a/src/server/app_render.jsx
+++ b/src/server/app_render.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { renderToString } from 'react-dom/server';
 import { VIEW_MODE_WHISTLE, PARAM_VIEW_MODE } from '../shared/constants';
 import ServerHTML from './server-html';
-import universalRender from '../shared/UniversalRender';
+import { serverRender } from '../shared/UniversalRender';
 import models from 'db/models';
 import secureRandom from 'secure-random';
 import ErrorPage from 'server/server-error';
@@ -80,14 +80,13 @@ async function appRender(ctx) {
             },
         };
 
-        const { body, title, statusCode, meta } = await universalRender({
+        const { body, title, statusCode, meta } = await serverRender(
+            ctx.request.url,
             initial_state,
-            location: ctx.request.url,
-            store,
             ErrorPage,
             userPreferences,
-            offchain,
-        });
+            offchain
+        );
 
         // Assets name are found in `webpack-stats` file
         const assets_filename =

--- a/src/server/app_render.jsx
+++ b/src/server/app_render.jsx
@@ -27,6 +27,8 @@ function getSupportedLocales() {
 const supportedLocales = getSupportedLocales();
 
 async function appRender(ctx) {
+    ctx.state.requestTimer.startTimer('request.appRender_ns');
+
     const store = {};
 
     // This is the part of SSR where we make session-specific changes:
@@ -85,7 +87,8 @@ async function appRender(ctx) {
             initial_state,
             ErrorPage,
             userPreferences,
-            offchain
+            offchain,
+            ctx.state.requestTimer
         );
 
         // Assets name are found in `webpack-stats` file
@@ -118,6 +121,8 @@ async function appRender(ctx) {
 
         throw err;
     }
+
+    ctx.state.requestTimer.stopTimer('request.appRender_ns');
 }
 
 appRender.dbStatus = { ok: true };

--- a/src/server/app_render.jsx
+++ b/src/server/app_render.jsx
@@ -27,7 +27,7 @@ function getSupportedLocales() {
 const supportedLocales = getSupportedLocales();
 
 async function appRender(ctx) {
-    ctx.state.requestTimer.startTimer('request.appRender_ns');
+    ctx.state.requestTimer.startTimer('appRender_ms');
 
     const store = {};
 
@@ -122,7 +122,7 @@ async function appRender(ctx) {
         throw err;
     }
 
-    ctx.state.requestTimer.stopTimer('request.appRender_ns');
+    ctx.state.requestTimer.stopTimer('appRender_ms');
 }
 
 appRender.dbStatus = { ok: true };

--- a/src/server/requesttimings.js
+++ b/src/server/requesttimings.js
@@ -7,12 +7,9 @@ function requestTime(statsLoggerClient) {
             path: this.request.path,
         });
 
-        this.state.requestTimer.startTimer('request.total_ns');
-
         yield* next;
 
-        this.state.requestTimer.stopTimer('request.total_ns');
-        this.state.requestTimer.sendToStatsd();
+        this.state.requestTimer.finish();
     };
 }
 

--- a/src/server/requesttimings.js
+++ b/src/server/requesttimings.js
@@ -2,10 +2,11 @@ import RequestTimer from './utils/RequestTimer';
 
 function requestTime(statsLoggerClient) {
     return function*(next) {
-        this.state.requestTimer = new RequestTimer(statsLoggerClient, {
-            method: this.request.method,
-            path: this.request.path,
-        });
+        this.state.requestTimer = new RequestTimer(
+            statsLoggerClient,
+            'condenser.request',
+            `method=${this.request.method} path=${this.request.path}`
+        );
 
         yield* next;
 

--- a/src/server/requesttimings.js
+++ b/src/server/requesttimings.js
@@ -1,20 +1,15 @@
-function requestTime(numProcesses) {
-    let number_of_requests = 0;
+import RequestTimer from './utils/RequestTimer';
+
+function requestTime(statsLoggerClient) {
     return function*(next) {
-        number_of_requests += 1;
-        const start = Date.now();
+        this.state.requestTimer = new RequestTimer(statsLoggerClient);
+
+        this.state.requestTimer.startTimer('request.total_ns');
+
         yield* next;
-        const delta = Math.ceil(Date.now() - start);
-        // log all requests that take longer than 150ms
-        if (delta > 150)
-            console.log(
-                `Request took too long! ${delta}ms: ${this.request.method} ${
-                    this.request.path
-                }. Number of parallel requests: ${
-                    number_of_requests
-                }, number of processes: ${numProcesses}`
-            );
-        number_of_requests -= 1;
+
+        this.state.requestTimer.stopTimer('request.total_ns');
+        this.state.requestTimer.sendToStatsd();
     };
 }
 

--- a/src/server/requesttimings.js
+++ b/src/server/requesttimings.js
@@ -2,7 +2,10 @@ import RequestTimer from './utils/RequestTimer';
 
 function requestTime(statsLoggerClient) {
     return function*(next) {
-        this.state.requestTimer = new RequestTimer(statsLoggerClient);
+        this.state.requestTimer = new RequestTimer(statsLoggerClient, {
+            method: this.request.method,
+            path: this.request.path,
+        });
 
         this.state.requestTimer.startTimer('request.total_ns');
 

--- a/src/server/requesttimings.js
+++ b/src/server/requesttimings.js
@@ -4,7 +4,7 @@ function requestTime(statsLoggerClient) {
     return function*(next) {
         this.state.requestTimer = new RequestTimer(
             statsLoggerClient,
-            'condenser.request',
+            'request',
             `method=${this.request.method} path=${this.request.path}`
         );
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -5,6 +5,7 @@ import mount from 'koa-mount';
 import helmet from 'koa-helmet';
 import koa_logger from 'koa-logger';
 import requestTime from './requesttimings';
+import StatsLoggerClient from './utils/StatsLoggerClient';
 import hardwareStats from './hardwarestats';
 import cluster from 'cluster';
 import os from 'os';
@@ -84,7 +85,9 @@ app.use(isBot());
 // (unless passed in as an env var)
 const numProcesses = process.env.NUM_PROCESSES || os.cpus().length;
 
-app.use(requestTime(numProcesses));
+const statsLoggerClient = new StatsLoggerClient(process.env.STATSD_IP);
+
+app.use(requestTime(statsLoggerClient));
 
 app.keys = [config.get('session_key')];
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -85,7 +85,10 @@ app.use(isBot());
 // (unless passed in as an env var)
 const numProcesses = process.env.NUM_PROCESSES || os.cpus().length;
 
-const statsLoggerClient = new StatsLoggerClient(process.env.STATSD_IP);
+const statsLoggerClient = new StatsLoggerClient(
+    process.env.GRAPHITE_HOST,
+    process.env.GRAPHITE_PORT
+);
 
 app.use(requestTime(statsLoggerClient));
 

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -85,10 +85,7 @@ app.use(isBot());
 // (unless passed in as an env var)
 const numProcesses = process.env.NUM_PROCESSES || os.cpus().length;
 
-const statsLoggerClient = new StatsLoggerClient(
-    process.env.GRAPHITE_HOST,
-    process.env.GRAPHITE_PORT
-);
+const statsLoggerClient = new StatsLoggerClient(process.env.STATSD_IP);
 
 app.use(requestTime(statsLoggerClient));
 

--- a/src/server/utils/RequestTimer.js
+++ b/src/server/utils/RequestTimer.js
@@ -1,11 +1,31 @@
+import assert from 'assert';
+import StatsLoggerClient from './StatsLoggerClient';
+
 /**
  * @param {array} hrtime process.hrtime() tuple
  * @returns {number} nanoseconds
  */
 const hrtimeToNanoseconds = hrtime => +hrtime[0] * 1e9 + +hrtime[1];
 
+/**
+ * Logs total request time starting at instantiation and ending when finish() is called.
+ * Additional timers can be managed with startTimer('name') and stopTimer('name')
+ *
+ * Results are stored in `timers` property and submitted to statsd at finish().
+ */
 export default class RequestTimer {
+    /**
+     *
+     * @param {StatsLoggerClient} statsdClient
+     * @param {object} tags a single-depth object where each property is a tag name and each value is a tag value
+     */
     constructor(statsdClient, tags) {
+        assert(
+            statsdClient instanceof StatsLoggerClient,
+            'provide an instance of StatsLoggerClient'
+        );
+
+        this.start = process.hrtime();
         this.timers = [];
         this.inProgressTimers = {};
         this.requestTags = tags;
@@ -20,11 +40,31 @@ export default class RequestTimer {
         this.timers.push([name, duration]);
     }
 
+    /**
+     * Starts keeping track of something to time.
+     *
+     * @param {string} name
+     */
     startTimer(name) {
+        assert(
+            typeof name === 'string',
+            'a name for the timer must be provided'
+        );
+
         this.inProgressTimers[name] = process.hrtime();
     }
 
+    /**
+     * Stops an in-progress timer and stores it in the list of timers to log when the request is finished.
+     *
+     * @param {*} name
+     */
     stopTimer(name) {
+        assert(
+            typeof this.inProgressTimers[name] !== 'undefined',
+            'provide an existing timer name'
+        );
+
         this.logSegment(
             name,
             hrtimeToNanoseconds(process.hrtime(this.inProgressTimers[name]))
@@ -32,7 +72,11 @@ export default class RequestTimer {
         delete this.inProgressTimers[name];
     }
 
-    sendToStatsd() {
+    finish() {
+        this.logSegment(
+            'total_ns',
+            hrtimeToNanoseconds(process.hrtime(this.start))
+        );
         this.statsdClient.logTimers(this.timers, this.requestTags);
     }
 }

--- a/src/server/utils/RequestTimer.js
+++ b/src/server/utils/RequestTimer.js
@@ -5,9 +5,10 @@
 const hrtimeToNanoseconds = hrtime => +hrtime[0] * 1e9 + +hrtime[1];
 
 export default class RequestTimer {
-    constructor(statsdClient) {
+    constructor(statsdClient, tags) {
         this.timers = [];
         this.inProgressTimers = {};
+        this.requestTags = tags;
         this.statsdClient = statsdClient;
     }
 
@@ -32,6 +33,6 @@ export default class RequestTimer {
     }
 
     sendToStatsd() {
-        this.statsdClient.logTimers(this.timers);
+        this.statsdClient.logTimers(this.timers, this.requestTags);
     }
 }

--- a/src/server/utils/RequestTimer.js
+++ b/src/server/utils/RequestTimer.js
@@ -1,0 +1,37 @@
+/**
+ * @param {array} hrtime process.hrtime() tuple
+ * @returns {number} nanoseconds
+ */
+const hrtimeToNanoseconds = hrtime => +hrtime[0] * 1e9 + +hrtime[1];
+
+export default class RequestTimer {
+    constructor(statsdClient) {
+        this.timers = [];
+        this.inProgressTimers = {};
+        this.statsdClient = statsdClient;
+    }
+
+    /**
+     * @param {string} name
+     * @param {number} duration nanoseconds
+     */
+    logSegment(name, duration) {
+        this.timers.push([name, duration]);
+    }
+
+    startTimer(name) {
+        this.inProgressTimers[name] = process.hrtime();
+    }
+
+    stopTimer(name) {
+        this.logSegment(
+            name,
+            hrtimeToNanoseconds(process.hrtime(this.inProgressTimers[name]))
+        );
+        delete this.inProgressTimers[name];
+    }
+
+    sendToStatsd() {
+        this.statsdClient.logTimers(this.timers);
+    }
+}

--- a/src/server/utils/RequestTimer.js
+++ b/src/server/utils/RequestTimer.js
@@ -22,13 +22,13 @@ const hrtimeToMilliseconds = hrtime => +hrtime[0] * 1000 + +hrtime[1] / 1000000;
 export default class RequestTimer {
     /**
      *
-     * @param {StatsLoggerClient} statsdClient
+     * @param {StatsLoggerClient} statsLoggerClient
      * @param {string} prefix namespace to tack on the front of each timer name
-     * @param {string} tags todo how to format tags?
+     * @param {string} tags not yet supported by statsd / StatsLoggerClient
      */
-    constructor(statsdClient, prefix, tags) {
+    constructor(statsLoggerClient, prefix, tags) {
         assert(
-            statsdClient instanceof StatsLoggerClient,
+            statsLoggerClient instanceof StatsLoggerClient,
             'provide an instance of StatsLoggerClient'
         );
 
@@ -37,7 +37,7 @@ export default class RequestTimer {
         this.inProgressTimers = {};
         this.prefix = prefix;
         this.requestTags = tags;
-        this.statsdClient = statsdClient;
+        this.statsLoggerClient = statsLoggerClient;
     }
 
     /**
@@ -85,6 +85,6 @@ export default class RequestTimer {
             'total_ms',
             hrtimeToMilliseconds(process.hrtime(this.start))
         );
-        this.statsdClient.logTimers(this.timers, this.requestTags);
+        this.statsLoggerClient.logTimers(this.timers, this.requestTags);
     }
 }

--- a/src/server/utils/StatsLoggerClient.js
+++ b/src/server/utils/StatsLoggerClient.js
@@ -1,36 +1,67 @@
-import SDC from 'statsd-client';
+import net from 'net';
 
 /**
- * In production, log stats to statsd.
+ * In production, log stats to graphite if a connection is available.
  * In dev, console.log 'em.
  */
 export default class StatsLoggerClient {
-    constructor(STATSD_IP) {
-        if (STATSD_IP) {
-            this.SDC = new SDC({
-                host: STATSD_IP,
-                prefix: 'condenser',
-            });
+    constructor(GRAPHITE_HOST, GRAPHITE_PORT) {
+        if (GRAPHITE_HOST) {
+            this.GRAPHITE_HOST = GRAPHITE_HOST;
+            this.GRAPHITE_PORT = GRAPHITE_PORT;
+            this.socket = null;
+            this.connected = false;
+            this.connect();
         } else {
             console.log(
-                'StatsLoggerClient: no statsd available, logging to console.'
+                'StatsLoggerClient: no graphite server available, logging to console.'
             );
             // Implement debug loggers here, as any new calls are added in methods below.
             this.SDC = {
                 timing() {
-                    console.log('statsd timing call: ', arguments);
+                    console.log('graphite call: ', arguments);
                 },
             };
         }
     }
 
+    connect() {
+        this.socket = net.connect(this.GRAPHITE_PORT, this.GRAPHITE_HOST);
+        this.socket.setKeepAlive(true);
+        this.socket.on('connect', this.onConnect.bind(this));
+        this.socket.on('error', this.onError.bind(this));
+    }
+
+    onConnect() {
+        console.log(
+            'connected to graphite server',
+            this.GRAPHITE_HOST,
+            this.GRAPHITE_PORT
+        );
+        this.connected = true;
+    }
+
+    onError(error) {
+        console.error('graphite server socket error', error);
+        this.socket.destroy();
+        this.socket.unref();
+        this.connected = false;
+        setTimeout(this.connect.bind(this), 1000); // wait just a second before attempting to reconnect
+    }
+
     /**
-     * Given an array of timer tuples that look like [namespace, milliseconds]
+     * Given an array of timer tuples that look like [namespace, value]
      * log them all to statsd.
      */
     logTimers(tuples, tags) {
+        if (!this.connected) {
+            console.warn('graphite not connected; will not try and log');
+            return;
+        }
+
+        const timestamp = +new Date();
         tuples.map(tuple => {
-            this.SDC.timing(tuple[0], tuple[1], tags);
+            this.socket.write(`${tuple[0]} ${tuple[1]} ${timestamp}\n`); // ${tags}\n`);
         });
     }
 }

--- a/src/server/utils/StatsLoggerClient.js
+++ b/src/server/utils/StatsLoggerClient.js
@@ -6,7 +6,7 @@ import net from 'net';
  */
 export default class StatsLoggerClient {
     constructor(GRAPHITE_HOST, GRAPHITE_PORT) {
-        if (GRAPHITE_HOST) {
+        if (GRAPHITE_HOST && GRAPHITE_PORT) {
             this.GRAPHITE_HOST = GRAPHITE_HOST;
             this.GRAPHITE_PORT = GRAPHITE_PORT;
             this.socket = null;
@@ -61,7 +61,7 @@ export default class StatsLoggerClient {
 
         const timestamp = +new Date();
         tuples.map(tuple => {
-            this.socket.write(`${tuple[0]} ${tuple[1]} ${timestamp}\n`); // ${tags}\n`);
+            this.socket.write(`${tuple[0]} ${tuple[1]} ${timestamp}`); // TODO: figure out tags: ${tags}\n`);
         });
     }
 }

--- a/src/server/utils/StatsLoggerClient.js
+++ b/src/server/utils/StatsLoggerClient.js
@@ -1,67 +1,37 @@
-import net from 'net';
+import SDC from 'statsd-client';
 
 /**
- * In production, log stats to graphite if a connection is available.
+ * In production, log stats to statsd.
  * In dev, console.log 'em.
  */
 export default class StatsLoggerClient {
-    constructor(GRAPHITE_HOST, GRAPHITE_PORT) {
-        if (GRAPHITE_HOST && GRAPHITE_PORT) {
-            this.GRAPHITE_HOST = GRAPHITE_HOST;
-            this.GRAPHITE_PORT = GRAPHITE_PORT;
-            this.socket = null;
-            this.connected = false;
-            this.connect();
+    constructor(STATSD_IP) {
+        if (STATSD_IP) {
+            this.SDC = new SDC({
+                host: STATSD_IP,
+                prefix: 'condenser',
+            });
         } else {
             console.log(
-                'StatsLoggerClient: no graphite server available, logging to console.'
+                'StatsLoggerClient: no server available, logging to console.'
             );
             // Implement debug loggers here, as any new calls are added in methods below.
             this.SDC = {
                 timing() {
-                    console.log('graphite call: ', arguments);
+                    console.log('StatsLoggerClient call: ', arguments);
                 },
             };
         }
-    }
-
-    connect() {
-        this.socket = net.connect(this.GRAPHITE_PORT, this.GRAPHITE_HOST);
-        this.socket.setKeepAlive(true);
-        this.socket.on('connect', this.onConnect.bind(this));
-        this.socket.on('error', this.onError.bind(this));
-    }
-
-    onConnect() {
-        console.log(
-            'connected to graphite server',
-            this.GRAPHITE_HOST,
-            this.GRAPHITE_PORT
-        );
-        this.connected = true;
-    }
-
-    onError(error) {
-        console.error('graphite server socket error', error);
-        this.socket.destroy();
-        this.socket.unref();
-        this.connected = false;
-        setTimeout(this.connect.bind(this), 1000); // wait just a second before attempting to reconnect
     }
 
     /**
      * Given an array of timer tuples that look like [namespace, value]
      * log them all to statsd.
      */
-    logTimers(tuples, tags) {
-        if (!this.connected) {
-            console.warn('graphite not connected; will not try and log');
-            return;
-        }
-
+    logTimers(tuples) {
         const timestamp = +new Date();
         tuples.map(tuple => {
-            this.socket.write(`${tuple[0]} ${tuple[1]} ${timestamp}`); // TODO: figure out tags: ${tags}\n`);
+            this.SDC.timing(tuple[0], tuple[1]);
         });
     }
 }

--- a/src/server/utils/StatsLoggerClient.js
+++ b/src/server/utils/StatsLoggerClient.js
@@ -1,0 +1,36 @@
+import SDC from 'statsd-client';
+
+/**
+ * In production, log stats to statsd.
+ * In dev, console.log 'em.
+ */
+export default class StatsLoggerClient {
+    constructor(STATSD_IP) {
+        if (STATSD_IP) {
+            this.SDC = new SDC({
+                host: STATSD_IP,
+                prefix: 'condenser',
+            });
+        } else {
+            console.log(
+                'StatsLoggerClient: no statsd available, logging to console.'
+            );
+            // Implement debug loggers here, as any new calls are added in methods below.
+            this.SDC = {
+                timing(name, value) {
+                    console.log('statsd timing call: ', { name, value });
+                },
+            };
+        }
+    }
+
+    /**
+     * Given an array of timer tuples that look like [namespace, milliseconds]
+     * log them all to statsd.
+     */
+    logTimers(tuples) {
+        tuples.map(tuple => {
+            this.SDC.timing(tuple[0], tuple[1]);
+        });
+    }
+}

--- a/src/server/utils/StatsLoggerClient.js
+++ b/src/server/utils/StatsLoggerClient.js
@@ -17,8 +17,8 @@ export default class StatsLoggerClient {
             );
             // Implement debug loggers here, as any new calls are added in methods below.
             this.SDC = {
-                timing(name, value) {
-                    console.log('statsd timing call: ', { name, value });
+                timing() {
+                    console.log('statsd timing call: ', arguments);
                 },
             };
         }
@@ -28,9 +28,9 @@ export default class StatsLoggerClient {
      * Given an array of timer tuples that look like [namespace, milliseconds]
      * log them all to statsd.
      */
-    logTimers(tuples) {
+    logTimers(tuples, tags) {
         tuples.map(tuple => {
-            this.SDC.timing(tuple[0], tuple[1]);
+            this.SDC.timing(tuple[0], tuple[1], tags);
         });
     }
 }

--- a/src/shared/UniversalRender.jsx
+++ b/src/shared/UniversalRender.jsx
@@ -271,9 +271,9 @@ export async function serverRender(
     try {
         const url = getUrlFromLocation(location);
 
-        requestTimer.startTimer('request.apiGetState_ns');
+        requestTimer.startTimer('apiGetState_ms');
         onchain = await apiGetState(url);
-        requestTimer.stopTimer('request.apiGetState_ns');
+        requestTimer.stopTimer('apiGetState_ms');
 
         // If a user profile URL is requested but no profile information is
         // included in the API response, return User Not Found.
@@ -363,7 +363,7 @@ export async function serverRender(
     // add pre-render hook to every component, check in-request timer and if time > timeout, return "too long" message
     let app, status, meta;
     try {
-        requestTimer.startTimer('request.ssr_ns');
+        requestTimer.startTimer('ssr_ms');
         app = renderToString(
             <Provider store={server_store}>
                 <Translator>
@@ -371,7 +371,7 @@ export async function serverRender(
                 </Translator>
             </Provider>
         );
-        requestTimer.stopTimer('request.ssr_ns');
+        requestTimer.stopTimer('ssr_ms');
         meta = extractMeta(onchain, renderProps.params);
         status = 200;
     } catch (re) {

--- a/src/shared/UniversalRender.jsx
+++ b/src/shared/UniversalRender.jsx
@@ -360,7 +360,7 @@ export async function serverRender(
             };
         }
     }
-    // add pre-render hook to every component, check in-request timer and if time > timeout, return "too long" message
+
     let app, status, meta;
     try {
         requestTimer.startTimer('ssr_ms');

--- a/src/shared/UniversalRender.jsx
+++ b/src/shared/UniversalRender.jsx
@@ -379,21 +379,6 @@ async function universalRender({
                 };
             }
         }
-        // Calculate signup bonus
-        const fee = parseFloat($STM_Config.registrar_fee.split(' ')[0]),
-            { base, quote } = onchain.feed_price,
-            feed =
-                parseFloat(base.split(' ')[0]) /
-                parseFloat(quote.split(' ')[0]);
-        const sd = fee * feed;
-        let sdDisp;
-        if (sd < 1.0) {
-            sdDisp = '¢' + parseInt(sd * 100);
-        } else {
-            const sdInt = parseInt(sd),
-                sdDec = sd - sdInt;
-            sdDisp = '$' + sdInt + (sdInt < 5 && sdDec >= 0.5 ? '.50' : '');
-        }
 
         server_store = createStore(rootReducer, {
             app: initial_state.app,
@@ -426,7 +411,7 @@ async function universalRender({
             };
         }
     }
-
+    // add pre-render hook to every component, check in-request timer and if time > timeout, return "too long" message
     let app, status, meta;
     try {
         app = renderToString(

--- a/yarn.lock
+++ b/yarn.lock
@@ -8678,6 +8678,10 @@ staged-git-files@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
 
+statsd-client@0.4.2:
+  version "0.4.2"
+  resolved "https://registry.yarnpkg.com/statsd-client/-/statsd-client-0.4.2.tgz#c0dc4d583609f97d638742f3ee412c34e9aea482"
+
 statuses@1, "statuses@>= 1.3.1 < 2", statuses@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8678,10 +8678,6 @@ staged-git-files@0.0.4:
   version "0.0.4"
   resolved "https://registry.yarnpkg.com/staged-git-files/-/staged-git-files-0.0.4.tgz#d797e1b551ca7a639dec0237dc6eb4bb9be17d35"
 
-statsd-client@0.4.2:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/statsd-client/-/statsd-client-0.4.2.tgz#c0dc4d583609f97d638742f3ee412c34e9aea482"
-
 statuses@1, "statuses@>= 1.3.1 < 2", statuses@^1.2.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/statuses/-/statuses-1.4.0.tgz#bb73d446da2796106efcc1b601a253d6c46bd087"


### PR DESCRIPTION
closes steemit/steempunks#333

doing a "loading" page is not desirable or advantageous right now, it turns out. instead, this is a refactor of the react render code as well as the addition of request timing logging using statsd (ends up in scalyr).

see logs like this: https://www.scalyr.com/events?filter=path4%3D%22request%22&mode=graph&teamToken=KBolCc6pavrJcaaz%2F4zDPw--&breakdownFacet=path5&logSource=*dev-statlyr*&startTime=1527254075447&facet=value&endTime=1527254214813