### PR TITLE
Community - clarify modal text for viewing posting key

### DIFF
--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -606,7 +606,8 @@
         "login_warning_body":
             "You are attempting to use a key with more permissions than required for everyday Steemit.com use. Since keys and passwords are more likely to get compromised the more they are used, it is strongly recommended to only use your Posting Key to log in.",
         "continue_anyway": "Continue Anyway",
-        "login_warning_link_text": "View my Posting Key at Steemit Wallet",
+        "login_warning_link_text":
+            "Open my Steemit Wallet to access and view my posting key",
         "join_our": "Join our",
         "sign_transfer": "Sign to complete transfer",
         "use_keychain": "Use keychain extension"


### PR DESCRIPTION
From @quochuy #3432:

> Closes #3290: Make modal text for viewing posting key clearer