### PR TITLE
Community - Only show reply link to logged in users

### DIFF
--- a/src/app/components/cards/Comment.jsx
+++ b/src/app/components/cards/Comment.jsx
@@ -305,7 +305,7 @@ class CommentImpl extends React.Component {
         const showEditOption = username === author;
         const showDeleteOption =
             username === author && allowDelete && !_isPaidout;
-        const showReplyOption = comment.depth < 255;
+        const showReplyOption = username !== undefined && comment.depth < 255;
 
         let body = null;
         let controls = null;

--- a/src/app/components/cards/PostFull.jsx
+++ b/src/app/components/cards/PostFull.jsx
@@ -422,7 +422,7 @@ class PostFull extends React.Component {
         const showReblog = !_isPaidout;
         const showPromote =
             username && !_isPaidout && post_content.get('depth') == 0;
-        const showReplyOption = post_content.get('depth') < 255;
+        const showReplyOption = username !== undefined && post_content.get('depth') < 255;
         const showEditOption = username === author;
         const showDeleteOption =
             username === author && content.stats.allowDelete && !_isPaidout;


### PR DESCRIPTION
From @quochuy #3369:

> Fixes #3362 - Only show reply link to logged in users under posts and comments