### PR TITLE
Fix #3340 non-existing post 404

### DIFF
--- a/src/app/components/pages/Post.jsx
+++ b/src/app/components/pages/Post.jsx
@@ -19,6 +19,8 @@ import { SIGNUP_URL } from 'shared/constants';
 
 import { isLoggedIn } from 'app/utils/UserUtil';
 
+import Icon from 'app/components/elements/Icon';
+
 class Post extends React.Component {
     static propTypes = {
         content: PropTypes.object.isRequired,
@@ -63,7 +65,47 @@ class Post extends React.Component {
         }
         const dis = content.get(post);
 
-        if (!dis) return null;
+        // check if the post doesn't exist
+        // !dis may be enough but keep 'created' & 'body' test for potential compatibility
+        const emptyPost =
+            !dis ||
+            (dis.get('created') === '1970-01-01T00:00:00' &&
+                dis.get('body') === '');
+
+        if (emptyPost)
+            return (
+                <div className="NotFound float-center">
+                    <div>
+                        <Icon name="steem" size="4x" />
+                        <h4 className="NotFound__header">
+                            Sorry! This page doesnt exist.
+                        </h4>
+                        <p>
+                            Not to worry. You can head back to{' '}
+                            <a style={{ fontWeight: 800 }} href="/">
+                                our homepage
+                            </a>, or check out some great posts.
+                        </p>
+                        <ul className="NotFound__menu">
+                            <li>
+                                <a href="/created">new posts</a>
+                            </li>
+                            <li>
+                                <a href="/hot">hot posts</a>
+                            </li>
+                            <li>
+                                <a href="/trending">trending posts</a>
+                            </li>
+                            <li>
+                                <a href="/promoted">promoted posts</a>
+                            </li>
+                            <li>
+                                <a href="/active">active posts</a>
+                            </li>
+                        </ul>
+                    </div>
+                </div>
+            );
 
         // A post should be hidden if it is not pinned, is not told to "show
         // anyway", and is designated "gray".
@@ -157,44 +199,6 @@ class Post extends React.Component {
                 link: selflink + '?sort=' + sort_orders[o] + '#comments',
             });
         }
-        const emptyPost =
-            dis.get('created') === '1970-01-01T00:00:00' &&
-            dis.get('body') === '';
-        if (emptyPost)
-            return (
-                <center>
-                    <div className="NotFound float-center">
-                        <div>
-                            <h4 className="NotFound__header">
-                                Sorry! This page doesnt exist.
-                            </h4>
-                            <p>
-                                Not to worry. You can head back to{' '}
-                                <a style={{ fontWeight: 800 }} href="/">
-                                    our homepage
-                                </a>, or check out some great posts.
-                            </p>
-                            <ul className="NotFound__menu">
-                                <li>
-                                    <a href="/created">new posts</a>
-                                </li>
-                                <li>
-                                    <a href="/hot">hot posts</a>
-                                </li>
-                                <li>
-                                    <a href="/trending">trending posts</a>
-                                </li>
-                                <li>
-                                    <a href="/promoted">promoted posts</a>
-                                </li>
-                                <li>
-                                    <a href="/active">active posts</a>
-                                </li>
-                            </ul>
-                        </div>
-                    </div>
-                </center>
-            );
 
         return (
             <div className="Post">


### PR DESCRIPTION
Fix #3340

non-existing post 404

![](https://user-images.githubusercontent.com/38183982/57959149-4cf82a00-78fa-11e9-9687-0a9ba7449f42.png)

The bug was due to `if (!dis) return null;` not rendering 404 page.

ps. Eventually, it might be better to be handled by `RootRoute.js` or somewhere centrally, but that may need some substantial change, so I rather fixed the existing `Post.jsx` only.