### PR TITLE
Community - Add message warning that transactions could be delayed (#2900)

### DIFF
--- a/src/app/components/modules/UserWallet.jsx
+++ b/src/app/components/modules/UserWallet.jsx
@@ -440,9 +440,7 @@ class UserWallet extends React.Component {
         // set dynamic secondary wallet values
         const sbdInterest = this.props.sbd_interest / 100;
         const sbdMessage = (
-            <span>
-                {tt('userwallet_jsx.tradeable_tokens_transferred')}
-            </span>
+            <span>{tt('userwallet_jsx.tradeable_tokens_transferred')}</span>
         );
 
         const reward_steem =
@@ -734,6 +732,12 @@ class UserWallet extends React.Component {
                             <span>
                                 {tt(
                                     'transfer_jsx.beware_of_spam_and_phishing_links'
+                                )}
+                            </span>
+                            &nbsp;
+                            <span>
+                                {tt(
+                                    'transfer_jsx.transactions_make_take_a_few_minutes'
                                 )}
                             </span>
                         </div>

--- a/src/app/components/modules/UserWallet.jsx
+++ b/src/app/components/modules/UserWallet.jsx
@@ -440,7 +440,9 @@ class UserWallet extends React.Component {
         // set dynamic secondary wallet values
         const sbdInterest = this.props.sbd_interest / 100;
         const sbdMessage = (
-            <span>{tt('userwallet_jsx.tradeable_tokens_transferred')}</span>
+            <span>
+                {tt('userwallet_jsx.tradeable_tokens_transferred')}
+            </span>
         );
 
         const reward_steem =

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -837,6 +837,8 @@
             "%(asset)s currently collecting %(interest)s%% APR.",
         "beware_of_spam_and_phishing_links":
             "Beware of spam and phishing links in transfer memos. Do not open links from users you do not trust. Do not provide your private keys to any third party websites.",
+        "transactions_make_take_a_few_minutes":
+            "Transactions will not show until they are confirmed on the blockchain, which may take a few minutes.",
         "autocomplete_previous_transfers": "previous transfers",
         "autocomplete_user_following": "following",
         "confirm_transfer": "Transfer %(amount)s from %(from)s to %(to)s?"


### PR DESCRIPTION
Adds ![Transactions will not show until they are confirmed on the blockchain, which may take a few minutes.](https://vgy.me/PiZnw6.png)
Uses i18n key ``transfer_jsx.transactions_make_take_a_few_minutes``.
Closes #2900. 