### PR TITLE
Fix border issues with comments

### DIFF
--- a/src/app/components/App.scss
+++ b/src/app/components/App.scss
@@ -173,7 +173,7 @@
         }
     }
 }
-.downvoted {
+.downvoted .downvoted {
     opacity: 0.5;
     -webkit-filter: grayscale(1); // image
     filter: gray; // image grayscale

--- a/src/app/components/App.scss
+++ b/src/app/components/App.scss
@@ -173,7 +173,7 @@
         }
     }
 }
-.downvoted .downvoted {
+.downvoted {
     opacity: 0.5;
     -webkit-filter: grayscale(1); // image
     filter: gray; // image grayscale

--- a/src/app/components/cards/Comment.jsx
+++ b/src/app/components/cards/Comment.jsx
@@ -372,18 +372,15 @@ class CommentImpl extends React.Component {
         const commentClasses = ['hentry'];
         commentClasses.push('Comment');
         commentClasses.push(this.props.root ? 'root' : 'reply');
+        if (this.state.collapsed) commentClasses.push('collapsed');
 
+        let innerCommentClass = 'Comment__block';
         if (ignore || gray) {
-            commentClasses.push('downvoted');
+            innerCommentClass += ' downvoted clearfix';
             if (!hide_body) {
-                commentClasses.push('revealed');
+                innerCommentClass += ' revealed';
             }
         }
-        if (hide_body || this.state.collapsed) {
-            commentClasses.push('collapsed');
-        }
-
-        let innerCommentClass = ignore || gray ? 'downvoted clearfix' : '';
         if (this.state.highlight) innerCommentClass += ' highlighted';
 
         //console.log(comment);

--- a/src/app/components/cards/Comment.jsx
+++ b/src/app/components/cards/Comment.jsx
@@ -372,7 +372,16 @@ class CommentImpl extends React.Component {
         const commentClasses = ['hentry'];
         commentClasses.push('Comment');
         commentClasses.push(this.props.root ? 'root' : 'reply');
-        if (hide_body || this.state.collapsed) commentClasses.push('collapsed');
+
+        if (ignore || gray) {
+            commentClasses.push('downvoted');
+            if (!hide_body) {
+                commentClasses.push('revealed');
+            }
+        }
+        if (hide_body || this.state.collapsed) {
+            commentClasses.push('collapsed');
+        }
 
         let innerCommentClass = ignore || gray ? 'downvoted clearfix' : '';
         if (this.state.highlight) innerCommentClass += ' highlighted';
@@ -405,17 +414,6 @@ class CommentImpl extends React.Component {
             );
         }
 
-        const depth_indicator = [];
-        if (depth > 1) {
-            for (let i = 1; i < depth; ++i) {
-                depth_indicator.push(
-                    <div key={i} className={`depth di-${i}`}>
-                        &middot;
-                    </div>
-                );
-            }
-        }
-
         return (
             <div
                 className={commentClasses.join(' ')}
@@ -423,7 +421,6 @@ class CommentImpl extends React.Component {
                 itemScope
                 itemType="http://schema.org/comment"
             >
-                {depth_indicator}
                 <div className={innerCommentClass}>
                     <div className="Comment__Userpic show-for-medium">
                         <Userpic account={comment.author} />

--- a/src/app/components/cards/Comment.scss
+++ b/src/app/components/cards/Comment.scss
@@ -59,7 +59,6 @@
     .Voting {
       margin-left: 1rem;
       border-right: none;
-      display: none;
     }
     a {
       @include themify($themes) {

--- a/src/app/components/cards/Comment.scss
+++ b/src/app/components/cards/Comment.scss
@@ -185,41 +185,6 @@
     }
 }
 
-.depth {
-  position: absolute;
-  top: 20px;
-  left: 0;
-  color: $dark-gray;
-}
-
-.Comment.collapsed > .depth {
-  top: 2px;
-}
-
-.depth.di-1 {
-  left: -38px;
-}
-
-.depth.di-2 {
-  left: -100px;
-}
-
-.depth.di-3 {
-  left: -162px;
-}
-
-.depth.di-4 {
-  left: -224px;
-}
-
-.depth.di-5 {
-  left: -286px;
-}
-
-.depth.di-6 {
-  left: -348px;
-}
-
 @media screen and (max-width: 39.9375em) {
   .root {
     .Comment__header, .Comment__footer, .Comment__body, .Comment__replies {
@@ -232,33 +197,6 @@
     }
   }
 
-  .depth {
-    top: 2px;
-  }
-
-  .depth.di-1 {
-    left: 0;
-  }
-
-  .depth.di-2 {
-    left: -20px;
-  }
-
-  .depth.di-3 {
-    left: -40px;
-  }
-
-  .depth.di-4 {
-    left: -60px;
-  }
-
-  .depth.di-5 {
-    left: -80px;
-  }
-
-  .depth.di-6 {
-    left: -100px;
-  }
   .Comment .highlighted { 
     padding-left: 0;
   }

--- a/src/app/components/cards/Comment.scss
+++ b/src/app/components/cards/Comment.scss
@@ -43,10 +43,8 @@
   }
 }
 
-.Comment.collapsed:not(.downvoted),
-.Comment.collapsed.downvoted.revealed .Comment__body,
-.Comment.downvoted.revealed .Comment.collapsed:not(.downvoted),
-.Comment.downvoted .downvoted {
+.Comment.collapsed .Comment__block,
+.Comment .Comment__block.downvoted:not(.revealed) {
   > .Comment__Userpic {
     top: 0;
     left: 26px;
@@ -112,8 +110,7 @@
   }
 }
 
-.Comment .Comment__body,
-.Comment.downvoted.revealed:not(.collapsed) .Comment__body {
+.Comment .Comment__block .Comment__body {
   @include themify($themes) {
     margin-left: 62px;
     max-width: 50rem;
@@ -124,8 +121,7 @@
   }
 }
 
-.Comment .Comment__footer,
-.Comment.downvoted.revealed:not(.collapsed) .Comment__footer {
+.Comment .Comment__block .Comment__footer {
   @include themify($themes) {
     margin-left: 62px;
     border: themed('border');

--- a/src/app/components/cards/Comment.scss
+++ b/src/app/components/cards/Comment.scss
@@ -43,7 +43,10 @@
   }
 }
 
-.Comment.collapsed {
+.Comment.collapsed:not(.downvoted),
+.Comment.collapsed.downvoted.revealed .Comment__body,
+.Comment.downvoted.revealed .Comment.collapsed:not(.downvoted),
+.Comment.downvoted .downvoted {
   > .Comment__Userpic {
     top: 0;
     left: 26px;
@@ -56,6 +59,7 @@
     .Voting {
       margin-left: 1rem;
       border-right: none;
+      display: none;
     }
     a {
       @include themify($themes) {
@@ -64,12 +68,16 @@
     }
   }
   .Comment__body {
-    padding: 0;
-    border: none;
+    @include themify($themes) {
+      padding: 0;
+      border: none;
+    }
   }
   .Comment__footer {
-    padding: 0;
-    border: none;
+    @include themify($themes) {
+      padding: 0;
+      border: none;
+    }
   }
 }
 
@@ -105,7 +113,8 @@
   }
 }
 
-.Comment__body {
+.Comment .Comment__body,
+.Comment.downvoted.revealed:not(.collapsed) .Comment__body {
   @include themify($themes) {
     margin-left: 62px;
     max-width: 50rem;
@@ -116,7 +125,8 @@
   }
 }
 
-.Comment__footer {
+.Comment .Comment__footer,
+.Comment.downvoted.revealed:not(.collapsed) .Comment__footer {
   @include themify($themes) {
     margin-left: 62px;
     border: themed('border');


### PR DESCRIPTION
- remove depth indicators as not needed now that comments layers are clearly defined
- new comment classes .downvoted and .revealed to have more precise CSS selectors
- hide the voting block from comments when collapsed as the block is too narrow, it breaks the layout. It does not make sense to vote/downvote without reading a comment anyway.
- tweaked and added more precise CSS selectors (for precedence) to fix the border issues with children comments of downvoted comments