### PR TITLE
Community - fix payout info for 100% beneficiary

### DIFF
--- a/src/app/components/elements/Voting.jsx
+++ b/src/app/components/elements/Voting.jsx
@@ -459,7 +459,9 @@ class Voting extends React.Component {
                 }),
             });
         }
-        if (total_author_payout > 0) {
+        // - payout instead of total_author_payout: total_author_payout can be zero with 100% beneficiary
+        // - !cashout_active is needed to avoid the info is also shown for pending posts.
+        if (!cashout_active && payout > 0) {
             payoutItems.push({
                 value: tt('voting_jsx.past_payouts', {
                     value: formatDecimal(


### PR DESCRIPTION
From @economicstudio #3451:

> Fix #3450 
> 
> 
> ![](https://user-images.githubusercontent.com/38183982/62007801-d2455980-b149-11e9-8ace-228640eaf6e9.png)
> 
> > before https://steemit.com/@blockchainstudio/finex-steem-power-liquify
> - There is no button to show detailed payout info
> 
> 
> ![](https://user-images.githubusercontent.com/38183982/62007798-cb1e4b80-b149-11e9-9838-ccf4ab7382af.png)
> 
> > after
> 