### PR TITLE
Cap image size to save on bandwidth costs

### DIFF
--- a/src/app/utils/ProxifyUrl.js
+++ b/src/app/utils/ProxifyUrl.js
@@ -11,6 +11,7 @@
 const rProxyDomain = /^http(s)?:\/\/steemit(dev|stage)?images.com\//g;
 const rProxyDomainsDimensions = /http(s)?:\/\/steemit(dev|stage)?images.com\/([0-9]+x[0-9]+)\//g;
 const NATURAL_SIZE = '0x0/';
+const CAPPED_SIZE = '640x0/';
 
 export const imageProxy = () => $STM_Config.img_proxy_prefix;
 
@@ -36,7 +37,14 @@ export default (url, dimensions = false) => {
                 ? proxyList.shift().match(/([0-9]+x[0-9]+)\//g)[0]
                 : NATURAL_SIZE;
         }
-        if (NATURAL_SIZE !== dims || !rProxyDomain.test(respUrl)) {
+
+        // NOTE: This forces the dimensions to be `CAPPED_SIZE` to save on
+        // bandwidth costs.
+        if (dims === NATURAL_SIZE) {
+            dims = CAPPED_SIZE;
+        }
+
+        if (CAPPED_SIZE !== dims || !rProxyDomain.test(respUrl)) {
             return $STM_Config.img_proxy_prefix + dims + respUrl;
         }
     }

--- a/src/app/utils/ProxifyUrl.js
+++ b/src/app/utils/ProxifyUrl.js
@@ -39,12 +39,15 @@ export default (url, dimensions = false) => {
         }
 
         // NOTE: This forces the dimensions to be `CAPPED_SIZE` to save on
-        // bandwidth costs.
-        if (dims === NATURAL_SIZE) {
+        // bandwidth costs. Do not modify gifs.
+        if (!respUrl.match(/\.gif$/) && dims === NATURAL_SIZE) {
             dims = CAPPED_SIZE;
         }
 
-        if (CAPPED_SIZE !== dims || !rProxyDomain.test(respUrl)) {
+        if (
+            (NATURAL_SIZE !== dims && CAPPED_SIZE !== dims) ||
+            !rProxyDomain.test(respUrl)
+        ) {
             return $STM_Config.img_proxy_prefix + dims + respUrl;
         }
     }

--- a/src/app/utils/ProxifyUrl.test.js
+++ b/src/app/utils/ProxifyUrl.test.js
@@ -15,12 +15,12 @@ describe('ProxifyUrl', () => {
         testCase(
             'https://example.com/img.png',
             '0x0',
-            'https://steemitimages.com/0x0/https://example.com/img.png'
+            'https://steemitimages.com/640x0/https://example.com/img.png'
         );
         testCase(
             'https://example.com/img.png',
             true,
-            'https://steemitimages.com/0x0/https://example.com/img.png'
+            'https://steemitimages.com/640x0/https://example.com/img.png'
         );
         testCase(
             'https://example.com/img.png',
@@ -126,7 +126,7 @@ describe('ProxifyUrl', () => {
         testCase(
             'https://steemitimages.com/0x0/https://example.com/img.png',
             true,
-            'https://steemitimages.com/0x0/https://example.com/img.png'
+            'https://steemitimages.com/640x0/https://example.com/img.png'
         );
         //case where last is natural sizing, assumes natural sizing - straight to direct steemit file url
         testCase(
@@ -138,7 +138,7 @@ describe('ProxifyUrl', () => {
         testCase(
             'https://steemitimages.com/0x0/https://steemitimages.com/100x100/https://example.com/img.png',
             true,
-            'https://steemitimages.com/0x0/https://example.com/img.png'
+            'https://steemitimages.com/640x0/https://example.com/img.png'
         );
     });
 });


### PR DESCRIPTION
Caps blog post image size and should finish the work to dramatically reduce bandwidth costs.

The work has been deployed `imageproxy` side, so we cap images by default, but clients can override the default if they need higher res. However, any blog post image on `condenser` will still be cached at the uncapped size, so this branch makes sure that the URLs are formatted such that they're rendered and cached at the capped size.

This change is easily reversible in case we wish to roll back this behavior later, by simply reverting the commit and re-deploying `condenser`.