### PR TITLE
Community - Show Steemit logo instead of text on 404 not found

### DIFF
--- a/src/app/components/elements/GptAd.jsx
+++ b/src/app/components/elements/GptAd.jsx
@@ -13,7 +13,7 @@ class GptAd extends Component {
 
             googletag.cmd.push(() => {
                 googletag.display(this.ad.slot_id);
-                googletag.pubads().refresh([this.ad.slot_id]);
+                googletag.pubads().refresh([slot]);
                 googletag
                     .pubads()
                     .addEventListener('slotRenderEnded', event => {


### PR DESCRIPTION
From @economicstudio #3202:
> Close #3201 
> 
> Currently, 404 not found page is as follows:
> ![](https://user-images.githubusercontent.com/38183982/52164375-4990b800-26e8-11e9-9a5e-6d662a2d71b6.png)
> 
> Show "steemitbeta" as a text looks too beta :)
> 
> What about this?
> 
> ![](https://user-images.githubusercontent.com/38183982/52164380-675e1d00-26e8-11e9-84c5-2e698f47d5dc.png)
> 
> This is also good for consistency with normal pages.