### PR TITLE
community - Allow the use of the json_metadata 'canonical_link' to set canonical links

### DIFF
--- a/src/app/utils/CanonicalLinker.js
+++ b/src/app/utils/CanonicalLinker.js
@@ -1,30 +1,40 @@
 import Apps from 'steemscript/apps.json';
 
 export function makeCanonicalLink(d) {
-    var canonicalUrl = 'https://steemit.com' + d.link;
-    if (
-        d.json_metadata &&
-        d.json_metadata.app &&
-        typeof d.json_metadata.app !== 'string'
-    ) {
-        return canonicalUrl;
-    }
-    const hasAppTemplateData =
-        d.json_metadata &&
-        d.json_metadata.app &&
-        d.category &&
-        d.json_metadata.app.split('/').length === 2;
-    if (hasAppTemplateData) {
-        const app = d.json_metadata.app.split('/')[0];
-        const hasAppData = Apps[app] && Apps[app].url_scheme;
-        if (hasAppData) {
-            canonicalUrl = Apps[app].url_scheme
-                .split('{category}')
-                .join(d.category)
-                .split('{username}')
-                .join(d.author)
-                .split('{permlink}')
-                .join(d.permlink);
+    let canonicalUrl = 'https://steemit.com' + d.link;
+
+    if (d.json_metadata) {
+        if (
+            d.json_metadata.canonical_link &&
+            typeof d.json_metadata.canonical_link === 'string'
+        ) {
+            const urlTester = new RegExp(
+                /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/gm
+            );
+            if (urlTester.test(d.json_metadata.canonical_link)) {
+                return d.json_metadata.canonical_link;
+            }
+        }
+
+        if (d.json_metadata.app && typeof d.json_metadata.app === 'string') {
+            const hasAppTemplateData =
+                d.json_metadata &&
+                d.json_metadata.app &&
+                d.category &&
+                d.json_metadata.app.split('/').length === 2;
+            if (hasAppTemplateData) {
+                const app = d.json_metadata.app.split('/')[0];
+                const hasAppData = Apps[app] && Apps[app].url_scheme;
+                if (hasAppData) {
+                    canonicalUrl = Apps[app].url_scheme
+                        .split('{category}')
+                        .join(d.category)
+                        .split('{username}')
+                        .join(d.author)
+                        .split('{permlink}')
+                        .join(d.permlink);
+                }
+            }
         }
     }
     return canonicalUrl;

--- a/src/app/utils/CanonicalLinker.js
+++ b/src/app/utils/CanonicalLinker.js
@@ -5,14 +5,12 @@ export function makeCanonicalLink(d) {
 
     if (d.json_metadata) {
         if (
-            d.json_metadata.canonical_link &&
-            typeof d.json_metadata.canonical_link === 'string'
+            d.json_metadata.canonical_url &&
+            typeof d.json_metadata.canonical_url === 'string'
         ) {
-            const urlTester = new RegExp(
-                /^(?:http(s)?:\/\/)?[\w.-]+(?:\.[\w\.-]+)+[\w\-\._~:/?#[\]@!\$&'\(\)\*\+,;=.]+$/gm
-            );
-            if (urlTester.test(d.json_metadata.canonical_link)) {
-                return d.json_metadata.canonical_link;
+            const urlTester = new RegExp(/^https?:\/\//);
+            if (urlTester.test(d.json_metadata.canonical_url)) {
+                return d.json_metadata.canonical_url;
             }
         }
 


### PR DESCRIPTION
This is a followup of #336. 

Long story short, the current implementation involves a JSON file which does app (from json_metadata) => cannonical link via a list Which works great for dapps like dtube or busy which have a static domain but doesn't work at all for steempress.

If you are unaware about the project, steempress is a wordpress plugin to allow wordpress powered websites to use steem (cross-posting and using steem as a comment section)

So basically this logic is added : add a parameter in the json_metadata "canonical_link" and if it's set, use that url as canonical link, otherwise fallback to the app logic.