### PR TITLE
Community - Fix 'transfer' page aliases

### DIFF
--- a/src/app/utils/steemApi.js
+++ b/src/app/utils/steemApi.js
@@ -15,10 +15,12 @@ export async function getStateAsync(url) {
     if (url === '') url = 'trending';
 
     // curation and author rewards pages are alias of `transfers`
-    if (url.indexOf('/curation-rewards') !== -1)
+    // @TODO: maybe remove these all together as Condenser should redirect them to Wallet?
+    if (url.match(/^@.*?\/curation-rewards$/) !== null) {
         url = url.replace('/curation-rewards', '/transfers');
-    if (url.indexOf('/author-rewards') !== -1)
+    } else if (url.match(/^@.*?\/author-rewards$/) !== null) {
         url = url.replace('/author-rewards', '/transfers');
+    }
 
     const raw = await api.getStateAsync(url);
     const cleansed = stateCleaner(raw);


### PR DESCRIPTION
From @quochuy #3482:

> Fixes #3481
>
> This bug would have affected all posts that have a title starting with "Curation Rewards" or "Author Rewards"