### PR TITLE
Community - Update power down message for HF20

### DIFF
--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -875,7 +875,7 @@
         "already_power_down":
             "You are already powering down %(AMOUNT)s %(LIQUID_TICKER)s (%(WITHDRAWN)s %(LIQUID_TICKER)s paid out so far). Note that if you change the power down amount the payout schedule will reset.",
         "delegating":
-            "You are delegating %(AMOUNT)s %(LIQUID_TICKER)s. That amount is locked up and not available to power down until the delegation is removed and a full reward period has passed.",
+            "You are delegating %(AMOUNT)s %(LIQUID_TICKER)s. That amount is locked up and not available to power down until the delegation is removed and 5 days has passed.",
         "per_week": "That's ~%(AMOUNT)s %(LIQUID_TICKER)s per week.",
         "warning":
             "Leaving less than %(AMOUNT)s %(VESTING_TOKEN)s in your account is not recommended and can leave your account in a unusable state.",


### PR DESCRIPTION
Edited power down message from "That amount is locked up and not available to power down until the delegation is removed and a full reward period has passed." to "That amount is locked up and not available to power down until the delegation is removed and 5 days has passed.", because full reward period is 7 days and delegations are returned in 5 days since hard fork 20.