### PR TITLE
Commmunity - Fix broken user profile page with posts having malformed image_url data

### DIFF
--- a/src/app/components/cards/PostSummary.jsx
+++ b/src/app/components/cards/PostSummary.jsx
@@ -298,7 +298,12 @@ class PostSummary extends React.Component {
         const userBlacklisted = ImageUserBlockList.includes(p.author);
 
         let thumb = null;
-        if (!gray && p.image_link && !userBlacklisted) {
+        if (
+            !gray &&
+            p.image_link &&
+            typeof p.image_link === 'string' &&
+            !userBlacklisted
+        ) {
             // on mobile, we always use blog layout style -- there's no toggler
             // on desktop, we offer a choice of either blog or list
             // if blogmode is false, output an image with a srcset


### PR DESCRIPTION
Fixes #2939  in a particular way (ignores improper image_url data, only processes it if it's a string).

We in theory could extract from a single array too but not sure how far we'd want to go that way.