### PR TITLE
Community - Fix specific permlink collision on create (#2950)

### DIFF
--- a/src/app/redux/TransactionSaga.js
+++ b/src/app/redux/TransactionSaga.js
@@ -597,6 +597,8 @@ export function* createPermlink(title, author, parent_author, parent_permlink) {
         if (s === '') {
             s = base58.encode(secureRandom.randomBuffer(4));
         }
+        // only letters numbers and dashes shall survive
+        s = s.toLowerCase().replace(/[^a-z0-9-]+/g, '');
         // ensure the permlink(slug) is unique
         const slugState = yield call([api, api.getContentAsync], author, s);
         let prefix;
@@ -617,8 +619,6 @@ export function* createPermlink(title, author, parent_author, parent_permlink) {
         // STEEMIT_MAX_PERMLINK_LENGTH
         permlink = permlink.substring(permlink.length - 255, permlink.length);
     }
-    // only letters numbers and dashes shall survive
-    permlink = permlink.toLowerCase().replace(/[^a-z0-9-]+/g, '');
     return permlink;
 }
 


### PR DESCRIPTION
A potential fix for #2950 by moving the character stripping logic to before the uniqueness check. It appears the parts behind will not add more invalid characters, but may need some auditing.