### PR TITLE
Enable support for start timestamp on YouTube and Vimeo embeds

### DIFF
--- a/src/app/components/cards/MarkdownViewer.jsx
+++ b/src/app/components/cards/MarkdownViewer.jsx
@@ -144,11 +144,12 @@ class MarkdownViewer extends Component {
         // HtmlReady inserts ~~~ embed:${id} type ~~~
         for (let section of cleanText.split('~~~ embed:')) {
             const match = section.match(
-                /^([A-Za-z0-9\_\-]+) (youtube|vimeo) ~~~/
+                /^([A-Za-z0-9\_\-]+) (youtube|vimeo) (\d+) ~~~/
             );
             if (match && match.length >= 3) {
                 const id = match[1];
                 const type = match[2];
+                const startTime = match[3];
                 const w = large ? 640 : 480,
                     h = large ? 360 : 270;
                 if (type === 'youtube') {
@@ -158,12 +159,17 @@ class MarkdownViewer extends Component {
                             width={w}
                             height={h}
                             youTubeId={id}
+                            startTime={parseInt(startTime)}
                             frameBorder="0"
                             allowFullScreen="true"
                         />
                     );
                 } else if (type === 'vimeo') {
-                    const url = `https://player.vimeo.com/video/${id}`;
+                    var startDate = new Date(null);
+                    startDate.setSeconds(startTime);
+                    var parsedTime = startDate.toISOString().substr(11, 8).split(":");
+                    var formattedTimestamp = `t=${parsedTime[0]}h${parsedTime[1]}m${parsedTime[2]}s`;
+                    const url = `https://player.vimeo.com/video/${id}#${formattedTimestamp}`;
                     sections.push(
                         <div className="videoWrapper">
                             <iframe
@@ -181,7 +187,7 @@ class MarkdownViewer extends Component {
                 } else {
                     console.error('MarkdownViewer unknown embed type', type);
                 }
-                section = section.substring(`${id} ${type} ~~~`.length);
+                section = section.substring(`${id} ${type} ${startTime} ~~~`.length);
                 if (section === '') continue;
             }
             sections.push(

--- a/src/app/components/elements/YoutubePreview.jsx
+++ b/src/app/components/elements/YoutubePreview.jsx
@@ -11,12 +11,14 @@ export default class YoutubePreview extends React.Component {
         youTubeId: string.isRequired,
         width: number,
         height: number,
+        startTime: number,
         dataParams: string,
     };
 
     static defaultProps = {
         width: 640,
         height: 360,
+        startTime: 0,
         dataParams: 'enablejsapi=0&rel=0&origin=https://steemit.com',
     };
 
@@ -32,7 +34,7 @@ export default class YoutubePreview extends React.Component {
     };
 
     render() {
-        const { youTubeId, width, height, dataParams } = this.props;
+        const { youTubeId, width, height, startTime, dataParams } = this.props;
         const { play } = this.state;
         if (!play) {
             // mqdefault.jpg (medium quality version, 320px × 180px)
@@ -57,7 +59,7 @@ export default class YoutubePreview extends React.Component {
         }
         const autoPlaySrc = `https://www.youtube.com/embed/${
             youTubeId
-        }?autoplay=1&autohide=1&${dataParams}`;
+        }?autoplay=1&autohide=1&${dataParams}&start=${startTime}`;
         return (
             <div className="videoWrapper">
                 <iframe

--- a/src/app/utils/Links.js
+++ b/src/app/utils/Links.js
@@ -44,7 +44,7 @@ export default {
     imageFile: imageFile(),
     youTube: youTube(),
     youTubeId: /(?:(?:youtube.com\/watch\?v=)|(?:youtu.be\/)|(?:youtube.com\/embed\/))([A-Za-z0-9\_\-]+)/i,
-    vimeo: /https?:\/\/(?:vimeo.com\/|player.vimeo.com\/video\/)([0-9]+)\/*/,
+    vimeo: /https?:\/\/(?:vimeo.com\/|player.vimeo.com\/video\/)([0-9]+)(#t=((\d*)h){0,1}((\d*)m){0,1}((\d*)s){0,1})?\/*/,
     vimeoId: /(?:vimeo.com\/|player.vimeo.com\/video\/)([0-9]+)/,
     // simpleLink: new RegExp(`<a href="(.*)">(.*)<\/a>`, 'ig'),
     ipfsPrefix: /(https?:\/\/.*)?\/ipfs/i,

--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -316,7 +316,7 @@ function embedYouTubeNode(child, links, images) {
         const yt = youTubeId(data);
         if (!yt) return child;
 
-        child.data = data.replace(yt.url, `~~~ embed:${yt.id} youtube ~~~`);
+        child.data = data.replace(yt.url, `~~~ embed:${yt.id} youtube ${yt.startTime} ~~~`);
 
         if (links) links.add(yt.url);
         if (images) images.add(yt.thumbnail);
@@ -338,9 +338,18 @@ function youTubeId(data) {
     const id = m2 && m2.length >= 2 ? m2[1] : null;
     if (!id) return null;
 
+    // parse timestamp
+    const m3 = url.match(/t=((\d*)h){0,1}((\d*)m){0,1}((\d*)s){0,1}/);
+    // convert timestamp to seconds
+    let hours = m3 ? parseInt((m3[2] || 0)*3600) : 0,
+        minutes = m3 ? parseInt((m3[4] || 0)*60) : 0,
+        seconds = m3 ? parseInt((m3[6] || 0)) : 0;
+    const startTime = hours + minutes + seconds;
+
     return {
         id,
         url,
+        startTime,
         thumbnail: 'https://img.youtube.com/vi/' + id + '/0.jpg',
     };
 }
@@ -351,7 +360,7 @@ function embedVimeoNode(child, links /*images*/) {
         const vimeo = vimeoId(data);
         if (!vimeo) return child;
 
-        child.data = data.replace(vimeo.url, `~~~ embed:${vimeo.id} vimeo ~~~`);
+        child.data = data.replace(vimeo.url, `~~~ embed:${vimeo.id} vimeo ${vimeo.startTime} ~~~`);
 
         if (links) links.add(vimeo.canonical);
         // if(images) images.add(vimeo.thumbnail) // not available
@@ -366,9 +375,18 @@ function vimeoId(data) {
     const m = data.match(linksRe.vimeo);
     if (!m || m.length < 2) return null;
 
+    // parse timestamp
+    const m2 = m[0].match(/t=((\d*)h){0,1}((\d*)m){0,1}((\d*)s){0,1}/);
+    // convert timestamp to seconds
+    let hours = m2 ? parseInt((m2[2] || 0)*3600) : 0,
+        minutes = m2 ? parseInt((m2[4] || 0)*60) : 0,
+        seconds = m2 ? parseInt((m2[6] || 0)) : 0;
+    const startTime = hours + minutes + seconds;
+
     return {
         id: m[1],
         url: m[0],
+        startTime,
         canonical: `https://player.vimeo.com/video/${m[1]}`,
         // thumbnail: requires a callback - http://stackoverflow.com/questions/1361149/get-img-thumbnails-from-vimeo
     };

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -196,7 +196,7 @@ describe('htmlready', () => {
         const testString =
             '<html><p>before text https://www.youtube.com/watch?v=NrS9vvNgx7I after text</p></html>';
         const htmlified =
-            '<html xmlns="http://www.w3.org/1999/xhtml"><p>before text ~~~ embed:NrS9vvNgx7I youtube ~~~ after text</p></html>';
+            '<html xmlns="http://www.w3.org/1999/xhtml"><p>before text ~~~ embed:NrS9vvNgx7I youtube 0 ~~~ after text</p></html>';
         const res = HtmlReady(testString).html;
         expect(res).toEqual(htmlified);
     });
@@ -205,7 +205,7 @@ describe('htmlready', () => {
         const testString =
             '<html><p>before text https://vimeo.com/193628816/ after text</p></html>';
         const htmlified =
-            '<html xmlns="http://www.w3.org/1999/xhtml"><p>before text ~~~ embed:193628816 vimeo ~~~ after text</p></html>';
+            '<html xmlns="http://www.w3.org/1999/xhtml"><p>before text ~~~ embed:193628816 vimeo 0 ~~~ after text</p></html>';
         const res = HtmlReady(testString).html;
         expect(res).toEqual(htmlified);
     });


### PR DESCRIPTION
Closes #3087

### Issue
Condenser does not support timestamps for Youtube/Vimeo embeds

### Description
When a user copies a timestamped link from Youtube/Vimeo, condenser ignores this data because of a simple regex match on the url that does not take timestamp into account. This pull request contains working logic for parsing the timestamp field from Youtube/Vimeo and properly delivering it in the URL. Users simply need to copy/paste a timestamp link to use this feature.

### Working Example
https://condenser.steemliberator.com/music/@netuoso/greydon-square-late-night-munchies-low-technology-youtube

### Files Changed
- `app/components/cards/MarkdownViewer.jsx`
- `app/components/elements/YoutubePreview.jsx`
- `app/utils/Links.js`
- `shared/HtmlReady.js`