### PR TITLE
Add Ability to Pin/Unpin a Community Post

### DIFF
--- a/src/app/components/cards/PostFull.jsx
+++ b/src/app/components/cards/PostFull.jsx
@@ -96,9 +96,8 @@ class PostFull extends React.Component {
         super(props);
         const post = this.props.cont.get(this.props.post);
         const isPinned = post.get('stats').get('is_pinned');
-        const { username, community } = this.props;
 
-        this.state = { username, community, isPinned };
+        this.state = { isPinned };
 
         this.fbShare = this.fbShare.bind(this);
         this.twitterShare = this.twitterShare.bind(this);
@@ -130,8 +129,6 @@ class PostFull extends React.Component {
             formId,
             PostFullReplyEditor: ReplyEditor(formId + '-reply'),
             PostFullEditEditor: ReplyEditor(formId + '-edit'),
-            username: this.props.username,
-            community: this.props.community,
         });
         if (process.env.BROWSER) {
             let showEditor = localStorage.getItem('showEditor-' + formId);
@@ -249,12 +246,10 @@ class PostFull extends React.Component {
 
     onTogglePin = isPinned => {
         const post_content = this.props.cont.get(this.props.post);
-        const accountName = this.props.username;
-        if (!accountName) {
+        const { community, username } = this.props;
+        if (!username) {
             return this.props.unlock();
         }
-
-        const { username, community } = this.state; // TODO: Determine where this value comes from and make it more clear.
         const permlink = post_content.get('permlink');
 
         this.props.togglePinnedPost(
@@ -275,14 +270,13 @@ class PostFull extends React.Component {
 
     render() {
         const {
-            props: { username, post, globalState },
+            props: { username, community, post, globalState },
             state: {
                 PostFullReplyEditor,
                 PostFullEditEditor,
                 formId,
                 showReply,
                 showEdit,
-                community,
             },
             onShowReply,
             onShowEdit,

--- a/src/app/components/cards/PostFull.jsx
+++ b/src/app/components/cards/PostFull.jsx
@@ -270,7 +270,7 @@ class PostFull extends React.Component {
 
     render() {
         const {
-            props: { username, community, post, globalState },
+            props: { username, community, post, role },
             state: {
                 PostFullReplyEditor,
                 PostFullEditEditor,
@@ -456,10 +456,7 @@ class PostFull extends React.Component {
         // TODO: Workout why the global user context has a blank role until a large amount of time has passed since the page loaded.
         const showPinToggle = CommunityAuthorization.CanPinPosts(
             username,
-            globalState.getIn(
-                ['community', community, 'context', 'role'],
-                'guest'
-            )
+            role
         );
         const { isPinned } = this.state;
         const showReplyOption =
@@ -618,7 +615,10 @@ export default connect(
             ...ownProps,
             community,
             username: state.user.getIn(['current', 'username']),
-            globalState: state.global,
+            role: state.global.getIn(
+                ['community', community, 'context', 'role'],
+                'guest'
+            ),
         };
     },
     dispatch => ({

--- a/src/app/components/cards/PostFull.jsx
+++ b/src/app/components/cards/PostFull.jsx
@@ -453,12 +453,13 @@ class PostFull extends React.Component {
         const showReblog = !isPaidout;
         const showPromote =
             username && !isPaidout && post_content.get('depth') == 0;
-        // TODO: Workout why the global user context has a blank role until a large amount of time has passed since the page loaded.
+
         const showPinToggle = CommunityAuthorization.CanPinPosts(
             username,
             role
         );
         const { isPinned } = this.state;
+
         const showReplyOption =
             username !== undefined && post_content.get('depth') < 255;
         const showEditOption = username === author;

--- a/src/app/components/cards/PostFull.jsx
+++ b/src/app/components/cards/PostFull.jsx
@@ -94,7 +94,9 @@ class PostFull extends React.Component {
 
     constructor(props) {
         super(props);
-        this.state = {};
+        const post = this.props.cont.get(this.props.post);
+        const isPinned = post.get('stats').get('is_pinned');
+        this.state = { isPinned };
         this.fbShare = this.fbShare.bind(this);
         this.twitterShare = this.twitterShare.bind(this);
         this.redditShare = this.redditShare.bind(this);
@@ -259,9 +261,11 @@ class PostFull extends React.Component {
             permlink,
             () => {
                 console.log('PostFull::onTogglePin()::success');
+                this.setState({ isPinned: !isPinned });
             },
             () => {
                 console.log('PostFull::onTogglePin()::failure');
+                this.setState({ isPinned });
             }
         );
     };
@@ -452,7 +456,7 @@ class PostFull extends React.Component {
         const showPromote =
             username && !_isPaidout && post_content.get('depth') == 0;
         const showPinToggle = true; // TODO: Introduce logic that switched on a user's role in this community
-        const isPinned = content.stats.is_pinned || false;
+        const { isPinned } = this.state;
         const showReplyOption =
             username !== undefined && post_content.get('depth') < 255;
         const showEditOption = username === author;
@@ -652,7 +656,7 @@ export default connect(
             successCallback,
             errorCallback
         ) => {
-            let action = 'unPinPost';
+            let action = 'unpinPost';
             if (pinPost) action = 'pinPost';
 
             const payload = [

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -67,6 +67,7 @@
         "permissions": "Permissions",
         "phishy_message":
             "Link expanded to plain text; beware of a potential phishing attempt",
+        "pin": "Pin",
         "post": "Post",
         "post_as_user": "Post as %(username)s",
         "posts": "Posts",
@@ -123,6 +124,7 @@
         "type": "Type",
         "unfollow": "Unfollow",
         "unmute": "Unmute",
+        "unpin": "Pinned",
         "unknown": "Unknown",
         "upvote": "Upvote",
         "upvote_post": "Upvote post",

--- a/src/app/redux/GlobalReducer.js
+++ b/src/app/redux/GlobalReducer.js
@@ -93,7 +93,9 @@ export default function reducer(state = defaultState, action = {}) {
                 });
                 new_state = new_state.set('content', content);
             }
-            return state.mergeDeep(new_state);
+            const merged = state.mergeDeep(new_state);
+            console.log('Merged state', merged.toJS());
+            return merged;
         }
 
         case RECEIVE_ACCOUNT: {


### PR DESCRIPTION
Allows a moderator/admin to pin and unpin a post within a community.

![image](https://user-images.githubusercontent.com/1451007/64611997-fbcfe280-d38f-11e9-978e-4f681b52e74a.png)


# Issues:
- The post doesn't seem to update after a successful change to the post's pin/unpinned status.
- Logic to gate on whether the user is a moderator/admin needed.

# Relies on:
- [ ] #3462


Closes #3463