### PR TITLE
Community - Add support for embedded dtube videos

### DIFF
--- a/config/default.json
+++ b/config/default.json
@@ -5,9 +5,9 @@
   "google_analytics_id": false,
   "helmet": {
     "directives": {
-      "childSrc": "'self' player.twitch.tv www.youtube.com staticxx.facebook.com w.soundcloud.com player.vimeo.com",
+      "childSrc": "'self' emb.d.tube player.twitch.tv www.youtube.com staticxx.facebook.com w.soundcloud.com player.vimeo.com",
       "connectSrc": "'self' steemit.com https://api.steemit.com api.blocktrades.us",
-      "defaultSrc": "'self' www.youtube.com staticxx.facebook.com player.vimeo.com",
+      "defaultSrc": "'self' emb.d.tube www.youtube.com staticxx.facebook.com player.vimeo.com",
       "fontSrc": "data: fonts.gstatic.com",
       "frameAncestors": "'none'",
       "imgSrc": "* data:",

--- a/src/app/components/cards/MarkdownViewer.jsx
+++ b/src/app/components/cards/MarkdownViewer.jsx
@@ -144,7 +144,7 @@ class MarkdownViewer extends Component {
         // HtmlReady inserts ~~~ embed:${id} type ~~~
         for (let section of cleanText.split('~~~ embed:')) {
             const match = section.match(
-                /^([A-Za-z0-9\?\=\_\-]+) (youtube|vimeo|twitch|dtube) ~~~/
+                /^([A-Za-z0-9\?\=\_\-\/]+) (youtube|vimeo|twitch|dtube) ~~~/
             );
             if (match && match.length >= 3) {
                 const id = match[1];

--- a/src/app/components/cards/MarkdownViewer.jsx
+++ b/src/app/components/cards/MarkdownViewer.jsx
@@ -144,7 +144,7 @@ class MarkdownViewer extends Component {
         // HtmlReady inserts ~~~ embed:${id} type ~~~
         for (let section of cleanText.split('~~~ embed:')) {
             const match = section.match(
-                /^([A-Za-z0-9\?\=\_\-]+) (youtube|vimeo|twitch) ~~~/
+                /^([A-Za-z0-9\?\=\_\-]+) (youtube|vimeo|twitch|dtube) ~~~/
             );
             if (match && match.length >= 3) {
                 const id = match[1];
@@ -180,6 +180,20 @@ class MarkdownViewer extends Component {
                     );
                 } else if (type === 'twitch') {
                     const url = `https://player.twitch.tv/${id}`;
+                    sections.push(
+                        <div className="videoWrapper">
+                            <iframe
+                                key={idx++}
+                                src={url}
+                                width={w}
+                                height={h}
+                                frameBorder="0"
+                                allowFullScreen
+                            />
+                        </div>
+                    );
+                } else if (type === 'dtube') {
+                    const url = `https://emb.d.tube/#!/${id}`;
                     sections.push(
                         <div className="videoWrapper">
                             <iframe

--- a/src/app/utils/Links.js
+++ b/src/app/utils/Links.js
@@ -49,8 +49,8 @@ export default {
     // simpleLink: new RegExp(`<a href="(.*)">(.*)<\/a>`, 'ig'),
     ipfsPrefix: /(https?:\/\/.*)?\/ipfs/i,
     twitch: /https?:\/\/(?:www.)?twitch.tv\/(?:(videos)\/)?([a-zA-Z0-9][\w]{3,24})/i,
-    dtube: /https?:\/\/(?:d.tube\/\#\!\/v\/)([0-9a-zA-Z\/]*)/,
-    dtubeId: /(?:d\.tube\/#!\/v\/([0-9a-zA-Z\/]*))+/,
+    dtube: /https?:\/\/(?:d.tube\/\#\!\/v\/)([a-zA-Z0-9\/]*)/,
+    dtubeId: /(?:d\.tube\/#!\/v\/([a-zA-Z0-9\/]*))+/,
 };
 
 //TODO: possible this should go somewhere else.

--- a/src/app/utils/Links.js
+++ b/src/app/utils/Links.js
@@ -49,7 +49,8 @@ export default {
     // simpleLink: new RegExp(`<a href="(.*)">(.*)<\/a>`, 'ig'),
     ipfsPrefix: /(https?:\/\/.*)?\/ipfs/i,
     twitch: /https?:\/\/(?:www.)?twitch.tv\/(?:(videos)\/)?([a-zA-Z0-9][\w]{3,24})/i,
-    dtube: /https?:\/\/(?:d.tube\/\#\!\/|emb.d.tube\/\#\!\/)(.*),
+    dtube: /https?:\/\/(?:d.tube\/\#\!\/v\/)(.*)/,
+    dtubeId: /(?:d\.tube\/#!\/v\/(.*))+/,
 };
 
 //TODO: possible this should go somewhere else.

--- a/src/app/utils/Links.js
+++ b/src/app/utils/Links.js
@@ -49,6 +49,7 @@ export default {
     // simpleLink: new RegExp(`<a href="(.*)">(.*)<\/a>`, 'ig'),
     ipfsPrefix: /(https?:\/\/.*)?\/ipfs/i,
     twitch: /https?:\/\/(?:www.)?twitch.tv\/(?:(videos)\/)?([a-zA-Z0-9][\w]{3,24})/i,
+    dtube: /https?:\/\/(?:d.tube\/\#\!\/|emb.d.tube\/\#\!\/)(.*),
 };
 
 //TODO: possible this should go somewhere else.

--- a/src/app/utils/Links.js
+++ b/src/app/utils/Links.js
@@ -49,8 +49,8 @@ export default {
     // simpleLink: new RegExp(`<a href="(.*)">(.*)<\/a>`, 'ig'),
     ipfsPrefix: /(https?:\/\/.*)?\/ipfs/i,
     twitch: /https?:\/\/(?:www.)?twitch.tv\/(?:(videos)\/)?([a-zA-Z0-9][\w]{3,24})/i,
-    dtube: /https?:\/\/(?:d.tube\/\#\!\/v\/)(.*)/,
-    dtubeId: /(?:d\.tube\/#!\/v\/(.*))+/,
+    dtube: /https?:\/\/(?:d.tube\/\#\!\/v\/)([0-9a-zA-Z\/]*)/,
+    dtubeId: /(?:d\.tube\/#!\/v\/([0-9a-zA-Z\/]*))+/,
 };
 
 //TODO: possible this should go somewhere else.

--- a/src/app/utils/SlateEditor/Iframe.js
+++ b/src/app/utils/SlateEditor/Iframe.js
@@ -32,6 +32,12 @@ export default class Iframe extends React.Component {
             }
         }
 
+        // Detect dtube
+        match = url.match(linksRe.dtubeId);
+        if (match && match.length >= 2) {
+            return 'https://emb.d.tube/#!/' + match[1];
+        }
+        
         console.log('unable to auto-detect embed url', url);
         return null;
     };

--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -236,6 +236,7 @@ function linkifyNode(child, state) {
         child = embedYouTubeNode(child, state.links, state.images);
         child = embedVimeoNode(child, state.links, state.images);
         child = embedTwitchNode(child, state.links, state.images);
+        child = embedDTubeNode(child, state.links, state.images);
 
         const data = XMLSerializer.serializeToString(child);
         const content = linkify(
@@ -407,6 +408,37 @@ function twitchId(data) {
                 : `https://player.twitch.tv/?channel=${m[2]}`,
     };
 }
+
+
+function embedDTubeNode(child, links /*images*/) {
+    try {
+        const data = child.data;
+        const dtube = dtubeId(data);
+        if (!dtube) return child;
+
+        child.data = data.replace(dtube.url, `~~~ embed:${dtube.id} dtube ~~~`);
+
+        if (links) links.add(dtube.canonical);
+    } catch (error) {
+        console.log(error);
+    }
+    return child;
+}
+
+function dtubeId(data) {
+    if (!data) return null;
+    const m = data.match(linksRe.dtube);
+    if (!m || m.length < 2) return null;
+
+    return {
+        id: m[1],
+        url: m[0],
+        canonical: `https://emb.d.tube/#!/${m[1]}`,
+        
+    };
+}
+
+
 
 function ipfsPrefix(url) {
     if ($STM_Config.ipfs_prefix) {

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -209,4 +209,13 @@ describe('htmlready', () => {
         const res = HtmlReady(testString).html;
         expect(res).toEqual(htmlified);
     });
+    
+    it('should not omit text on same line as dtube link', () => {
+        const testString =
+            '<html><p>before text https://d.tube/#!/v/tibfox/mvh7g26e after text</p></html>';
+        const htmlified =
+            '<html xmlns="http://www.w3.org/1999/xhtml"><p>before text ~~~ embed:tibfox/mvh7g26e dtube ~~~ after text</p></html>';
+        const res = HtmlReady(testString).html;
+        expect(res).toEqual(htmlified);
+    });
 });


### PR DESCRIPTION
Many people asked for a functionality to embed dtube videos in steemit posts. To support some other video platforms outside the steem blockchain but not support dtube is their argument. This can happen now by adding a dtube video URL within the post. The Markdown editor of steemit manage the iframe code itself but can not retrieve the thumbnail yet.

Pasting https://d.tube/#!/v/tibfox/mvh7g26e will result in an iframe for playing the video within a steemit post by the specific https://emb.d.tube/#!/tibfox/mvh7g26e embedded player URL.