### PR TITLE
voting weight error clarification

### DIFF
--- a/src/app/redux/TransactionReducer.js
+++ b/src/app/redux/TransactionReducer.js
@@ -67,6 +67,11 @@ export default function reducer(state = defaultState, action) {
                             errorKey = 'You already voted for this post';
                             console.error('You already voted for this post.');
                         }
+                        if (/Voting weight is too small/.test(errorStr)) {
+                            errorKey = 'Voting weight is too small';
+                            errorStr =
+                                'Voting weight is too small, please accumulate more voting power or steem power.';
+                        }
                         break;
                     case 'comment':
                         if (


### PR DESCRIPTION
Local branch for #2858 by @eonwarped:
> #2847 Voting weight too small fix.
> 
> ![errorpic](https://user-images.githubusercontent.com/34953718/41198194-736b49ea-6c41-11e8-87e5-5e9d9d42e1a4.PNG)
> 
> Very quick fix to change error message.