### PR TITLE
prevent wallet render if acct is lite

### DIFF
--- a/src/app/components/modules/UserWallet.jsx
+++ b/src/app/components/modules/UserWallet.jsx
@@ -101,7 +101,12 @@ class UserWallet extends React.Component {
         } = this.props;
         const gprops = this.props.gprops.toJS();
 
+        // do not render if account is not loaded or available
         if (!account) return null;
+
+        // do not render if state appears to contain only lite account info
+        if (!account.has('vesting_shares')) return null;
+
         let vesting_steem = vestingSteem(account.toJS(), gprops);
         let delegated_steem = delegatedSteem(account.toJS(), gprops);
 


### PR DESCRIPTION
Fixes a bug where going from user's Blog -> Wallet causes errors which break further navigation. Solution is to skip rendering until full acct data is loaded.