### PR TITLE
Make server side use the server side steemd url

### DIFF
--- a/src/server/index.js
+++ b/src/server/index.js
@@ -43,7 +43,7 @@ global.webpackIsomorphicTools = new WebpackIsomorphicTools(
 
 global.webpackIsomorphicTools.server(ROOT, () => {
     steem.api.setOptions({
-        url: config.steemd_connection_client,
+        url: config.steemd_connection_server,
         retry: {
             retries: 10,
             factor: 5,


### PR DESCRIPTION
Condenser is not using the config object / env var for the server side steemd URL, it is using the client URL in both places. This resolves that.