### PR TITLE
Setting the max-width of editor preview to 42.125rem

### DIFF
--- a/src/app/components/elements/ReplyEditor.scss
+++ b/src/app/components/elements/ReplyEditor.scss
@@ -87,7 +87,7 @@
 }
 
 .ReplyEditor .Preview {
-  max-width: 42rem;
+  max-width: 42.125rem;
   margin-left: auto;
   margin-right: auto;
 }


### PR DESCRIPTION
Setting the max-width of editor preview to 42.125rem so that it renders to exactly 640px like the post width

![Screen Shot 2019-05-03 at 7 35 43 pm](https://user-images.githubusercontent.com/310654/57129926-49818080-6ddb-11e9-9c44-8f28899d6743.jpg)
