### PR TITLE
Community - Fix wallet page so that transfer history is not corrupted

### DIFF
--- a/src/app/redux/GlobalReducer.js
+++ b/src/app/redux/GlobalReducer.js
@@ -63,20 +63,9 @@ const transformAccount = account =>
  */
 
 const mergeAccounts = (state, account) => {
-    const accountName = account.get('name');
-    let newState = state.updateIn(['accounts', accountName], Map(), a =>
+    return state.updateIn(['accounts', account.get('name')], Map(), a =>
         a.mergeDeep(account)
     );
-
-    // Handle transfer history manually, as it deep-merges the two otherwise. ??? no. transfer history for these is always null. but set a watch point here just in case while debugging.
-    const accountTransferHistory = account.get('transfer_history');
-    if (accountTransferHistory && !accountTransferHistory.isEmpty()) {
-        newState = newState.setIn(
-            ['accounts', accountName, 'transfer_history'],
-            accountTransferHistory
-        );
-    }
-    return newState;
 };
 
 export default function reducer(state = defaultState, action = {}) {

--- a/src/app/redux/GlobalReducer.test.js
+++ b/src/app/redux/GlobalReducer.test.js
@@ -54,6 +54,40 @@ describe('Global reducer', () => {
         );
     });
 
+    it('should replace transfer history for a RECEIVE_STATE action', () => {
+        // Arrange, payload has one account with transfer history, one without
+        const payload = {
+            accounts: Map({
+                fooman: Map({
+                    transfer_history: List([Map({ a: 1 })]),
+                }),
+                barman: Map({}),
+            }),
+        };
+
+        // Two accounts both with transfer history
+        const initial = reducer()
+            .setIn(
+                ['accounts', 'fooman', 'transfer_history'],
+                List([Map({ b: 2 })])
+            )
+            .setIn(
+                ['accounts', 'barman', 'transfer_history'],
+                List([Map({ c: 3 })])
+            );
+
+        // Act
+        const actual = reducer(initial, globalActions.receiveState(payload));
+        // Assert
+        expect(
+            actual.getIn(['accounts', 'fooman', 'transfer_history'])
+        ).toEqual(List([Map({ a: 1 })]));
+        // Payload had no transfer history, does not affect account.
+        expect(
+            actual.getIn(['accounts', 'barman', 'transfer_history'])
+        ).toEqual(List([Map({ c: 3 })]));
+    });
+
     it('should return correct state for a RECEIVE_ACCOUNT action', () => {
         // Arrange
         const payload = {


### PR DESCRIPTION
This should resolve #2970 #2968 #2967.

The problem is that mergeDeep when given two parallel lists will merge each entry by index, and this causes some weird behavior when the two transfer history lists aren't exactly matching up. Instead, the transfer history should be replacing the old transfer history. This change attempts to do just that.

One problem is that I was unable to reproduce the linked errors predictably, so I will try to see if there's a sequence that can reproduce. For now, just wanted to show the proposed fix.

I believe this should only happen in RECEIVE_STATE, and not in the other pieces of code that merge accounts (since they are used on account fetch calls that do not contain transfer history).