### PR TITLE
Add ability to mute a post

### DIFF
--- a/src/app/components/cards/Comment.jsx
+++ b/src/app/components/cards/Comment.jsx
@@ -204,7 +204,6 @@ class CommentImpl extends React.Component {
 
             if (hide) {
                 const { onHide } = this.props;
-                // console.log('Comment --> onHide')
                 if (onHide) onHide();
             }
             this.setState({ hide, hide_body: notOwn && (hide || gray) });
@@ -263,7 +262,6 @@ class CommentImpl extends React.Component {
         }
         const { gray } = comment.stats;
         const isMuted = gray;
-        console.log('comment->render()', comment);
         const authorRepLog10 = repLog10(comment.author_reputation);
         const { author, json_metadata } = comment;
         const {
@@ -400,7 +398,6 @@ class CommentImpl extends React.Component {
         }
         if (this.state.highlight) innerCommentClass += ' highlighted';
 
-        //console.log(comment);
         let renderedEditor = null;
         if (showReply || showEdit) {
             renderedEditor = (
@@ -516,7 +513,6 @@ const Comment = connect(
     // mapStateToProps
     (state, ownProps) => {
         const { content } = ownProps;
-        console.log('Comment', content);
         const username = state.user.getIn(['current', 'username']);
         const ignore_list = username
             ? state.global.getIn([

--- a/src/app/components/cards/Comment.jsx
+++ b/src/app/components/cards/Comment.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import Author from 'app/components/elements/Author';
 import ReplyEditor from 'app/components/elements/ReplyEditor';
+import MuteButtonContainer from 'app/components/elements/MuteButtonContainer';
 import MarkdownViewer from 'app/components/cards/MarkdownViewer';
 import shouldComponentUpdate from 'app/utils/shouldComponentUpdate';
 import Voting from 'app/components/elements/Voting';
@@ -249,7 +250,7 @@ class CommentImpl extends React.Component {
 
         // Don't server-side render the comment if it has a certain number of newlines
         if (
-            global['process'] !== undefined &&
+            global.process !== undefined &&
             (dis.get('body').match(/\r?\n/g) || '').length > 25
         ) {
             return <div>{tt('g.loading')}...</div>;
@@ -261,6 +262,8 @@ class CommentImpl extends React.Component {
             comment.stats = {};
         }
         const { gray } = comment.stats;
+        const isMuted = gray;
+        console.log('comment->render()', comment);
         const authorRepLog10 = repLog10(comment.author_reputation);
         const { author, json_metadata } = comment;
         const {
@@ -308,6 +311,7 @@ class CommentImpl extends React.Component {
 
         const _isPaidout = comment.cashout_time === '1969-12-31T23:59:59'; // TODO: audit after HF19. #1259
         const showEditOption = username === author;
+        const showMuteToggle = true;
         const showDeleteOption =
             username === author && allowDelete(comment) && !_isPaidout;
         const showReplyOption = username !== undefined && comment.depth < 255;
@@ -331,6 +335,13 @@ class CommentImpl extends React.Component {
                     <span className="Comment__footer__controls">
                         {showReplyOption && (
                             <a onClick={onShowReply}>{tt('g.reply')}</a>
+                        )}{' '}
+                        {showMuteToggle && (
+                            <MuteButtonContainer
+                                community={comment.category}
+                                isMuted={isMuted}
+                                permlink={comment.permlink}
+                            />
                         )}{' '}
                         {showEditOption && (
                             <a onClick={onShowEdit}>{tt('g.edit')}</a>
@@ -505,7 +516,7 @@ const Comment = connect(
     // mapStateToProps
     (state, ownProps) => {
         const { content } = ownProps;
-
+        console.log('Comment', content);
         const username = state.user.getIn(['current', 'username']);
         const ignore_list = username
             ? state.global.getIn([

--- a/src/app/components/cards/PostFull.jsx
+++ b/src/app/components/cards/PostFull.jsx
@@ -608,7 +608,7 @@ class PostFull extends React.Component {
                                 isMuted && (
                                     <a
                                         onClick={() =>
-                                            this.onToggleMute(true, 'Unmuted')
+                                            this.onTogglePromptForMuteNotes()
                                         }
                                     >
                                         {tt('g.unmute')}
@@ -635,9 +635,10 @@ class PostFull extends React.Component {
                                         }
                                     />
                                     <MutePost
+                                        isMuted={isMuted}
                                         onSubmit={notes => {
                                             this.onTogglePromptForMuteNotes();
-                                            this.onToggleMute(false, notes);
+                                            this.onToggleMute(isMuted, notes);
                                         }}
                                     />
                                 </Reveal>

--- a/src/app/components/elements/MuteButton.jsx
+++ b/src/app/components/elements/MuteButton.jsx
@@ -23,7 +23,7 @@ export default function MuteButton(props) {
         <span>
             <a onClick={() => onToggleDialog()}> {label} </a>
             {showDialog && (
-                <Reveal onHide={() => console.log('Reveal::onHide')} show>
+                <Reveal onHide={() => null} show>
                     <CloseButton onClick={() => onToggleDialog()} />
                     <MutePost
                         isMuted={isMuted}
@@ -37,27 +37,6 @@ export default function MuteButton(props) {
         </span>
     );
 }
-
-// { showMuteToggle &&
-//     isMuted && (
-//         <a
-//             onClick={() =>
-//                 this.onTogglePromptForMuteNotes()
-//             }
-//         >
-//             {tt('g.unmute')}
-//         </a>
-//     ) } { ' ' }
-// { showMuteToggle &&
-//     !isMuted && (
-//         <a
-//             onClick={() =>
-//                 this.onTogglePromptForMuteNotes()
-//             }
-//         >
-//             {tt('g.mute')}
-//         </a>
-//     ) } { ' ' }
 
 MuteButton.propTypes = {
     label: PropTypes.string.isRequired,

--- a/src/app/components/elements/MuteButton.jsx
+++ b/src/app/components/elements/MuteButton.jsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Reveal from 'app/components/elements/Reveal';
+import CloseButton from 'app/components/elements/CloseButton';
+import MutePost from 'app/components/modules/MutePost';
+
+export default function MuteButton(props) {
+    const {
+        label,
+        loading,
+        isMuted,
+        onToggleMute,
+        onToggleDialog,
+        showDialog,
+    } = props;
+
+    if (loading) {
+        return <span>Loading...</span>;
+    }
+
+    return (
+        <span>
+            <a onClick={() => onToggleDialog()}> {label} </a>
+            {showDialog && (
+                <Reveal onHide={() => console.log('Reveal::onHide')} show>
+                    <CloseButton onClick={() => onToggleDialog()} />
+                    <MutePost
+                        isMuted={isMuted}
+                        onSubmit={notes => {
+                            onToggleDialog();
+                            onToggleMute(isMuted, notes);
+                        }}
+                    />
+                </Reveal>
+            )}
+        </span>
+    );
+}
+
+// { showMuteToggle &&
+//     isMuted && (
+//         <a
+//             onClick={() =>
+//                 this.onTogglePromptForMuteNotes()
+//             }
+//         >
+//             {tt('g.unmute')}
+//         </a>
+//     ) } { ' ' }
+// { showMuteToggle &&
+//     !isMuted && (
+//         <a
+//             onClick={() =>
+//                 this.onTogglePromptForMuteNotes()
+//             }
+//         >
+//             {tt('g.mute')}
+//         </a>
+//     ) } { ' ' }
+
+MuteButton.propTypes = {
+    label: PropTypes.string.isRequired,
+    loading: PropTypes.bool.isRequired,
+    isMuted: PropTypes.bool.isRequired,
+    showDialog: PropTypes.bool.isRequired,
+    onToggleMute: PropTypes.func.isRequired,
+    onToggleDialog: PropTypes.func.isRequired,
+};

--- a/src/app/components/elements/MuteButtonContainer.jsx
+++ b/src/app/components/elements/MuteButtonContainer.jsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import * as transactionActions from 'app/redux/TransactionReducer';
+
+import MuteButton from './MuteButton';
+
+class MuteButtonContainer extends React.Component {
+    constructor(props) {
+        super(props);
+        const { isMuted } = this.props;
+        this.state = {
+            showDialog: false,
+            loading: false,
+            isMuted,
+        };
+    }
+
+    onTogglePromptForMuteNotes = () => {
+        this.setState({ showDialog: !this.state.showDialog });
+    };
+
+    onToggleMute = (isMuted, notes) => {
+        const { community, username, permlink } = this.props;
+        if (!notes || !community || !username) return false; // Fail Fast
+
+        this.props.toggleMutedPost(
+            !isMuted,
+            community,
+            username,
+            notes,
+            permlink,
+            () => {
+                console.log('MuteButtonContainer::onToggleMute()::success');
+                this.setState({ isMuted: !isMuted });
+            },
+            () => {
+                console.log('MuteButtonContainer::onToggleMute()::failure');
+                this.setState({ isMuted });
+            }
+        );
+    };
+
+    render() {
+        const { isMuted, showDialog, loading } = this.state;
+
+        let label = `Mute`;
+        if (isMuted) {
+            label = `Unmute`;
+        }
+
+        return (
+            <MuteButton
+                loading={loading}
+                label={label}
+                showDialog={showDialog}
+                onToggleMute={this.onToggleMute}
+                onToggleDialog={this.onTogglePromptForMuteNotes}
+                isMuted={isMuted}
+            />
+        );
+    }
+}
+
+MuteButtonContainer.propTypes = {
+    permlink: PropTypes.string.isRequired,
+    username: PropTypes.string.isRequired,
+    community: PropTypes.string.isRequired, //TODO: Define shape
+};
+
+export default connect(
+    (state, ownProps) => {
+        return {
+            ...ownProps,
+            username: state.user.getIn(['current', 'username']),
+            // community: state.global.getIn(
+            //     ['community', ownProps.community],
+            //     {}
+            // ),
+        };
+    },
+    dispatch => ({
+        toggleMutedPost: (
+            mutePost,
+            community,
+            account,
+            notes,
+            permlink,
+            successCallback,
+            errorCallback
+        ) => {
+            let action = 'unmutePost';
+            if (mutePost) action = 'mutePost';
+
+            const payload = [
+                action,
+                {
+                    community,
+                    account,
+                    notes,
+                    permlink,
+                },
+            ];
+
+            return dispatch(
+                transactionActions.broadcastOperation({
+                    type: 'custom_json',
+                    operation: {
+                        id: 'community',
+                        required_posting_auths: [account],
+                        json: JSON.stringify(payload),
+                    },
+                    successCallback,
+                    errorCallback,
+                })
+            );
+        },
+    })
+)(MuteButtonContainer);

--- a/src/app/components/elements/MuteButtonContainer.jsx
+++ b/src/app/components/elements/MuteButtonContainer.jsx
@@ -74,10 +74,6 @@ export default connect(
         return {
             ...ownProps,
             username: state.user.getIn(['current', 'username']),
-            // community: state.global.getIn(
-            //     ['community', ownProps.community],
-            //     {}
-            // ),
         };
     },
     dispatch => ({

--- a/src/app/components/modules/MutePost.jsx
+++ b/src/app/components/modules/MutePost.jsx
@@ -1,0 +1,64 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import tt from 'counterpart';
+
+class MutePost extends Component {
+    constructor(props) {
+        super(props);
+        this.state = { notes: '', disableSubmit: true };
+    }
+
+    componentWillUpdate = (nextProps, nextState) => {
+        if (nextState.notes != this.state.notes) {
+            this.setState({ disableSubmit: false });
+        }
+    };
+
+    onInput = e => {
+        this.setState({ notes: `${e.target.value || ''}` });
+    };
+
+    onSubmit = () => {
+        if (this.state.notes) this.props.onSubmit(this.state.notes);
+    };
+
+    render() {
+        const { notes, disableSubmit } = this.state;
+        return (
+            <span className="ExplorePost">
+                <h4>{tt('g.mute_this_post')}</h4>
+                <p>
+                    Please provide a note regarding your decision to mute this
+                    post.
+                </p>
+                <hr />
+                <form onSubmit={() => this.onSubmit()}>
+                    <div className="input-group">
+                        <span className="input-group-label">Notes</span>
+                        <input
+                            className="input-group-field"
+                            type="text"
+                            onChange={e => this.onInput(e)}
+                        />
+                        <button
+                            className="button slim hollow secondary"
+                            type="submit"
+                            title={tt('g.mute')}
+                            disabled={disableSubmit}
+                        >
+                            {tt('g.mute')}
+                        </button>
+                    </div>
+                </form>
+            </span>
+        );
+    }
+}
+
+MutePost.propTypes = {
+    onSubmit: PropTypes.func.isRequired,
+};
+
+export default connect()(MutePost);

--- a/src/app/components/modules/MutePost.jsx
+++ b/src/app/components/modules/MutePost.jsx
@@ -26,32 +26,48 @@ class MutePost extends Component {
 
     render() {
         const { notes, disableSubmit } = this.state;
+        const { isMuted } = this.props;
+
+        let submitButtonLabel = tt('g.mute');
+        if (isMuted) submitButtonLabel = tt('g.unmute');
+
         return (
-            <span className="ExplorePost">
-                <h4>{tt('g.mute_this_post')}</h4>
-                <p>
-                    Please provide a note regarding your decision to mute this
-                    post.
-                </p>
-                <hr />
-                <form onSubmit={() => this.onSubmit()}>
-                    <div className="input-group">
-                        <span className="input-group-label">Notes</span>
-                        <input
-                            className="input-group-field"
-                            type="text"
-                            onChange={e => this.onInput(e)}
-                        />
-                        <button
-                            className="button slim hollow secondary"
-                            type="submit"
-                            title={tt('g.mute')}
-                            disabled={disableSubmit}
-                        >
-                            {tt('g.mute')}
-                        </button>
+            <span>
+                {isMuted ? (
+                    <div>
+                        <h4>{tt('g.unmute_this_post')}</h4>{' '}
+                        <p> {tt('g.unmute_this_post_description')}</p>
                     </div>
-                </form>
+                ) : (
+                    <div>
+                        <h4>{tt('g.mute_this_post')}</h4>
+                        <p>{tt('g.mute_this_post_description')}</p>
+                    </div>
+                )}
+                <hr />
+                <div className="input-group">
+                    <span className="input-group-label">Notes</span>
+                    <input
+                        className="input-group-field"
+                        type="text"
+                        maxLength={120}
+                        onKeyUp={e => {
+                            if (e.key === 'Enter') {
+                                this.onSubmit();
+                            }
+                            this.onInput(e);
+                        }}
+                    />
+                    <button
+                        className="button slim hollow secondary"
+                        type="submit"
+                        title={submitButtonLabel}
+                        disabled={disableSubmit}
+                        onClick={() => this.onSubmit()}
+                    >
+                        {submitButtonLabel}
+                    </button>
+                </div>
             </span>
         );
     }
@@ -59,6 +75,11 @@ class MutePost extends Component {
 
 MutePost.propTypes = {
     onSubmit: PropTypes.func.isRequired,
+    isMuted: PropTypes.bool,
+};
+
+MutePost.defaultProps = {
+    isMuted: false,
 };
 
 export default connect()(MutePost);

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -105,6 +105,7 @@
         "sell": "Sell",
         "settings": "Settings",
         "share_this_post": "Share this post",
+        "mute_this_post": "Mute this post",
         "show": "Show",
         "sign_in": "Sign in",
         "sign_up": "Sign up",

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -106,6 +106,11 @@
         "settings": "Settings",
         "share_this_post": "Share this post",
         "mute_this_post": "Mute this post",
+        "mute_this_post_description":
+            "Please provide a note regarding your decision to mute this post.",
+        "unmute_this_post": "Unmute this post",
+        "unmute_this_post_description":
+            "Please provide a note regarding your decision to unmute this post.",
         "show": "Show",
         "sign_in": "Sign in",
         "sign_up": "Sign up",


### PR DESCRIPTION
This allows a user to mute a post, provide a note regarding the mutage, and
unmute a previously muted post.

Screenshots:
![image (8)](https://user-images.githubusercontent.com/1451007/64961292-667e9380-d852-11e9-8b21-af16100f7687.png)
![image (9)](https://user-images.githubusercontent.com/1451007/64961291-667e9380-d852-11e9-95ab-62786e059c65.png)
![image (10)](https://user-images.githubusercontent.com/1451007/64961290-667e9380-d852-11e9-875b-8e5469ebefdb.png)
![image (11)](https://user-images.githubusercontent.com/1451007/64961289-667e9380-d852-11e9-88bc-af678e2f5a36.png)
![image (14)](https://user-images.githubusercontent.com/1451007/65013590-ecddb880-d8d8-11e9-8107-d95ed16a49f5.png)
![image (13)](https://user-images.githubusercontent.com/1451007/65013591-ecddb880-d8d8-11e9-921d-7b84e9c8e1ca.png)
![image (12)](https://user-images.githubusercontent.com/1451007/65013592-ecddb880-d8d8-11e9-9992-38abbfa4c94f.png)

Issues:
- ~~The user is not prompted for notes when unmuting.~~
- The layout of the dialog needs love.
- Comments don't full refresh after being muted therefore the user muting the comment will not see the comment greyed out until the page reloads.

Closes #3501