### PR TITLE
Community - remove duplicate space in powerdown message

### DIFF
--- a/src/app/components/modules/UserWallet.jsx
+++ b/src/app/components/modules/UserWallet.jsx
@@ -699,7 +699,7 @@ class UserWallet extends React.Component {
                             <span>
                                 {tt(
                                     'userwallet_jsx.next_power_down_is_scheduled_to_happen'
-                                )}&nbsp;{' '}
+                                )}{' '}
                                 <TimeAgoWrapper
                                     date={account.get(
                                         'next_vesting_withdrawal'


### PR DESCRIPTION
Fix #3186 

![](https://user-images.githubusercontent.com/38183982/51779639-7a795780-2100-11e9-8122-ab861d0058c3.png)
> Current: There are two spaces.

![](https://user-images.githubusercontent.com/38183982/51779646-8402bf80-2100-11e9-94a8-ec82ceb62a5e.png)
> Fixed: one space
