### PR TITLE
Fix occasionally disabled ads issue

### DIFF
--- a/src/app/components/elements/GptAd.jsx
+++ b/src/app/components/elements/GptAd.jsx
@@ -82,6 +82,7 @@ export default connect(
             !!state.app.getIn(['googleAds', 'gptEnabled']) &&
             !!process.env.BROWSER &&
             !!window.googletag;
+        console.log(`enabled: ${enabled}, state.app.getIn(['googleAds', 'gptEnabled']): ${state.app.getIn(['googleAds', 'gptEnabled'])}, process.env.BROWSER: ${process.env.BROWSER}, window.googletag: ${window.googletag}`);
         const postCategory = state.global.get('postCategory');
         const basicSlots = state.app.getIn(['googleAds', `gptBasicSlots`]);
         const biddingSlots = state.app.getIn(['googleAds', `gptBiddingSlots`]);
@@ -101,6 +102,8 @@ export default connect(
         if (type != 'Freestar') {
             slot = state.app.getIn(['googleAds', `gpt${type}Slots`, slotName]);
         }
+
+        console.log(`slot: ${slot}`);
 
         return {
             enabled,

--- a/src/app/components/elements/GptAd.jsx
+++ b/src/app/components/elements/GptAd.jsx
@@ -12,8 +12,6 @@ class GptAd extends Component {
         this.tags = tags;
         this.bannedTags = bannedTags;
 
-        console.log(`enabled from props: ${enabled}`);
-
         if (ad_identifier != '') {
             // console.info(
             //     `ad_identifier of '${ad_identifier}' will render.`,
@@ -82,9 +80,7 @@ export default connect(
     (state, props) => {
         const enabled =
             !!state.app.getIn(['googleAds', 'gptEnabled']) &&
-            !!process.env.BROWSER &&
-            !!window.googletag;
-        console.log(`enabled: ${enabled}, state.app.getIn(['googleAds', 'gptEnabled']): ${state.app.getIn(['googleAds', 'gptEnabled'])}, process.env.BROWSER: ${process.env.BROWSER}, window.googletag: ${window.googletag}`);
+            !!process.env.BROWSER;
         const postCategory = state.global.get('postCategory');
         const basicSlots = state.app.getIn(['googleAds', `gptBasicSlots`]);
         const biddingSlots = state.app.getIn(['googleAds', `gptBiddingSlots`]);
@@ -104,8 +100,6 @@ export default connect(
         if (type != 'Freestar') {
             slot = state.app.getIn(['googleAds', `gpt${type}Slots`, slotName]);
         }
-
-        console.log(`slot: ${slot}`);
 
         return {
             enabled,

--- a/src/app/components/elements/GptAd.jsx
+++ b/src/app/components/elements/GptAd.jsx
@@ -12,6 +12,8 @@ class GptAd extends Component {
         this.tags = tags;
         this.bannedTags = bannedTags;
 
+        console.log(`enabled from props: ${enabled}`);
+
         if (ad_identifier != '') {
             // console.info(
             //     `ad_identifier of '${ad_identifier}' will render.`,

--- a/src/server/server-html.jsx
+++ b/src/server/server-html.jsx
@@ -182,6 +182,7 @@ export default function ServerHTML({
                             __html: `
                             (function() {
                               var bsa_optimize = document.createElement('script');
+                              window.optimize = { queue: [] };
                               bsa_optimize.type = 'text/javascript';
                               bsa_optimize.async = true;
                               bsa_optimize.src = 'https://cdn-s2s.buysellads.net/pub/steemit.js?' + (new Date() - new Date() % 3600000);


### PR DESCRIPTION
There was an occasional condition where `enabled` within `GptAd` and `enabled` passed in through props were not the same - this was caused when the google ad script was not loaded prior to beginning to render ads. Since BSA's optimize script already handles this, we don't need to check for it here.

Fixing this problem uncovered an additional one - occasionally BSA's optimize queue would not exist prior to trying to push items to it. Pre-initializing an empty queue solves this.