### PR TITLE
Disable blackboxtest workflows for now

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -58,8 +58,8 @@ workflows:
   condenser:
     jobs:
       - build
-      - build-blackboxtest
-      - run-blackboxtest:
-          requires:
-            - build
-            - build-blackboxtest
+    #  - build-blackboxtest
+    #  - run-blackboxtest:
+    #      requires:
+    #        - build
+    #        - build-blackboxtest


### PR DESCRIPTION
Until we have time to update the black box tests, this is a nice simple piece of housekeeping for visual sanity on github.