### PR TITLE
 Remove pin icon, rename pinned to featured

### DIFF
--- a/src/app/components/cards/PostsList.jsx
+++ b/src/app/components/cards/PostsList.jsx
@@ -206,7 +206,7 @@ class PostsList extends React.Component {
                 return (
                     <li key={pinnedPost}>
                         <div className="PinLabel">
-                            <span className="PinText">Featured Post</span>
+                            <span className="PinText">Featured</span>
                             <a
                                 onClick={close}
                                 className="DismissPost"

--- a/src/app/components/cards/PostsList.jsx
+++ b/src/app/components/cards/PostsList.jsx
@@ -206,11 +206,7 @@ class PostsList extends React.Component {
                 return (
                     <li key={pinnedPost}>
                         <div className="PinLabel">
-                            <Icon
-                                className="PinIcon"
-                                name={isSeen ? 'pin-disabled' : 'pin'}
-                            />{' '}
-                            <span className="PinText">Pinned Post</span>
+                            <span className="PinText">Featured Post</span>
                             <a
                                 onClick={close}
                                 className="DismissPost"


### PR DESCRIPTION
This simply removes the pin icon on the pinned posts feature, and changes the wording to say 'Featured'.

Things this doesn't do: renaming 'pinned posts' in the code elsewhere, it is only a quick visual change for now.