### PR TITLE
Fix bug introduced in state cleanup project that causes 'missing posts'

### DIFF
--- a/src/app/components/cards/Comment.jsx
+++ b/src/app/components/cards/Comment.jsx
@@ -25,7 +25,7 @@ function hideSubtree(cont, c) {
 
 function hasPositivePayout(cont, c) {
     const post = cont.get(c);
-    if (Long.fromString(String(content.get('net_rshares'))).gt(Long.ZERO)) {
+    if (Long.fromString(String(cont.get('net_rshares'))).gt(Long.ZERO)) {
         return true;
     }
     if (post.get('replies').find(reply => hasPositivePayout(cont, reply))) {


### PR DESCRIPTION
Certain posts are currently failing to load and return the infamous Steemit 'robot error page'. This is caused by a bug introduced in #3456 and is resolved with this PR.

Example posts:

https://steemit.com/curation/@transisto/steemium-likwid-quick-easy-money-if-you-don-t-take-it-someone-else-will

https://steemit.com/blocktrades/@blocktrades/blocktrades-rocksdb-proposal-to-steemit