### PR TITLE
Add Twitch Support to condenser

### DIFF
--- a/src/app/components/cards/MarkdownViewer.jsx
+++ b/src/app/components/cards/MarkdownViewer.jsx
@@ -144,7 +144,7 @@ class MarkdownViewer extends Component {
         // HtmlReady inserts ~~~ embed:${id} type ~~~
         for (let section of cleanText.split('~~~ embed:')) {
             const match = section.match(
-                /^([A-Za-z0-9\_\-]+) (youtube|vimeo) ~~~/
+                /^([A-Za-z0-9\?\=\_\-]+) (youtube|vimeo|twitch) ~~~/
             );
             if (match && match.length >= 3) {
                 const id = match[1];
@@ -174,6 +174,20 @@ class MarkdownViewer extends Component {
                                 frameBorder="0"
                                 webkitallowfullscreen
                                 mozallowfullscreen
+                                allowFullScreen
+                            />
+                        </div>
+                    );
+                } else if (type === 'twitch') {
+                    const url = `https://player.twitch.tv/${id}`;
+                    sections.push(
+                        <div className="videoWrapper">
+                            <iframe
+                                key={idx++}
+                                src={url}
+                                width={w}
+                                height={h}
+                                frameBorder="0"
                                 allowFullScreen
                             />
                         </div>

--- a/src/app/utils/Links.js
+++ b/src/app/utils/Links.js
@@ -48,6 +48,7 @@ export default {
     vimeoId: /(?:vimeo.com\/|player.vimeo.com\/video\/)([0-9]+)/,
     // simpleLink: new RegExp(`<a href="(.*)">(.*)<\/a>`, 'ig'),
     ipfsPrefix: /(https?:\/\/.*)?\/ipfs/i,
+    twitch: /https?:\/\/(?:www.)?twitch.tv\/(?:(videos)\/)?([a-zA-Z0-9][\w]{3,24})/i,
 };
 
 //TODO: possible this should go somewhere else.

--- a/src/app/utils/SanitizeConfig.js
+++ b/src/app/utils/SanitizeConfig.js
@@ -38,12 +38,12 @@ const iframeWhitelist = [
         },
     },
     {
-        re: /^(https?:)?\/\/player.twitch.com\/.*/i,
+        re: /^(https?:)?\/\/player.twitch.tv\/.*/i,
         fn: src => {
             //<iframe src="https://player.twitch.tv/?channel=ninja" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620">
             return src;
         },
-    }
+    },
 ];
 export const noImageText = '(Image not shown due to low ratings)';
 export const allowedTags = `

--- a/src/app/utils/SanitizeConfig.js
+++ b/src/app/utils/SanitizeConfig.js
@@ -37,6 +37,13 @@ const iframeWhitelist = [
             );
         },
     },
+    {
+        re: /^(https?:)?\/\/player.twitch.com\/.*/i,
+        fn: src => {
+            //<iframe src="https://player.twitch.tv/?channel=ninja" frameborder="0" allowfullscreen="true" scrolling="no" height="378" width="620">
+            return src;
+        },
+    }
 ];
 export const noImageText = '(Image not shown due to low ratings)';
 export const allowedTags = `

--- a/src/app/utils/SlateEditor/Iframe.js
+++ b/src/app/utils/SlateEditor/Iframe.js
@@ -17,6 +17,22 @@ export default class Iframe extends React.Component {
             return 'https://player.vimeo.com/video/' + match[1];
         }
 
+        // Detect twitch stream
+        match = url.match(linksRe.twitch);
+        console.log(match);
+        if (match && match.length >= 3) {
+            if (match[1] === undefined) {
+                return (
+                    'https://player.twitch.tv/?autoplay=false&channel=' +
+                    match[2]
+                );
+            } else {
+                return (
+                    'https://player.twitch.tv/?autoplay=false&video=' + match[1]
+                );
+            }
+        }
+
         console.log('unable to auto-detect embed url', url);
         return null;
     };

--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -235,6 +235,7 @@ function linkifyNode(child, state) {
         if (!child.data) return;
         child = embedYouTubeNode(child, state.links, state.images);
         child = embedVimeoNode(child, state.links, state.images);
+        child = embedTwitchNode(child, state.links, state.images);
 
         const data = XMLSerializer.serializeToString(child);
         const content = linkify(
@@ -371,6 +372,40 @@ function vimeoId(data) {
         url: m[0],
         canonical: `https://player.vimeo.com/video/${m[1]}`,
         // thumbnail: requires a callback - http://stackoverflow.com/questions/1361149/get-img-thumbnails-from-vimeo
+    };
+}
+
+function embedTwitchNode(child, links /*images*/) {
+    try {
+        const data = child.data;
+        const twitch = twitchId(data);
+        if (!twitch) return child;
+
+        child.data = data.replace(
+            twitch.url,
+            `~~~ embed:${twitch.id} twitch ~~~`
+        );
+
+        if (links) links.add(twitch.canonical);
+    } catch (error) {
+        console.log(error);
+    }
+    return child;
+}
+
+function twitchId(data) {
+    if (!data) return null;
+    const m = data.match(linksRe.twitch);
+    console.log(m);
+    if (!m || m.length < 3) return null;
+
+    return {
+        id: m[1] === `videos` ? `?video=${m[2]}` : `?channel=${m[2]}`,
+        url: m[0],
+        canonical:
+            m[1] === `videos`
+                ? `https://player.twitch.tv/?video=${m[2]}`
+                : `https://player.twitch.tv/?channel=${m[2]}`,
     };
 }
 


### PR DESCRIPTION
With this pull request I want to add support for Twitch.TV livestreams and VODs to condenser.

Links like
`https://twitch.tv/ninja` or `https://www.twitch.tv/ninja`
for channels
and
`https://twitch.tv/videos/330831726`or `https://www.twitch.tv/videos/330831726`

will be converted to an iframe. It will allow more livestreamers to share their streams on steem.

![image](https://user-images.githubusercontent.com/6608103/47954075-183c0b00-df86-11e8-914c-c2df5ccda4a1.png)
![image](https://user-images.githubusercontent.com/6608103/47954076-1e31ec00-df86-11e8-8c82-f3b0de050710.png)
