### PR TITLE
Community - add proposals to hamburger menu

### DIFF
--- a/src/app/components/modules/SidePanel/index.jsx
+++ b/src/app/components/modules/SidePanel/index.jsx
@@ -97,6 +97,11 @@ const SidePanel = ({
                 label: tt('navigation.vote_for_witnesses'),
                 link: `${walletUrl}/~witnesses`,
             },
+            {
+                value: 'proposals',
+                label: tt('navigation.steem_proposals'),
+                link: `${walletUrl}/proposals`,
+            },
         ],
         exchanges: [
             {

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -281,7 +281,8 @@
         "intro_tagline": "Your voice is worth something",
         "intro_paragraph":
             "Get paid for good content. Post and upvote articles on Steemit to get your share of the daily rewards pool.",
-        "jobs": "Jobs at Steemit"
+        "jobs": "Jobs at Steemit",
+        "steem_proposals": "Steem Proposals"
     },
     "main_menu": {
         "hot": "Hot",


### PR DESCRIPTION
This adds "Steem Proposals" link in the hamburger menu. Issue #3530 .

Translations in /src/app/locales will need new key:value pairs for `steem_proposals`.