### PR TITLE
Add Imgur GIFV support for embed

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -5,9 +5,9 @@
   "google_analytics_id": false,
   "helmet": {
     "directives": {
-      "childSrc": "'self' www.youtube.com staticxx.facebook.com w.soundcloud.com player.vimeo.com",
+      "childSrc": "'self' www.youtube.com staticxx.facebook.com w.soundcloud.com player.vimeo.com i.imgur.com",
       "connectSrc": "'self' steemit.com https://api.steemit.com api.blocktrades.us",
-      "defaultSrc": "'self' www.youtube.com staticxx.facebook.com player.vimeo.com",
+      "defaultSrc": "'self' www.youtube.com staticxx.facebook.com player.vimeo.com i.imgur.com",
       "fontSrc": "data: fonts.gstatic.com",
       "frameAncestors": "'none'",
       "imgSrc": "* data:",

--- a/config/default.json
+++ b/config/default.json
@@ -5,9 +5,9 @@
   "google_analytics_id": false,
   "helmet": {
     "directives": {
-      "childSrc": "'self' www.youtube.com staticxx.facebook.com w.soundcloud.com player.vimeo.com i.imgur.com",
+      "childSrc": "'self' www.youtube.com staticxx.facebook.com w.soundcloud.com player.vimeo.com imgur.com i.imgur.com",
       "connectSrc": "'self' steemit.com https://api.steemit.com api.blocktrades.us",
-      "defaultSrc": "'self' www.youtube.com staticxx.facebook.com player.vimeo.com i.imgur.com",
+      "defaultSrc": "'self' www.youtube.com staticxx.facebook.com player.vimeo.com imgur.com i.imgur.com",
       "fontSrc": "data: fonts.gstatic.com",
       "frameAncestors": "'none'",
       "imgSrc": "* data:",

--- a/src/app/components/cards/MarkdownViewer.jsx
+++ b/src/app/components/cards/MarkdownViewer.jsx
@@ -147,7 +147,7 @@ class MarkdownViewer extends Component {
         // HtmlReady inserts ~~~ embed:${id} type ~~~
         for (let section of cleanText.split('~~~ embed:')) {
             const match = section.match(
-                /^([A-Za-z0-9\_\-]+) (youtube|vimeo) ~~~/
+                /^([A-Za-z0-9\_\-]+) (youtube|vimeo|imgur) ~~~/
             );
             if (match && match.length >= 3) {
                 const id = match[1];
@@ -179,6 +179,15 @@ class MarkdownViewer extends Component {
                                 mozallowfullscreen
                                 allowFullScreen
                             />
+                        </div>
+                    );
+                } else if (type === 'imgur') {
+                    const url = `https://imgur.com/${id}.mp4`;
+                    sections.push(
+                        <div key={idx++} className="videoWrapper">
+                            <video preload="auto" autoPlay="autoplay" loop="loop" style={{width: w}}>
+                                <source src={url} type="video/mp4"></source>
+                            </video>
                         </div>
                     );
                 } else {

--- a/src/app/utils/Links.js
+++ b/src/app/utils/Links.js
@@ -46,6 +46,8 @@ export default {
     youTubeId: /(?:(?:youtube.com\/watch\?v=)|(?:youtu.be\/)|(?:youtube.com\/embed\/))([A-Za-z0-9\_\-]+)/i,
     vimeo: /https?:\/\/(?:vimeo.com\/|player.vimeo.com\/video\/)([0-9]+)\/*/,
     vimeoId: /(?:vimeo.com\/|player.vimeo.com\/video\/)([0-9]+)/,
+    imgur: /https?:\/\/(?:imgur.com\/|i.imgur.com\/)([A-Za-z0-9]+).gifv/,
+    imgurId: /(?:imgur.com\/|i.imgur.com\/)([A-Za-z0-9]+)/,
     // simpleLink: new RegExp(`<a href="(.*)">(.*)<\/a>`, 'ig'),
     ipfsPrefix: /(https?:\/\/.*)?\/ipfs/i,
 };

--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -235,6 +235,7 @@ function linkifyNode(child, state) {
         if (!child.data) return;
         child = embedYouTubeNode(child, state.links, state.images);
         child = embedVimeoNode(child, state.links, state.images);
+        child = embedImgurNode(child, state.links, state.images);
 
         const data = XMLSerializer.serializeToString(child);
         const content = linkify(
@@ -370,6 +371,35 @@ function vimeoId(data) {
         id: m[1],
         url: m[0],
         canonical: `https://player.vimeo.com/video/${m[1]}`,
+        // thumbnail: requires a callback - http://stackoverflow.com/questions/1361149/get-img-thumbnails-from-vimeo
+    };
+}
+
+function embedImgurNode(child, links /*images*/) {
+    try {
+        const data = child.data;
+        const imgur = imgurId(data);
+        if (!imgur) return child;
+
+        child.data = data.replace(imgur.url, `~~~ embed:${imgur.id} imgur ~~~`);
+
+        if (links) links.add(imgur.canonical);
+        // if(images) images.add(vimeo.thumbnail) // not available
+    } catch (error) {
+        console.log(error);
+    }
+    return child;
+}
+
+function imgurId(data) {
+    if (!data) return null;
+    const m = data.match(linksRe.imgur);
+    if (!m || m.length < 2) return null;
+
+    return {
+        id: m[1],
+        url: m[0],
+        canonical: `https://i.imgur.com/${m[1]}.mp4`,
         // thumbnail: requires a callback - http://stackoverflow.com/questions/1361149/get-img-thumbnails-from-vimeo
     };
 }


### PR DESCRIPTION
### Issue
Currently gifv is not supported natively in condenser. This ends up with users pasting traditional GIF files which can be very large in comparison.

### Summary
Since GIFV is not a real extension and merely just a friendly interpretation of a video link, rewrite the GIFV url to a MP4 source and include in HTML video tag.

### Screenshot
---
![screen shot 2018-08-30 at 11 38 31 am](https://user-images.githubusercontent.com/7006965/44865923-509f3000-ac49-11e8-9e7e-a82bedf67130.png)
---
![screen shot 2018-08-30 at 11 38 52 am](https://user-images.githubusercontent.com/7006965/44865925-5137c680-ac49-11e8-865d-1617ccc65017.png)
---

### Files Changed
- `utils/Links.js`
- `cards/MarkdownViewer.js`
- `shared/HtmlReady.js`