### PR TITLE
Community - fix clear draft on posting.

### DIFF
--- a/src/app/components/elements/ReplyEditor.jsx
+++ b/src/app/components/elements/ReplyEditor.jsx
@@ -374,6 +374,7 @@ class ReplyEditor extends React.Component {
             this.setState({ postError: estr, loading: false });
         };
         const successCallbackWrapper = (...args) => {
+            replyForm.resetForm();
             this.setState({ loading: false });
             this.props.setPayoutType(formId, defaultPayoutType);
             this.props.setBeneficiaries(formId, []);


### PR DESCRIPTION
Under certain conditions the draft does not clear when posting is done, which can give the impression that a post is being edited if one is not careful.