### PR TITLE
distinguish disabled witnesses

### DIFF
--- a/src/app/components/pages/Witnesses.jsx
+++ b/src/app/components/pages/Witnesses.jsx
@@ -98,7 +98,6 @@ class Witnesses extends React.Component {
             const signingKey = item.get('signing_key');
             const isDisabled = signingKey == DISABLED_SIGNING_KEY;
             const lastBlock = item.get('last_confirmed_block_num');
-            const priceFeed = item.get('sbd_exchange_rate');
             const classUp =
                 'Voting__button Voting__button-up' +
                 (myVote === true ? ' Voting__button--upvoted' : '');

--- a/src/app/components/pages/Witnesses.jsx
+++ b/src/app/components/pages/Witnesses.jsx
@@ -12,6 +12,8 @@ import tt from 'counterpart';
 const Long = ByteBuffer.Long;
 const { string, func, object } = PropTypes;
 
+const DISABLED_SIGNING_KEY = 'STM1111111111111111111111111111111114T1Anm';
+
 class Witnesses extends React.Component {
     static propTypes = {
         // HTML properties
@@ -74,23 +76,24 @@ class Witnesses extends React.Component {
         const up = <Icon name="chevron-up-circle" />;
         let witness_vote_count = 30;
         let rank = 1;
+
         const witnesses = sorted_witnesses.map(item => {
             const owner = item.get('owner');
             const thread = item.get('url');
             const myVote = witness_votes ? witness_votes.has(owner) : null;
             const signingKey = item.get('signing_key');
-            const witnessIsDisabled = /STM1111111111111111111111111111111114T1Anm/.test(signingKey);
+            const isDisabled = signingKey == DISABLED_SIGNING_KEY;
             const priceFeed = item.get('sbd_exchange_rate');
-            const noPriceFeed = /0.000 STEEM/.test(priceFeed.get('base'));
             const classUp =
                 'Voting__button Voting__button-up' +
                 (myVote === true ? ' Voting__button--upvoted' : '');
+
             let witness_thread = '';
             if (thread) {
                 if (links.remote.test(thread)) {
                     witness_thread = (
                         <a href={thread}>
-                            {tt('witnesses_jsx.witness_thread')}&nbsp;<Icon name="extlink" />
+                            {tt('witnesses_jsx.external_site')}&nbsp;<Icon name="extlink" />
                         </a>
                     );
                 } else {
@@ -101,10 +104,13 @@ class Witnesses extends React.Component {
                     );
                 }
             }
+
+            const ownerStyle = isDisabled
+                ? { textDecoration: 'line-through', color: '#AAA' }
+                : {};
+
             return (
-                <tr
-                    key={owner}
-                    style = { witnessIsDisabled || noPriceFeed ? { opacity: '0.4' } : null }>
+                <tr key={owner}>
                     <td width="75">
                         {rank < 10 && '0'}
                         {rank++}
@@ -123,8 +129,13 @@ class Witnesses extends React.Component {
                             </a>
                         </span>
                     </td>
-                    <td style = { witnessIsDisabled || noPriceFeed ? { textDecoration: 'line-through' } : null }>
-                        <Link to={'/@' + owner}>{owner}</Link>
+                    <td>
+                        <Link to={'/@' + owner} style={ownerStyle}>
+                            {owner}
+                        </Link>
+                        {isDisabled && (
+                            <small> ({tt('witnesses_jsx.disabled')})</small>
+                        )}
                     </td>
                     <td>{witness_thread}</td>
                 </tr>

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -489,6 +489,8 @@
     },
     "witnesses_jsx": {
         "witness_thread": "witness thread",
+        "external_site": "external site",
+        "disabled": "disabled",
         "top_witnesses": "Witness Voting",
         "you_have_votes_remaining": {
             "zero": "You have no votes remaining",


### PR DESCRIPTION
Replaces PR #2228 by @netuoso:

> ### Issue
> There is no distinction between a disabled and active witness on the witness page.
> 
> ### Solution
> Add a logic check and change the CSS for the name of the witness.
> 
> ### Summary
> If there are disabled witnesses in the top 50, users are unaware because the Condenser witness page does not show any distinction. This pull request contains code that will perform a basic check on the witness price feed and signing key. If the price feed is blank or the signing key is the disabled key, the witness name will be grey and strikethrough.
> 
> ### Screenshots
> - Without CSS
> ![screen shot 2017-12-26 at 11 08 24 pm](https://user-images.githubusercontent.com/7006965/34371312-b2c15b5c-ea91-11e7-976b-5454e5109afc.png)
> - With CSS
> ![screen shot 2017-12-26 at 11 08 12 pm](https://user-images.githubusercontent.com/7006965/34371317-b7c53858-ea91-11e7-88e9-92900b760329.png)
> 
> ### Extra Notes
> This pull request should also address https://github.com/steemit/condenser/issues/1610 by adding a `forceUpdate` after applying the witness vote. Sometimes a simple `setState` does not properly trigger the `ComponentShouldUpdate`.