### PR TITLE
Community - Add good-kama as a bad actor (#2598)

### DIFF
--- a/src/app/utils/BadActorList.js
+++ b/src/app/utils/BadActorList.js
@@ -220,6 +220,7 @@ gatehub
 gatehub.net
 gdax.com
 gemini.com
+good-kama
 gtg.witnesses
 hitbtc.com
 hitbtcexchange


### PR DESCRIPTION
Adds the "good-kama" user as a bad actor. They are stealing funds intended for "good-ka**r**ma"

Closes #2598.