### PR TITLE
Fixes #3281 - Replacing 'slotRenderEnded' with 'impressionViewable' …

### DIFF
--- a/src/app/components/elements/GptAd.jsx
+++ b/src/app/components/elements/GptAd.jsx
@@ -22,7 +22,7 @@ class GptAd extends Component {
                     googletag.pubads().refresh([slot]);
                     googletag
                         .pubads()
-                        .addEventListener('slotRenderEnded', event => {
+                        .addEventListener('impressionViewable', event => {
                             window.dispatchEvent(new Event('gptadshown'));
                         });
                 });


### PR DESCRIPTION
…to resize the header only when the ad is visible.

I can't seem to get ads to work on my dev environment so help testing this would be appreciated.

I wanted to test this solution:
https://stackoverflow.com/questions/35025046/the-exact-moment-of-gpt-viewability-vs-slotrenderended-event-fired