### PR TITLE
Use steemscript to format canonical URLs

### DIFF
--- a/package.json
+++ b/package.json
@@ -127,6 +127,7 @@
     "speakingurl": "9.0.0",
     "sqlite3": "4.0.1",
     "statsd-client": "0.4.2",
+    "steemscript": "1.0.1",
     "store": "1.3.20",
     "style-loader": "0.18.2",
     "svg-inline-loader": "0.8.0",

--- a/src/app/utils/ExtractMeta.js
+++ b/src/app/utils/ExtractMeta.js
@@ -1,6 +1,7 @@
 import extractContent from 'app/utils/ExtractContent';
 import { objAccessor } from 'app/utils/Accessors';
 import normalizeProfile from 'app/utils/NormalizeProfile';
+import Apps from 'steemscript/apps.json';
 
 const site_desc =
     'Steemit is a social media platform where everyone gets paid for creating and curating content. It leverages a robust digital points system (Steem) for digital rewards.';
@@ -39,6 +40,20 @@ export default function extractMeta(chain_data, rp) {
             // API currently returns 'false' data with id 0.0.0 for posts that do not exist
             const d = extractContent(objAccessor, content, false);
             const url = 'https://steemit.com' + d.link;
+            const canonicalUrl =
+                d.json_metadata.app &&
+                d.category &&
+                d.json_metadata.app.split('/').length === 2 &&
+                Apps[d.json_metadata.app.split('/')[0]] &&
+                Apps[d.json_metadata.app.split('/')[0]].url_scheme
+                    ? Apps[d.json_metadata.app.split('/')[0]].url_scheme
+                          .split('{category}')
+                          .join(d.category)
+                          .split('{username}')
+                          .join(d.author)
+                          .split('{permlink}')
+                          .join(d.permlink)
+                    : url;
             const title = d.title + ' — Steemit';
             const desc = d.desc + ' by ' + d.author;
             const image = d.image_link || profile.profile_image;
@@ -46,7 +61,7 @@ export default function extractMeta(chain_data, rp) {
 
             // Standard meta
             metas.push({ title });
-            metas.push({ canonical: url });
+            metas.push({ canonical: canonicalUrl });
             metas.push({ name: 'description', content: desc });
 
             // Open Graph data

--- a/yarn.lock
+++ b/yarn.lock
@@ -8766,6 +8766,10 @@ stealthy-require@^1.1.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/stealthy-require/-/stealthy-require-1.1.1.tgz#35b09875b4ff49f26a777e509b3090a3226bf24b"
 
+steemscript@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/steemscript/-/steemscript-1.0.1.tgz#3739bc91420825f5c505049d33d888842eaf0bbd"
+
 store@1.3.20:
   version "1.3.20"
   resolved "https://registry.yarnpkg.com/store/-/store-1.3.20.tgz#13ea7e3fb2d6c239868265d686b1d84e99c5be3e"


### PR DESCRIPTION
Closes #336. Now canonical URLs are formatted according to [steemscript](https://github.com/bonuschain/steemscript) rules.