### PR TITLE
Bump steem-js version to 0.7.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "license": "MIT",
   "dependencies": {
     "@steem/crypto-session": "git+https://github.com/steemit/crypto-session.git#83a90b319ce5bc6a70362d52a15a815de7e729bb",
-    "@steemit/steem-js": "0.7.4",
+    "@steemit/steem-js": "0.7.5",
     "assert": "1.4.1",
     "autoprefixer-loader": "3.2.0",
     "axios": "^0.18.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -28,9 +28,10 @@
   dependencies:
     "@steemit/libcrypto" "^1.0.1"
 
-"@steemit/steem-js@0.7.4":
-  version "0.7.4"
-  resolved "https://registry.yarnpkg.com/@steemit/steem-js/-/steem-js-0.7.4.tgz#65053fffe0ad99a4c18bd4b089c2cd78ac09bf3d"
+"@steemit/steem-js@0.7.5":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@steemit/steem-js/-/steem-js-0.7.5.tgz#2894b84005f839b56aa0b1152424cf316f702f78"
+  integrity sha512-qcjkUCFy3MMu5TrIQ2zwm4Ow5Yh3J2udTvRykFymQ4SE/dWWb1w4inXrYwp+SmWqyvesvoeak4bSKyp6OrTLuw==
   dependencies:
     "@steemit/rpc-auth" "^1.1.1"
     bigi "^1.4.2"


### PR DESCRIPTION
This version of steem-js includes the fix to use `get_block_header` instead of `get_block` to gather the pervious block id when preparing a transaction (data transfer usage / performance savings for client and server).