### PR TITLE
Add Community Settings Editor

### DIFF
--- a/src/app/components/elements/SettingsEditButton.jsx
+++ b/src/app/components/elements/SettingsEditButton.jsx
@@ -42,10 +42,6 @@ export default function SettingsButton(props) {
                     <CommunitySettings
                         {...settings}
                         onSubmit={newSettings => {
-                            console.log(
-                                'SettingsEditButton::onSubmit()::newSettings',
-                                newSettings
-                            );
                             onToggleDialog();
                             onSave(newSettings);
                         }}

--- a/src/app/components/elements/SettingsEditButton.jsx
+++ b/src/app/components/elements/SettingsEditButton.jsx
@@ -1,0 +1,66 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+import Reveal from 'app/components/elements/Reveal';
+import CloseButton from 'app/components/elements/CloseButton';
+import CommunitySettings from 'app/components/modules/CommunitySettings';
+
+export default function SettingsButton(props) {
+    const {
+        label,
+        loading,
+        onSave,
+        onToggleDialog,
+        showDialog,
+        settings,
+    } = props;
+
+    if (loading) {
+        return (
+            <button
+                disabled
+                className="button slim hollow secondary"
+                type="button"
+            >
+                Loading...
+            </button>
+        );
+    }
+
+    return (
+        <span>
+            <button
+                onClick={onToggleDialog}
+                className="button slim hollow secondary"
+                type="button"
+            >
+                {label}
+            </button>
+            {showDialog && (
+                <Reveal onHide={() => null} show>
+                    <CloseButton onClick={() => onToggleDialog()} />
+                    <CommunitySettings
+                        {...settings}
+                        onSubmit={newSettings => {
+                            console.log(
+                                'SettingsEditButton::onSubmit()::newSettings',
+                                newSettings
+                            );
+                            onToggleDialog();
+                            onSave(newSettings);
+                        }}
+                    />
+                </Reveal>
+            )}
+        </span>
+    );
+}
+
+SettingsButton.propTypes = {
+    label: PropTypes.string.isRequired,
+    loading: PropTypes.bool.isRequired,
+    showDialog: PropTypes.bool.isRequired,
+    onSave: PropTypes.func.isRequired,
+    onToggleDialog: PropTypes.func.isRequired,
+    settings: PropTypes.object.isRequired, //TODO: Define this shape
+};

--- a/src/app/components/elements/SettingsEditButtonContainer.jsx
+++ b/src/app/components/elements/SettingsEditButtonContainer.jsx
@@ -24,17 +24,21 @@ class SettingsEditButtonContainer extends React.Component {
     onSave = newSettings => {
         const community = this.props.community.get('name');
         this.setState({ loading: true });
+        // TODO: this.props.getCommunity(community) won't work as expected here
+        // because hivemind lags by 10s or so. We need a new saga which updates
+        // (local) global state for immediate feedback (i.e. without making any
+        // call to the server). We can assume the op was successful. See #3524
         this.props.saveSettings(
             this.props.username,
             community,
             newSettings,
             () => {
                 this.setState({ loading: false, settings: newSettings });
-                this.props.getCommunity(community);
+                //this.props.getCommunity(community);
             },
             () => {
                 this.setState({ loading: false });
-                this.props.getCommunity(community);
+                //this.props.getCommunity(community);
             }
         );
     };

--- a/src/app/components/elements/SettingsEditButtonContainer.jsx
+++ b/src/app/components/elements/SettingsEditButtonContainer.jsx
@@ -22,10 +22,6 @@ class SettingsEditButtonContainer extends React.Component {
     };
 
     onSave = newSettings => {
-        console.log(
-            'SettingsEditButtonContainer::onSave::newSettings',
-            newSettings
-        );
         const community = this.props.community.get('name');
         this.setState({ loading: true });
         this.props.saveSettings(
@@ -33,12 +29,10 @@ class SettingsEditButtonContainer extends React.Component {
             community,
             newSettings,
             () => {
-                console.log('onSave::Success()');
                 this.setState({ loading: false, settings: newSettings });
                 this.props.getCommunity(community);
             },
             () => {
-                console.log('onSave::failure()');
                 this.setState({ loading: false });
                 this.props.getCommunity(community);
             }
@@ -46,12 +40,6 @@ class SettingsEditButtonContainer extends React.Component {
     };
 
     render() {
-        // const { subscribed } = this.state;
-        console.log(
-            'SettingsEditButtonContainer->render()',
-            this.state.settings
-        );
-
         const label = `Settings`;
 
         return (

--- a/src/app/components/elements/SettingsEditButtonContainer.jsx
+++ b/src/app/components/elements/SettingsEditButtonContainer.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 
 import * as transactionActions from 'app/redux/TransactionReducer';
+import { actions as fetchDataSagaActions } from 'app/redux/FetchDataSaga';
 
 import SettingsEditButton from './SettingsEditButton';
 
@@ -34,10 +35,12 @@ class SettingsEditButtonContainer extends React.Component {
             () => {
                 console.log('onSave::Success()');
                 this.setState({ loading: false, settings: newSettings });
+                this.props.getCommunity(community);
             },
             () => {
                 console.log('onSave::failure()');
                 this.setState({ loading: false });
+                this.props.getCommunity(community);
             }
         );
     };
@@ -119,6 +122,9 @@ export default connect(
                     errorCallback,
                 })
             );
+        },
+        getCommunity: communityName => {
+            return dispatch(fetchDataSagaActions.getCommunity(communityName));
         },
     })
 )(SettingsEditButtonContainer);

