### PR TITLE
Make Slot Id Slightly More Unique

### DIFF
--- a/src/app/components/elements/GptAd.jsx
+++ b/src/app/components/elements/GptAd.jsx
@@ -5,11 +5,12 @@ class GptAd extends Component {
     componentDidMount() {
         if (!this.ad_identifier || !this.enabled) return;
         const ad_identifier = this.ad_identifier;
+        const unique_slot_id = this.unique_slot_id;
 
         freestar.newAdSlots([
             {
                 placementName: ad_identifier, // This has to match up with the backend and frontend and all the other ends.
-                slotId: ad_identifier, //TODO: This has to be unique.
+                slotId: unique_slot_id, // This has to be unique per page and must match the id of the ad element.
             },
         ]);
 
@@ -46,6 +47,7 @@ class GptAd extends Component {
             //     }' will be disabled because we were unable to find the ad details.`
             // );
         }
+        this.unique_slot_id = `${this.ad_identifier}-${Date.now()}`;
     }
 
     render() {
@@ -57,7 +59,7 @@ class GptAd extends Component {
             <div
                 className="gpt-ad"
                 style={{ width: '100%' }}
-                id={this.ad_identifier}
+                id={this.unique_slot_id}
             />
         );
     }


### PR DESCRIPTION
The ID of the element and the ID of the "slot" needs to be unique to each unit on the page. The in-feed units use the same ID because I was using the ad unit ID, which is generated by the ad manager. Since none of the in-feed ads render at the same time, this is a simple way to make the slot IDs a little unique -- unique enough.

![image (4)](https://user-images.githubusercontent.com/1451007/60805996-0d51ff80-a13f-11e9-932c-d889fb0d3e04.png)
![image (3)](https://user-images.githubusercontent.com/1451007/60805997-0d51ff80-a13f-11e9-9b3e-b3c789157704.png)
