### PR TITLE
Community - hide ad when less than 5 comments

### DIFF
--- a/src/app/components/pages/Post.jsx
+++ b/src/app/components/pages/Post.jsx
@@ -249,7 +249,7 @@ class Post extends React.Component {
                         </div>
                     </div>
                 )}
-                {this.props.gptEnabled ? (
+                {this.props.gptEnabled && commentCount >= 5 ? (
                     <div className="Post_footer__ad">
                         <GptAd
                             tags={tags}
@@ -277,7 +277,7 @@ class Post extends React.Component {
                         </div>
                     </div>
                 </div>
-                {this.props.gptEnabled && commentCount >= 5 ? (
+                {this.props.gptEnabled ? (
                     <div className="Post_footer__ad">
                         <GptAd
                             tags={tags}

--- a/src/app/components/pages/Post.jsx
+++ b/src/app/components/pages/Post.jsx
@@ -154,9 +154,9 @@ class Post extends React.Component {
         const positiveComments = replies.map(reply => {
             commentCount++;
             const showAd =
-                commentCount % 5 == 0 &&
-                commentCount != replies.length &&
-                commentCount != commentLimit;
+                commentCount % 5 === 0 &&
+                commentCount !== replies.length &&
+                commentCount !== commentLimit;
 
             return (
                 <div key={post + reply}>
@@ -277,7 +277,7 @@ class Post extends React.Component {
                         </div>
                     </div>
                 </div>
-                {this.props.gptEnabled ? (
+                {this.props.gptEnabled && commentCount >= 5 ? (
                     <div className="Post_footer__ad">
                         <GptAd
                             tags={tags}


### PR DESCRIPTION
From @quochuy #3483:

> Closes #3480 - Don't two ads in the comments when there are less than 5