### PR TITLE
Community - Return '451 Content unavailable' for users on black lists

### DIFF
--- a/src/server/json/post_json.jsx
+++ b/src/server/json/post_json.jsx
@@ -2,6 +2,7 @@ import koa_router from 'koa-router';
 import React from 'react';
 import { routeRegex } from 'app/ResolveRoute';
 import { api } from '@steemit/steem-js';
+import GDPRUserList from 'app/utils/GDPRUserList';
 
 export default function usePostJson(app) {
     const router = koa_router();
@@ -14,7 +15,10 @@ export default function usePostJson(app) {
         let status = '';
         let post = yield api.getContentAsync(author, permalink);
 
-        if (post.author) {
+        if (GDPRUserList.includes(post.author)) {
+            post = 'Content unavailable';
+            status = '451';
+        } else if (post.author) {
             status = '200';
             // try parse for post metadata
             try {

--- a/src/server/json/user_json.jsx
+++ b/src/server/json/user_json.jsx
@@ -2,6 +2,7 @@ import koa_router from 'koa-router';
 import React from 'react';
 import { routeRegex } from 'app/ResolveRoute';
 import { api } from '@steemit/steem-js';
+import GDPRUserList from 'app/utils/GDPRUserList';
 
 export default function useUserJson(app) {
     const router = koa_router();
@@ -18,7 +19,10 @@ export default function useUserJson(app) {
 
         const [chainAccount] = yield api.getAccountsAsync([user_name]);
 
-        if (chainAccount) {
+        if (GDPRUserList.includes(user_name)) {
+            user = 'Content unavailable';
+            status = '451';
+        } else if (chainAccount) {
             user = chainAccount;
             try {
                 user.json_metadata = JSON.parse(user.json_metadata);


### PR DESCRIPTION
From @netuoso #3156:

> Closes #3155 
> 
> This PR intercepts requests made for users in the GDPRUserList.jsx blocklist and responds to requests with a 451 status code instead of a 404 status code.
> 
> These changes result in a prevention of any aspect of the page load process. Changes were also made to the PostJson and UserJson parser to prevent returning data for blocked users.
> 
> This implementation is live on https://mspsteem.com/ and can be tested by visiting the following links:
> `https://mspsteem.com/@thedarkoverlord`
> `https://mspsteem.com/thedarkoverlord/@thedarkoverlord/thedarkoverlord-is-now-on-steemit`