### PR TITLE
Community - Fix witness voting not resolving properly, add feedback

### DIFF
--- a/src/app/components/pages/Witnesses.jsx
+++ b/src/app/components/pages/Witnesses.jsx
@@ -104,14 +104,14 @@ class Witnesses extends React.Component {
             const signingKey = item.get('signing_key');
             const isDisabled = signingKey == DISABLED_SIGNING_KEY;
             const lastBlock = item.get('last_confirmed_block_num');
-            const votingUpActive = witnessVotesInProgress.has(owner);
+            const votingActive = witnessVotesInProgress.has(owner);
             const classUp =
                 'Voting__button Voting__button-up' +
                 (myVote === true ? ' Voting__button--upvoted' : '') +
-                (votingUpActive ? ' votingUp' : '');
+                (votingActive ? ' votingUp' : '');
             const up = (
                 <Icon
-                    name={votingUpActive ? 'empty' : 'chevron-up-circle'}
+                    name={votingActive ? 'empty' : 'chevron-up-circle'}
                     className="upvote"
                 />
             );
@@ -144,7 +144,7 @@ class Witnesses extends React.Component {
                         {rank++}
                         &nbsp;&nbsp;
                         <span className={classUp}>
-                            {votingUpActive ? (
+                            {votingActive ? (
                                 up
                             ) : (
                                 <a
@@ -182,30 +182,44 @@ class Witnesses extends React.Component {
         if (witness_votes) {
             witness_vote_count -= witness_votes.size;
             addl_witnesses = witness_votes
+                .union(witnessVotesInProgress)
                 .filter(item => {
                     return !sorted_witnesses.has(item);
                 })
                 .map(item => {
+                    const votingActive = witnessVotesInProgress.has(item);
+                    const classUp =
+                        'Voting__button Voting__button-up' +
+                        (votingActive
+                            ? ' votingUp'
+                            : ' Voting__button--upvoted');
+                    const up = (
+                        <Icon
+                            name={votingActive ? 'empty' : 'chevron-up-circle'}
+                            className="upvote"
+                        />
+                    );
                     return (
                         <div className="row" key={item}>
                             <div className="column small-12">
                                 <span>
                                     {/*className="Voting"*/}
-                                    <span className="Voting__button Voting__button-up space-right Voting__button--upvoted">
-                                        <a
-                                            href="#"
-                                            onClick={accountWitnessVote.bind(
-                                                this,
-                                                item,
-                                                false
-                                            )}
-                                            title={tt('g.vote')}
-                                        >
-                                            <Icon
-                                                name="chevron-up-circle"
-                                                className="upvote"
-                                            />
-                                        </a>
+                                    <span className={classUp}>
+                                        {votingActive ? (
+                                            up
+                                        ) : (
+                                            <a
+                                                href="#"
+                                                onClick={accountWitnessVote.bind(
+                                                    this,
+                                                    item,
+                                                    false
+                                                )}
+                                                title={tt('g.vote')}
+                                            >
+                                                {up}
+                                            </a>
+                                        )}
                                         &nbsp;
                                     </span>
                                 </span>
@@ -404,20 +418,14 @@ module.exports = {
             const current_proxy =
                 current_account && current_account.get('proxy');
             const witnesses = state.global.get('witnesses');
-            var witnessVotesInProgress = Set();
-            if (witnesses) {
-                witnesses.forEach(item => {
-                    const witness = item.get('owner');
-                    const isVotingActive = state.global.get(
-                        `transaction_witness_vote_active_${username}_${witness}`
-                    );
-                    if (isVotingActive) {
-                        witnessVotesInProgress = witnessVotesInProgress.add(
-                            witness
-                        );
-                    }
-                });
+            var witnessVotesInProgress = state.global.get(
+                `transaction_witness_vote_active_${username}`
+            );
+            if (!witnessVotesInProgress) {
+                witnessVotesInProgress = Set();
             }
+            console.log(witnessVotesInProgress.toJS());
+            console.log(witness_votes ? witness_votes.toJS() : null);
             return {
                 head_block: state.global.getIn(['props', 'head_block_number']),
                 witnesses,

--- a/src/app/components/pages/Witnesses.jsx
+++ b/src/app/components/pages/Witnesses.jsx
@@ -418,14 +418,10 @@ module.exports = {
             const current_proxy =
                 current_account && current_account.get('proxy');
             const witnesses = state.global.get('witnesses');
-            var witnessVotesInProgress = state.global.get(
-                `transaction_witness_vote_active_${username}`
+            const witnessVotesInProgress = state.global.get(
+                `transaction_witness_vote_active_${username}`,
+                Set()
             );
-            if (!witnessVotesInProgress) {
-                witnessVotesInProgress = Set();
-            }
-            console.log(witnessVotesInProgress.toJS());
-            console.log(witness_votes ? witness_votes.toJS() : null);
             return {
                 head_block: state.global.getIn(['props', 'head_block_number']),
                 witnesses,

--- a/src/app/components/pages/Witnesses.jsx
+++ b/src/app/components/pages/Witnesses.jsx
@@ -5,7 +5,7 @@ import links from 'app/utils/Links';
 import Icon from 'app/components/elements/Icon';
 import * as transactionActions from 'app/redux/TransactionReducer';
 import ByteBuffer from 'bytebuffer';
-import { is } from 'immutable';
+import { is, Set } from 'immutable';
 import * as globalActions from 'app/redux/GlobalReducer';
 import tt from 'counterpart';
 
@@ -38,6 +38,7 @@ class Witnesses extends React.Component {
         username: string,
         witness_votes: object,
     };
+
     constructor() {
         super();
         this.state = { customUsername: '', proxy: '', proxyFailed: false };
@@ -65,6 +66,7 @@ class Witnesses extends React.Component {
     shouldComponentUpdate(np, ns) {
         return (
             !is(np.witness_votes, this.props.witness_votes) ||
+            !is(np.witnessVotesInProgress, this.props.witnessVotesInProgress) ||
             np.witnesses !== this.props.witnesses ||
             np.current_proxy !== this.props.current_proxy ||
             np.username !== this.props.username ||
@@ -76,7 +78,12 @@ class Witnesses extends React.Component {
 
     render() {
         const {
-            props: { witness_votes, current_proxy, head_block },
+            props: {
+                witness_votes,
+                witnessVotesInProgress,
+                current_proxy,
+                head_block,
+            },
             state: { customUsername, proxy },
             accountWitnessVote,
             accountWitnessProxy,
@@ -87,7 +94,6 @@ class Witnesses extends React.Component {
                 Long.fromString(String(a.get('votes'))).toString()
             )
         );
-        const up = <Icon name="chevron-up-circle" />;
         let witness_vote_count = 30;
         let rank = 1;
 
@@ -98,9 +104,17 @@ class Witnesses extends React.Component {
             const signingKey = item.get('signing_key');
             const isDisabled = signingKey == DISABLED_SIGNING_KEY;
             const lastBlock = item.get('last_confirmed_block_num');
+            const votingUpActive = witnessVotesInProgress.has(owner);
             const classUp =
                 'Voting__button Voting__button-up' +
-                (myVote === true ? ' Voting__button--upvoted' : '');
+                (myVote === true ? ' Voting__button--upvoted' : '') +
+                (votingUpActive ? ' votingUp' : '');
+            const up = (
+                <Icon
+                    name={votingUpActive ? 'empty' : 'chevron-up-circle'}
+                    className="upvote"
+                />
+            );
 
             let witness_thread = '';
             if (thread) {
@@ -130,17 +144,21 @@ class Witnesses extends React.Component {
                         {rank++}
                         &nbsp;&nbsp;
                         <span className={classUp}>
-                            <a
-                                href="#"
-                                onClick={accountWitnessVote.bind(
-                                    this,
-                                    owner,
-                                    !myVote
-                                )}
-                                title={tt('g.vote')}
-                            >
-                                {up}
-                            </a>
+                            {votingUpActive ? (
+                                up
+                            ) : (
+                                <a
+                                    href="#"
+                                    onClick={accountWitnessVote.bind(
+                                        this,
+                                        owner,
+                                        !myVote
+                                    )}
+                                    title={tt('g.vote')}
+                                >
+                                    {up}
+                                </a>
+                            )}
                         </span>
                     </td>
                     <td>
@@ -183,7 +201,10 @@ class Witnesses extends React.Component {
                                             )}
                                             title={tt('g.vote')}
                                         >
-                                            {up}
+                                            <Icon
+                                                name="chevron-up-circle"
+                                                className="upvote"
+                                            />
                                         </a>
                                         &nbsp;
                                     </span>
@@ -382,11 +403,27 @@ module.exports = {
                 current_account && current_account.get('witness_votes').toSet();
             const current_proxy =
                 current_account && current_account.get('proxy');
+            const witnesses = state.global.get('witnesses');
+            var witnessVotesInProgress = Set();
+            if (witnesses) {
+                witnesses.forEach(item => {
+                    const witness = item.get('owner');
+                    const isVotingActive = state.global.get(
+                        `transaction_witness_vote_active_${username}_${witness}`
+                    );
+                    if (isVotingActive) {
+                        witnessVotesInProgress = witnessVotesInProgress.add(
+                            witness
+                        );
+                    }
+                });
+            }
             return {
                 head_block: state.global.getIn(['props', 'head_block_number']),
-                witnesses: state.global.get('witnesses'),
+                witnesses,
                 username,
                 witness_votes,
+                witnessVotesInProgress,
                 current_proxy,
             };
         },

--- a/src/app/redux/GlobalReducer.js
+++ b/src/app/redux/GlobalReducer.js
@@ -36,6 +36,8 @@ const FETCH_JSON = 'global/FETCH_JSON';
 const FETCH_JSON_RESULT = 'global/FETCH_JSON_RESULT';
 const SHOW_DIALOG = 'global/SHOW_DIALOG';
 const HIDE_DIALOG = 'global/HIDE_DIALOG';
+const ADD_ACTIVE_WITNESS_VOTE = 'global/ADD_ACTIVE_WITNESS_VOTE';
+const REMOVE_ACTIVE_WITNESS_VOTE = 'global/REMOVE_ACTIVE_WITNESS_VOTE';
 // Saga-related:
 export const GET_STATE = 'global/GET_STATE';
 
@@ -61,6 +63,8 @@ const transformAccount = account =>
  */
 
 const mergeAccounts = (state, account) => {
+    console.log('merge');
+    console.log(account ? account.toJS() : account);
     return state.updateIn(['accounts', account.get('name')], Map(), a =>
         a.mergeDeep(account)
     );
@@ -410,6 +414,21 @@ export default function reducer(state = defaultState, action = {}) {
             return state.update('active_dialogs', d => d.delete(payload.name));
         }
 
+        case ADD_ACTIVE_WITNESS_VOTE: {
+            return state.update(
+                `transaction_witness_vote_active_${payload.account}`,
+                Set(),
+                s => s.add(payload.witness)
+            );
+        }
+
+        case REMOVE_ACTIVE_WITNESS_VOTE: {
+            return state.update(
+                `transaction_witness_vote_active_${payload.account}`,
+                s => s.delete(payload.witness)
+            );
+        }
+
         default:
             return state;
     }
@@ -545,6 +564,16 @@ export const showDialog = payload => ({
 
 export const hideDialog = payload => ({
     type: HIDE_DIALOG,
+    payload,
+});
+
+export const addActiveWitnessVote = payload => ({
+    type: ADD_ACTIVE_WITNESS_VOTE,
+    payload,
+});
+
+export const removeActiveWitnessVote = payload => ({
+    type: REMOVE_ACTIVE_WITNESS_VOTE,
     payload,
 });
 

--- a/src/app/redux/GlobalReducer.js
+++ b/src/app/redux/GlobalReducer.js
@@ -63,8 +63,6 @@ const transformAccount = account =>
  */
 
 const mergeAccounts = (state, account) => {
-    console.log('merge');
-    console.log(account ? account.toJS() : account);
     return state.updateIn(['accounts', account.get('name')], Map(), a =>
         a.mergeDeep(account)
     );

--- a/src/app/redux/TransactionSaga.js
+++ b/src/app/redux/TransactionSaga.js
@@ -102,16 +102,15 @@ function* preBroadcast_account_witness_vote({ operation, username }) {
     if (!operation.account) operation.account = username;
     const { account, witness, approve } = operation;
     // give immediate feedback
+    console.log('adding vote active ' + witness);
     yield put(
-        globalActions.set({
-            key: `transaction_witness_vote_active_${account}_${witness}`,
-            value: true,
+        globalActions.addActiveWitnessVote({
+            account,
+            witness,
         })
     );
-
-    yield put(
-        globalActions.updateAccountWitnessVote({ account, witness, approve })
-    );
+    console.log('added vote active ' + witness);
+    console.log('broadcasting vote ' + witness);
     return operation;
 }
 
@@ -464,13 +463,19 @@ function* accepted_vote({ operation: { author, permlink, weight } }) {
 function* accepted_account_witness_vote({
     operation: { account, witness, approve },
 }) {
-    console.log('refetching votes');
-    // re-fetch user votes
-    const accountObj = yield call(getAccount, account, true);
+    console.log('re-tallying status of vote');
+    yield put(
+        globalActions.updateAccountWitnessVote({ account, witness, approve })
+    );
+
     console.log('removing from vote active: ' + witness);
-    // wait for this to resolve reducers
-    const key = `transaction_witness_vote_active_${account}_${witness}`;
-    yield put(globalActions.remove({ key }));
+
+    yield put(
+        globalActions.removeActiveWitnessVote({
+            account,
+            witness,
+        })
+    );
     console.log('removed vote active');
 }
 

--- a/src/app/redux/TransactionSaga.js
+++ b/src/app/redux/TransactionSaga.js
@@ -102,15 +102,12 @@ function* preBroadcast_account_witness_vote({ operation, username }) {
     if (!operation.account) operation.account = username;
     const { account, witness, approve } = operation;
     // give immediate feedback
-    console.log('adding vote active ' + witness);
     yield put(
         globalActions.addActiveWitnessVote({
             account,
             witness,
         })
     );
-    console.log('added vote active ' + witness);
-    console.log('broadcasting vote ' + witness);
     return operation;
 }
 
@@ -463,12 +460,9 @@ function* accepted_vote({ operation: { author, permlink, weight } }) {
 function* accepted_account_witness_vote({
     operation: { account, witness, approve },
 }) {
-    console.log('re-tallying status of vote');
     yield put(
         globalActions.updateAccountWitnessVote({ account, witness, approve })
     );
-
-    console.log('removing from vote active: ' + witness);
 
     yield put(
         globalActions.removeActiveWitnessVote({
@@ -476,7 +470,6 @@ function* accepted_account_witness_vote({
             witness,
         })
     );
-    console.log('removed vote active');
 }
 
 function* accepted_withdraw_vesting({ operation }) {


### PR DESCRIPTION
This addresses #1610, while also adding the spinner for in-progress votes.

For now the logging is still there, but I'll strip it out, the main point is explain what I saw:

-- prebroadcast Saga it tweaks the account state to remove the witness vote.
-- broadcast of the transaction , at some point it seems to re-fetch the account state, and often it undoes the state setting in the prebroadcast phase

So I've moved the state setting to the accepted phase of the transaction saga (post transaction broadcast).

That was quite an annoying bug.

(If you want a quicker patch, you can ignore the tweaks from the spinner I was adding and go directly to just moving the setting of the witness votes on the account to the 'accepted' phase).