### PR TITLE
Fix docker build arg env vars

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,10 @@
 FROM node:8.7
 
+ARG SOURCE_COMMIT
+ENV SOURCE_COMMIT ${SOURCE_COMMIT}
+ARG DOCKER_TAG
+ENV DOCKER_TAG ${DOCKER_TAG}
+
 # yarn > npm
 #RUN npm install --global yarn
 

--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -69,8 +69,6 @@
   "steemd_use_appbase": "SDC_USE_APPBASE",
   "chain_id": "SDC_CHAIN_ID",
   "address_prefix": "SDC_ADDRESS_PREFIX",
-  "docker_tag": "DOCKER_TAG",
-  "source_commit": "SOURCE_COMMIT",
   "conveyor_posting_wif": "CONVEYOR_POSTING_WIF",
   "conveyor_username": "CONVEYOR_USERNAME"
 }

--- a/config/default.json
+++ b/config/default.json
@@ -74,8 +74,6 @@
   "steemd_use_appbase": false,
   "chain_id": "0000000000000000000000000000000000000000000000000000000000000000",
   "address_prefix": "STM",
-  "docker_tag": false,
-  "source_commit": false,
   "conveyor_posting_wif": false,
   "conveyor_username": false
 }

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -126,8 +126,8 @@ app.use(function*(next) {
         this.status = 200;
         this.body = {
             status: 'ok',
-            docker_tag: config.get('docker_tag'),
-            source_commit: config.get('source_commit'),
+            docker_tag: process.env.DOCKER_TAG ? process.env.DOCKER_TAG : false,
+            source_commit: process.env.SOURCE_COMMIT ? process.env.SOURCE_COMMIT : false,
         };
         return;
     }


### PR DESCRIPTION
Because these variables exist statically within the image and are set at build time, we don't want to set them as part of the config object. This makes data from `/.well-known/healthcheck.json` useful.