### PR TITLE
Serve ads.txt without staticCache

### DIFF
--- a/src/server/server.js
+++ b/src/server/server.js
@@ -27,6 +27,7 @@ import userIllegalContent from 'app/utils/userIllegalContent';
 import koaLocale from 'koa-locale';
 import { getSupportedLocales } from './utils/misc';
 import { pinnedPosts } from './utils/PinnedPosts';
+import fs from 'fs';
 
 if (cluster.isMaster) console.log('application server starting, please wait.');
 
@@ -37,6 +38,12 @@ app.name = 'Steemit app';
 const env = process.env.NODE_ENV || 'development';
 // cache of a thousand days
 const cacheOpts = { maxAge: 86400000, gzip: true, buffer: true };
+
+// import ads.txt to be served statically
+const adstxt = fs.readFileSync(
+    path.join(__dirname, '../app/assets/ads.txt'),
+    'utf8'
+);
 
 // Serve static assets without fanfare
 app.use(
@@ -71,10 +78,10 @@ app.use(
 );
 
 app.use(
-    mount(
-        '/ads.txt',
-        staticCache(path.join(__dirname, '../app/assets/ads.txt'), cacheOpts)
-    )
+    mount('/ads.txt', function*() {
+        this.type = 'text/plain';
+        this.body = adstxt;
+    })
 );
 
 // Proxy asset folder to webpack development server in development mode


### PR DESCRIPTION
It has been requested that ads.txt load in a browser instead of prompt a download automatically. Since you can't set `Content-Type` using `koa-static-cache`, this PR loads the file in at startup and serves using only `koa-mount` and setting the content type.