### PR TITLE
Width of blog content & Witness vote removal confirmation modal

### DIFF
--- a/src/app/components/cards/PostFull.scss
+++ b/src/app/components/cards/PostFull.scss
@@ -8,7 +8,7 @@
   padding-bottom: 1rem;
   padding-top: 2rem;
   margin: 0 auto;
-  max-width: 50rem;
+  max-width: 52rem;
   @include themify($themes) {
       border-bottom: themed('border');
   }
@@ -65,7 +65,6 @@
 }
 
 .PostFull__header, .PostFull__body {
-  max-width: 40rem;
   margin: 0 auto;
 }
 

--- a/src/app/components/pages/Witnesses.jsx
+++ b/src/app/components/pages/Witnesses.jsx
@@ -155,7 +155,7 @@ class Witnesses extends React.Component {
                                         owner,
                                         !myVote
                                     )}
-                                    title={tt('g.vote')}
+                                    title={myVote === true ? tt('g.remove_vote') : tt('g.vote')}
                                 >
                                     {up}
                                 </a>
@@ -216,7 +216,7 @@ class Witnesses extends React.Component {
                                                     item,
                                                     false
                                                 )}
-                                                title={tt('g.vote')}
+                                                title={tt('g.remove_vote')}
                                             >
                                                 {up}
                                             </a>
@@ -439,6 +439,9 @@ module.exports = {
                         transactionActions.broadcastOperation({
                             type: 'account_witness_vote',
                             operation: { account: username, witness, approve },
+                            confirm: !approve
+                                ? 'You are about to remove your vote for this witness'
+                                : null
                         })
                     );
                 },


### PR DESCRIPTION
Previously, the mismatch in width makes it difficult to know in advance if certain markdown will mess up the layout once the post is created.

Setting PostFull max-width to 52rem to match the width of ".ReplyEditor form".

Also added a confirmation modal upon removing a witness vote on the witnesses page.