### PR TITLE
Fix blank space at the bottom of a post on nightmode

### DIFF
--- a/src/app/assets/stylesheets/_themes.scss
+++ b/src/app/assets/stylesheets/_themes.scss
@@ -118,7 +118,8 @@ $themes: (
 /*
  * Implementation of themes
  */
-@mixin themify($themes) {
+
+ @mixin themify($themes) {
   @each $theme, $map in $themes {
     .theme-#{$theme} & {
       $theme-map: () !global;
@@ -143,6 +144,7 @@ $themes: (
     @include MQ(M) {
       background-color: $color-background-off-white;
     }
+    padding-bottom: 1px;
   }
   .theme-light {
     background-color: $white;
@@ -150,10 +152,12 @@ $themes: (
     @include MQ(M) {
       background-color: $color-background-off-white;
     }
+    padding-bottom: 1px;
   }
   .theme-dark {
     background-color: $color-background-dark;
     color: $color-text-white;
+    padding-bottom: 1px;
   }
 
 

--- a/src/app/assets/stylesheets/_themes.scss
+++ b/src/app/assets/stylesheets/_themes.scss
@@ -118,7 +118,7 @@ $themes: (
 /*
  * Implementation of themes
  */
- @mixin themify($themes) {
+@mixin themify($themes) {
   @each $theme, $map in $themes {
     .theme-#{$theme} & {
       $theme-map: () !global;

--- a/src/app/assets/stylesheets/_themes.scss
+++ b/src/app/assets/stylesheets/_themes.scss
@@ -118,7 +118,6 @@ $themes: (
 /*
  * Implementation of themes
  */
-
  @mixin themify($themes) {
   @each $theme, $map in $themes {
     .theme-#{$theme} & {


### PR DESCRIPTION
When viewing a post in darkmode, the bottom of the page contains whitespace that is not the same background color as darkmode. Adding a 1px `padding-bottom` to the body makes the browser calculate where the body actually ends so it will use the background color all the way to the bottom.

There could be other ways to fix this bug.

Before:

![Screen Shot 2019-10-19 at 3 24 44 PM](https://user-images.githubusercontent.com/23157604/67150370-a9ce8680-f284-11e9-89e5-901427b3ca11.png)


After:

![Screen Shot 2019-10-19 at 3 06 04 PM](https://user-images.githubusercontent.com/23157604/67150320-fc5b7300-f283-11e9-9376-59473ed0bc7d.png)
