### PR TITLE
Community - Adjust power-down info string to HF20 conditions

### DIFF
--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -875,7 +875,7 @@
         "already_power_down":
             "You are already powering down %(AMOUNT)s %(LIQUID_TICKER)s (%(WITHDRAWN)s %(LIQUID_TICKER)s paid out so far). Note that if you change the power down amount the payout schedule will reset.",
         "delegating":
-            "You are delegating %(AMOUNT)s %(LIQUID_TICKER)s. That amount is locked up and not available to power down until the delegation is removed and a full reward period has passed.",
+            "You are delegating %(AMOUNT)s %(LIQUID_TICKER)s. That amount is locked up and not available to power down until the delegation is removed and the delegation return period has passed.",
         "per_week": "That's ~%(AMOUNT)s %(LIQUID_TICKER)s per week.",
         "warning":
             "Leaving less than %(AMOUNT)s %(VESTING_TOKEN)s in your account is not recommended and can leave your account in a unusable state.",


### PR DESCRIPTION
The delegation return period was changed from a full reward period to 5 days with HF20.
This PR only adjusts the English text - the other languages need adjustments as well.