--- a/src/app/components/elements/SettingsEditButtonContainer.jsx
+++ b/src/app/components/elements/SettingsEditButtonContainer.jsx
@@ -1,0 +1,124 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import * as transactionActions from 'app/redux/TransactionReducer';
+
+import SettingsEditButton from './SettingsEditButton';
+
+class SettingsEditButtonContainer extends React.Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            showDialog: false,
+            loading: false,
+            settings: this.props.settings,
+        };
+    }
+
+    onToggleDialog = () => {
+        this.setState({ showDialog: !this.state.showDialog });
+    };
+
+    onSave = newSettings => {
+        console.log(
+            'SettingsEditButtonContainer::onSave::newSettings',
+            newSettings
+        );
+        const community = this.props.community.get('name');
+        this.setState({ loading: true });
+        this.props.saveSettings(
+            this.props.username,
+            community,
+            newSettings,
+            () => {
+                console.log('onSave::Success()');
+                this.setState({ loading: false, settings: newSettings });
+            },
+            () => {
+                console.log('onSave::failure()');
+                this.setState({ loading: false });
+            }
+        );
+    };
+
+    render() {
+        // const { subscribed } = this.state;
+        console.log(
+            'SettingsEditButtonContainer->render()',
+            this.state.settings
+        );
+
+        const label = `Settings`;
+
+        return (
+            <SettingsEditButton
+                {...this.state}
+                onSave={this.onSave}
+                onToggleDialog={this.onToggleDialog}
+                label={label}
+            />
+        );
+    }
+}
+
+SettingsEditButtonContainer.propTypes = {
+    username: PropTypes.string.isRequired,
+    community: PropTypes.object.isRequired, //TODO: Define this shape
+    settings: PropTypes.object.isRequired, //TODO: Define this shape
+};
+
+export default connect(
+    (state, ownProps) => {
+        const community = state.global.getIn(
+            ['community', ownProps.community],
+            {}
+        );
+        const settings = {
+            title: community.get('title'),
+            about: community.get('about'),
+            is_nsfw: community.get('is_nsfw'),
+            description: community.get('description'),
+            flag_text: '', //TODO: Where is flag_text supposed to be?
+        };
+
+        return {
+            ...ownProps,
+            username: state.user.getIn(['current', 'username']),
+            community,
+            settings,
+        };
+    },
+    dispatch => ({
+        saveSettings: (
+            account,
+            community,
+            settings,
+            successCallback,
+            errorCallback
+        ) => {
+            const action = 'updateProps';
+
+            const payload = [
+                action,
+                {
+                    community,
+                    props: settings,
+                },
+            ];
+
+            return dispatch(
+                transactionActions.broadcastOperation({
+                    type: 'custom_json',
+                    operation: {
+                        id: 'community',
+                        required_posting_auths: [account],
+                        json: JSON.stringify(payload),
+                    },
+                    successCallback,
+                    errorCallback,
+                })
+            );
+        },
+    })
+)(SettingsEditButtonContainer);

--- a/src/app/components/elements/SettingsEditButtonContainer.jsx
+++ b/src/app/components/elements/SettingsEditButtonContainer.jsx
@@ -79,7 +79,7 @@ export default connect(
             about: community.get('about'),
             is_nsfw: community.get('is_nsfw'),
             description: community.get('description'),
-            flag_text: '', //TODO: Where is flag_text supposed to be?
+            flag_text: community.get('flag_text', ''),
         };
 
         return {

--- a/src/app/components/modules/CommunitySettings.jsx
+++ b/src/app/components/modules/CommunitySettings.jsx
@@ -158,8 +158,4 @@ CommunitySettings.propTypes = {
     flag_text: PropTypes.string.isRequired,
 };
 
-CommunitySettings.defaultProps = {
-    isMuted: false,
-};
-
 export default connect()(CommunitySettings);

--- a/src/app/components/modules/CommunitySettings.jsx
+++ b/src/app/components/modules/CommunitySettings.jsx
@@ -28,11 +28,12 @@ class CommunitySettings extends Component {
 
     onSubmit = () => {
         // Trim leading and trailing whitespace before submission.
-        const settings = Object.keys(this.state).filter((k, v) => {
-            if (typeof v === 'string') {
-                return v.trim();
+        const settings = {};
+        Object.keys(this.state).filter(k => {
+            if (typeof this.state[k] === 'string') {
+                return (settings[k] = this.state[k].trim());
             }
-            return v;
+            return (settings[k] = this.state[k]);
         });
 
         console.log('CommunitySettings::onSubmit()::settings', settings);

--- a/src/app/components/modules/CommunitySettings.jsx
+++ b/src/app/components/modules/CommunitySettings.jsx
@@ -27,7 +27,14 @@ class CommunitySettings extends Component {
     };
 
     onSubmit = () => {
-        const settings = { ...this.state };
+        // Trim leading and trailing whitespace before submission.
+        const settings = Object.keys(this.state).filter((k, v) => {
+            if (typeof v === 'string') {
+                return v.trim();
+            }
+            return v;
+        });
+
         console.log('CommunitySettings::onSubmit()::settings', settings);
         this.props.onSubmit(settings);
     };

--- a/src/app/components/modules/CommunitySettings.jsx
+++ b/src/app/components/modules/CommunitySettings.jsx
@@ -1,0 +1,158 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+import tt from 'counterpart';
+
+class CommunitySettings extends Component {
+    constructor(props) {
+        super(props);
+        this.state = {
+            title: this.props.title,
+            about: this.props.about,
+            is_nsfw: this.props.is_nsfw,
+            description: this.props.description,
+            flag_text: this.props.flag_text,
+        };
+    }
+
+    onInput = event => {
+        console.log('CommunitySettings::onInput(event)', event);
+        const newState = {};
+        let newValue = event.target.value || '';
+        if (event.target.hasOwnProperty('checked'))
+            newValue = event.target.checked;
+        newState[event.target.name] = newValue;
+        this.setState(newState);
+    };
+
+    onSubmit = () => {
+        const settings = { ...this.state };
+        console.log('CommunitySettings::onSubmit()::settings', settings);
+        this.props.onSubmit(settings);
+    };
+
+    render() {
+        const { title, about, is_nsfw, description, flag_text } = this.state;
+
+        const submitButtonLabel = 'Save';
+
+        return (
+            <span>
+                <div>
+                    <h4>{tt('g.community_settings_header')}</h4>
+                    <p>{tt('g.community_settings_description')}</p>
+                </div>
+                <hr />
+                <div className="input-group">
+                    <span className="input-group-label">
+                        Title &nbsp;<small>
+                            [<a title="the display name of this community (32 chars)">
+                                ?
+                            </a>]
+                        </small>
+                    </span>{' '}
+                    <input
+                        className="input-group-field"
+                        type="text"
+                        maxLength={32}
+                        name="title"
+                        value={title}
+                        onChange={e => this.onInput(e)}
+                    />
+                </div>
+                <div className="input-group">
+                    <span className="input-group-label">
+                        About &nbsp;<small>
+                            [<a title="short blurb about this community (120 chars)">
+                                ?
+                            </a>]
+                        </small>
+                    </span>{' '}
+                    <input
+                        className="input-group-field"
+                        type="text"
+                        maxLength={120}
+                        name="about"
+                        value={about}
+                        onChange={e => this.onInput(e)}
+                    />
+                </div>
+                <div className="input-group">
+                    <span className="input-group-label">
+                        NSFW? &nbsp;<small>
+                            [<a title="true if this community is 18+">?</a>]
+                        </small>
+                    </span>{' '}
+                    <input
+                        className="input-group-field"
+                        type="checkbox"
+                        name="is_nsfw"
+                        checked={is_nsfw}
+                        onChange={e => this.onInput(e)}
+                    />
+                </div>
+                <div className="input-group">
+                    <span className="input-group-label">
+                        Description &nbsp;<small>
+                            [<a title="describes purpose of community, etc. (5000 chars)">
+                                ?
+                            </a>]
+                        </small>
+                    </span>{' '}
+                    <textarea
+                        className="input-group-field"
+                        type="text"
+                        maxLength={2000}
+                        onChange={e => this.onInput(e)}
+                        name="description"
+                        value={description}
+                    />
+                </div>
+                <div className="input-group">
+                    <span className="input-group-label">
+                        Flag Text &nbsp;<small>
+                            [<a title="custom text for reporting content (2000 chars)">
+                                ?
+                            </a>]
+                        </small>
+                    </span>{' '}
+                    <textarea
+                        className="input-group-field"
+                        type="text"
+                        maxLength={2000}
+                        onChange={e => this.onInput(e)}
+                        name="flag_text"
+                        value={flag_text}
+                    />
+                </div>
+                <div className="input-group">
+                    <button
+                        className="button slim hollow secondary"
+                        type="submit"
+                        title={submitButtonLabel}
+                        onClick={() => this.onSubmit()}
+                    >
+                        {' '}
+                        {submitButtonLabel}{' '}
+                    </button>{' '}
+                </div>
+            </span>
+        );
+    }
+}
+
+CommunitySettings.propTypes = {
+    onSubmit: PropTypes.func.isRequired,
+    title: PropTypes.string.isRequired,
+    about: PropTypes.string.isRequired,
+    is_nsfw: PropTypes.bool.isRequired,
+    description: PropTypes.string.isRequired,
+    flag_text: PropTypes.string.isRequired,
+};
+
+CommunitySettings.defaultProps = {
+    isMuted: false,
+};
+
+export default connect()(CommunitySettings);

--- a/src/app/components/modules/CommunitySettings.jsx
+++ b/src/app/components/modules/CommunitySettings.jsx
@@ -17,7 +17,6 @@ class CommunitySettings extends Component {
     }
 
     onInput = event => {
-        console.log('CommunitySettings::onInput(event)', event);
         const newState = {};
         let newValue = event.target.value || '';
         if (event.target.hasOwnProperty('checked'))
@@ -35,14 +34,14 @@ class CommunitySettings extends Component {
             }
             return (settings[k] = this.state[k]);
         });
+        // If there is no value for flag text, don't send it.
+        if (settings.flag_text == '') delete settings.flag_text;
 
-        console.log('CommunitySettings::onSubmit()::settings', settings);
         this.props.onSubmit(settings);
     };
 
     render() {
         const { title, about, is_nsfw, description, flag_text } = this.state;
-
         const submitButtonLabel = 'Save';
 
         return (

--- a/src/app/components/pages/PostsIndex.jsx
+++ b/src/app/components/pages/PostsIndex.jsx
@@ -124,15 +124,15 @@ class PostsIndex extends React.Component {
                 );
             }
         } else if (posts && posts.size === 0) {
-                emptyText = (
-                    <div>
-                        {'No ' +
-                            order +
-                            (category ? ' #' + category : '') +
-                            ' posts found'}
-                    </div>
-                );
-            }
+            emptyText = (
+                <div>
+                    {'No ' +
+                        order +
+                        (category ? ' #' + category : '') +
+                        ' posts found'}
+                </div>
+            );
+        }
 
         function teamMembers(members) {
             return members.map((row, idx) => (
@@ -440,7 +440,7 @@ module.exports = {
                 gptBannedTags: state.app.getIn(['googleAds', 'gptBannedTags']),
             };
         },
-        (dispatch) => {
+        dispatch => {
             return {
                 requestData: args =>
                     dispatch(fetchDataSagaActions.requestData(args)),

--- a/src/app/components/pages/PostsIndex.jsx
+++ b/src/app/components/pages/PostsIndex.jsx
@@ -16,6 +16,7 @@ import SidebarNewUsers from 'app/components/elements/SidebarNewUsers';
 import Notices from 'app/components/elements/Notices';
 import SteemMarket from 'app/components/elements/SteemMarket';
 import SubscribeButtonContainer from 'app/components/elements/SubscribeButtonContainer';
+import SettingsEditButtonContainer from 'app/components/elements/SettingsEditButtonContainer';
 import { GptUtils } from 'app/utils/GptUtils';
 import GptAd from 'app/components/elements/GptAd';
 import ArticleLayoutSelector from 'app/components/modules/ArticleLayoutSelector';
@@ -122,8 +123,7 @@ class PostsIndex extends React.Component {
                     </div>
                 );
             }
-        } else {
-            if (posts && posts.size === 0) {
+        } else if (posts && posts.size === 0) {
                 emptyText = (
                     <div>
                         {'No ' +
@@ -133,7 +133,6 @@ class PostsIndex extends React.Component {
                     </div>
                 );
             }
-        }
 
         function teamMembers(members) {
             return members.map((row, idx) => (
@@ -300,6 +299,9 @@ class PostsIndex extends React.Component {
                                 >
                                     Create Post
                                 </Link>
+                                <SettingsEditButtonContainer
+                                    community={community.get('name')}
+                                />
                             </div>
                             {community.get('subscribers')} subscribers
                             <br />
@@ -438,7 +440,7 @@ module.exports = {
                 gptBannedTags: state.app.getIn(['googleAds', 'gptBannedTags']),
             };
         },
-        dispatch => {
+        (dispatch) => {
             return {
                 requestData: args =>
                     dispatch(fetchDataSagaActions.requestData(args)),

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -21,6 +21,9 @@
         "clear": "Clear",
         "close": "Close",
         "collapse_or_expand": "Collapse/Expand",
+        "community_settings_header": "Community Settings",
+        "community_settings_description":
+            "Here you can customize this community as you see fit.",
         "comments": "Comments",
         "confirm": "Confirm",
         "convert": "Convert",


### PR DESCRIPTION
# Screenshots:
![image (15)](https://user-images.githubusercontent.com/1451007/65310878-7d6fff00-db4c-11e9-990e-dd2e9866f382.png)
![image (16)](https://user-images.githubusercontent.com/1451007/65310899-81038600-db4c-11e9-8498-be0fa12407f4.png)
![image (17)](https://user-images.githubusercontent.com/1451007/65310909-8660d080-db4c-11e9-911a-278289c8b890.png)

# Issues:
- [ ] Need to use a saga in order to promote refreshing the community page when settings change.
- [ ] Settings don't appear to have changed sometimes despite a successful broadcast transaction: [worked](https://steemd.com/b/36579958#a259d17ca3d8fed6a85681e2de373a98f1dc5af4) and [didn't work](https://steemd.com/b/36580938#16ba8aa0090a3dbc6920597153fc01595c00afd4)
- [ ] UI/layout needs love and attention.
- [ ] i18n remaining copy.

Fixes #3493