### PR TITLE
Community - Add voting power and vote estimate

### DIFF
--- a/src/app/components/elements/Voting.jsx
+++ b/src/app/components/elements/Voting.jsx
@@ -664,6 +664,8 @@ export default connect(
         const enable_slider =
             net_vesting_shares > VOTE_WEIGHT_DROPDOWN_THRESHOLD;
 
+        const currentAccountData = state.global.getIn(['accounts', username]);
+        const votingData = computeVotingData(currentAccountData);
         return {
             post: ownProps.post,
             showList: ownProps.showList,
@@ -678,6 +680,7 @@ export default connect(
             voting,
             price_per_steem,
             sbd_print_rate,
+            votingData,
         };
     },
 

--- a/src/app/components/elements/Voting.scss
+++ b/src/app/components/elements/Voting.scss
@@ -293,6 +293,20 @@
     color: $dark-gray;
     line-height: 2.6rem;
   }
+  .voting-power-display {
+    float: left;
+    margin-right: 0.5rem;
+    text-align: right;
+    color: $dark-gray;
+    line-height: 2.6rem;
+  }
+  .voting-est-display {
+    float: left;
+    margin-right: 0.5rem;
+    text-align: right;
+    color: $dark-gray;
+    line-height: 2.6rem;
+  }
   a.confirm_weight {
     float: left;
     width: 2rem;

--- a/src/app/locales/add_missing.js
+++ b/src/app/locales/add_missing.js
@@ -1,0 +1,17 @@
+// for LANG in es fr it ja ko pl ru zh; do echo $LANG; node add_missing.js en $LANG > tmp.json ; mv tmp.json $LANG.json ; done
+
+const fs = require('fs');
+const lodash = require('lodash');
+
+const locale = process.argv[2];
+const otherLocale = process.argv[3];
+
+const currentJson = fs.readFileSync(`${locale}.json`);
+const otherJson = fs.readFileSync(`${otherLocale}.json`);
+
+const current = JSON.parse(currentJson);
+const other = JSON.parse(otherJson);
+
+const modified = lodash.merge(current, other);
+
+console.log(JSON.stringify(modified, null, 4));

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -452,7 +452,9 @@
         },
         "must_reached_minimum_payout": "(amount must reach $0.02 for payout)",
         "payout": "Payout",
-        "breakdown": "Breakdown"
+        "breakdown": "Breakdown",
+        "voting_power": "Voting Power",
+        "estimated_vote": "Estimated Vote Value"
     },
     "votesandcomments_jsx": {
         "no_responses_yet_click_to_respond":

--- a/src/app/locales/es.json
+++ b/src/app/locales/es.json
@@ -12,6 +12,7 @@
         "blog": "Blog",
         "browse": "Navegar",
         "buy": "Comprar",
+        "buy_steem_power": "Buy Steem Power",
         "buy_or_sell": "Comprar o Vender",
         "by": "por",
         "cancel": "Cancelar",
@@ -28,6 +29,10 @@
         "dismiss": "Descartar",
         "edit": "Editar",
         "email": "Email",
+        "external_link_message":
+            "This link will take you away from steemit.com",
+        "affiliation_steemit": "Steemit Team",
+        "affiliation_sm": "Steem Monsters Team",
         "feed": "Favoritos",
         "follow": "Seguir",
         "for": "para",
@@ -38,12 +43,18 @@
         "in_reply_to": "en respuesta a",
         "insufficient_balance": "Saldo insuficiente",
         "invalid_amount": "Cantidad inválida",
+        "links": "Links",
         "joined": "Unió",
         "loading": "Cargando",
         "login": "Iniciar sesión",
         "logout": "Cerrar sesión",
         "memo": "Memo",
         "mute": "Silenciar",
+        "my_blog": "My blog",
+        "my_comments": "My comments",
+        "my_feed": "My feed",
+        "my_replies": "Replies to me",
+        "my_wallet": "My wallet",
         "new": "nuevo",
         "newer": "Nuevo",
         "next": "Próximo",
@@ -58,7 +69,7 @@
         "phishy_message":
             "Enlace expuesto a texto sin formato; cuidado con un posible intento de phishing",
         "post": "Publicación",
-        "post_as": "Publicar como",
+        "post_as_user": "Post as %(username)s",
         "posts": "Publicaciones",
         "powered_up_100": "Powered Up 100 %%",
         "preview": "Vista previa",
@@ -69,6 +80,7 @@
         "promoted": "promocionado",
         "re": "RE",
         "re_to": "RE %(topic)s",
+        "read_offical_blog": "Steemit Blog",
         "recent_password": "Contraseña reciente",
         "receive": "Recibir",
         "remove": "Quitar",
@@ -83,6 +95,7 @@
         },
         "reputation": "Reputación",
         "reveal_comment": "Mostrar Comentario",
+        "will_be_hidden_due_to_low_rating": "Will be hidden due to low rating",
         "request": "solicitud",
         "required": "Requerido",
         "rewards": "Recompensa",
@@ -101,9 +114,13 @@
         "submit_a_story": "Publicar",
         "tag": "Etiqueta",
         "to": "hasta",
+        "topics": "Topics",
+        "toggle_nightmode": "Toggle Night Mode",
         "all_tags": "All tags",
+        "all_tags_mobile": "All content",
         "transfer": "Transferir",
         "trending_topics": "Temas Tendencia",
+        "try_again": "Try Again",
         "type": "Tipo",
         "unfollow": "Dejar de seguir",
         "unmute": "Desmutear",
@@ -238,19 +255,22 @@
             "warning":
                 "Los usuarios legítimos, incluidos los empleados de Steemit Inc., nunca le pedirán una clave privada o contraseña maestra.",
             "checkbox": "Entiendo"
-        }
+        },
+        "post_as": "Publicar como"
     },
     "navigation": {
         "about": "Sobre",
         "explore": "Explorar",
         "APP_NAME_whitepaper": "%(APP_NAME)s Documentación técnica",
+        "third_party_exchanges": "Third-party exchanges:",
         "buy_LIQUID_TOKEN": "Comprar %(LIQUID_TOKEN)s",
         "sell_LIQUID_TOKEN": "Vender %(LIQUID_TOKEN)s",
         "currency_market": "Mercado de monedas",
         "stolen_account_recovery": "Recuperación de cuentas robadas",
         "change_account_password": "Cambia la contraseña de la cuenta",
-        "witnesses": "Testigos",
         "vote_for_witnesses": "Vota a los testigos",
+        "advertise": "Advertise",
+        "media_kit": "Media Kit",
         "privacy_policy": "Política de Privacidad",
         "terms_of_service": "Términos del Servicio",
         "sign_up": "Unirse",
@@ -266,7 +286,10 @@
         "whitepaper": "Libro blanco de Steem",
         "intro_tagline": "El dinero habla.",
         "intro_paragraph":
-            "Tu voz tiene valor. Únete a la comunidad que te paga por publicar y votar contenido de alta calidad"
+            "Tu voz tiene valor. Únete a la comunidad que te paga por publicar y votar contenido de alta calidad",
+        "jobs": "Jobs at Steemit",
+        "steem_proposals": "Steem Proposals",
+        "witnesses": "Testigos"
     },
     "main_menu": {
         "hot": "en alza",
@@ -330,11 +353,19 @@
         "must_end_with_a_letter_or_number":
             "Debe terminar con una letra o número"
     },
+    "post_advanced_settings_jsx": {
+        "payout_option_header": "Author rewards",
+        "payout_option_description":
+            "What type of tokens do you want as rewards from this post?",
+        "current_default": "Default",
+        "update_default_in_settings": "Update"
+    },
     "postfull_jsx": {
         "this_post_is_not_available_due_to_a_copyright_claim":
             "Este post no está disponible por reclamación de derechos de autor.",
         "share_on_facebook": "Compartir en Facebook",
         "share_on_twitter": "Compartir en Twitter",
+        "share_on_reddit": "Share on Reddit",
         "share_on_linkedin": "Compartir en Linkedin",
         "recent_password": "Contraseña reciente",
         "in_week_convert_DEBT_TOKEN_to_LIQUID_TOKEN":
@@ -390,7 +421,13 @@
             "Mostrando ahora comentarios con bajas calificaciones",
         "sort_order": "Clase de órden",
         "comments_were_hidden_due_to_low_ratings":
-            "Los comentarios fueron ocultados debido a las bajas calificaciones"
+            "Los comentarios fueron ocultados debido a las bajas calificaciones",
+        "comment_sort_order": {
+            "trending": "Trending",
+            "votes": "Votes",
+            "age": "Age",
+            "reputation": "Reputation"
+        }
     },
     "voting_jsx": {
         "flagging_post_can_remove_rewards_the_flag_should_be_used_for_the_following":
@@ -408,17 +445,28 @@
         "past_payouts": "Pagos pasados $ %(value)s",
         "past_payouts_author": "Autor $ %(value)s",
         "past_payouts_curators": "Curador $ %(value)s",
-        "we_will_reset_curation_rewards_for_this_post":
-            "Reseteará tus recompensas de curación para este post",
         "removing_your_vote": "Quitando tu voto",
+        "removing_your_vote_will_reset_curation_rewards_for_this_post":
+            "Removing your vote will reset your curation rewards for this post",
         "changing_to_an_upvote": "Cambiando a Up-vote",
+        "changing_to_an_upvote_will_reset_curation_rewards_for_this_post":
+            "Changing to an Up-Vote will reset your curation rewards for this post",
         "changing_to_a_downvote": "Cambiando a Down-Vote",
+        "changing_to_a_downvote_will_reset_curation_rewards_for_this_post":
+            "Changing to a Down-Vote will reset your curation rewards for this post",
         "confirm_flag": "Confirmar Flag",
         "and_more": "y %(count)s más",
         "votes_plural": {
             "one": "%(count)s voto",
             "other": "%(count)s votos"
-        }
+        },
+        "must_reached_minimum_payout": "(amount must reach $0.02 for payout)",
+        "payout": "Payout",
+        "breakdown": "Breakdown",
+        "voting_power": "Voting Power",
+        "estimated_vote": "Estimated Vote Value",
+        "we_will_reset_curation_rewards_for_this_post":
+            "Reseteará tus recompensas de curación para este post"
     },
     "votesandcomments_jsx": {
         "no_responses_yet_click_to_respond":
@@ -518,7 +566,9 @@
             "Si recientemente has añadido a gente para seguir, tu feed personalizado aparecerá una vez que el contenido esté disponible",
         "empty_feed_3": "Explorar artículos en tendencia",
         "empty_feed_4": "leer la guía básica para comenzar",
-        "empty_feed_5": "Explorar la FAQ"
+        "empty_feed_5": "Explorar la FAQ",
+        "my_feed": "My Feed",
+        "accountnames_feed": "%(account_name)s's Feed"
     },
     "explorepost_jsx": {
         "copied": "¡Copiado!",
@@ -578,15 +628,42 @@
         "keep_me_logged_in": "Manténme logeado",
         "amazing_community": "comunidad increíble",
         "to_comment_and_reward_others": "para comentar y recompensar a otros",
-        "sign_up_get_steem": "Crea una cuenta. Comienza en STEEM",
         "signup_button": "Crea una cuenta, comienza a ganar ",
         "signup_button_emphasis": "FREE STEEM!",
+        "sign_up_get_steem": "Crea una cuenta. Comienza en STEEM",
         "returning_users": "Inicia sesion",
+        "login_warning_title": "Logging in with non-posting key",
+        "login_warning_body":
+            "You are attempting to use a key with more permissions than required for everyday Steemit.com use. Since keys and passwords are more likely to get compromised the more they are used, it is strongly recommended to only use your Posting Key to log in.",
+        "continue_anyway": "Continue Anyway",
+        "login_warning_link_text":
+            "Open my Steemit Wallet to access and view my posting key",
         "join_our": "Únete a nuestro",
         "sign_transfer": "Sign to complete transfer",
         "use_keychain": "Use keychain extension"
     },
     "chainvalidation_js": {
+        "account_name_should_not_be_empty": "Account name should not be empty.",
+        "account_name_should_be_longer": "Account name should be longer.",
+        "account_name_should_be_shorter": "Account name should be shorter.",
+        "each_account_segment_should_start_with_a_letter":
+            "Each account segment should start with a letter.",
+        "each_account_segment_should_have_only_letters_digits_or_dashes":
+            "Each account segment should have only letters, digits, or dashes.",
+        "each_account_segment_should_have_only_one_dash_in_a_row":
+            "Each account segment should have only one dash in a row.",
+        "each_account_segment_should_end_with_a_letter_or_digit":
+            "Each account segment should end with a letter or digit.",
+        "each_account_segment_should_be_longer":
+            "Each account segment should be longer.",
+        "verified_exchange_no_memo":
+            "Tienes que incluir un memo para la transferencia al exchange",
+        "badactor":
+            "Use caution sending to this account. Please double check your spelling for possible phishing.",
+        "memo_has_privatekey":
+            "Please do not include what appears to be a private key or password.",
+        "memo_is_privatekey": "Do not use private keys in memos.",
+        "memo_is_password": "Do not use passwords in memos.",
         "account_name_should": "El nombre de la cuenta debería",
         "not_be_empty": "No estar vacío",
         "be_longer": "ser más largo",
@@ -596,9 +673,7 @@
         "have_only_letters_digits_or_dashes":
             "tener sólo letras, dígitos o guiones.",
         "have_only_one_dash_in_a_row": "tener sólo un guión consecutivo.",
-        "end_with_a_letter_or_digit": "terminar con una legra o dígito.",
-        "verified_exchange_no_memo":
-            "Tienes que incluir un memo para la transferencia al exchange"
+        "end_with_a_letter_or_digit": "terminar con una legra o dígito."
     },
     "settings_jsx": {
         "invalid_url": "URL inválida",
@@ -613,14 +688,19 @@
         "always_hide": "Ocultar siempre",
         "always_warn": "Advertir siempre",
         "always_show": "Mostrar siempre",
+        "choose_default_blog_payout": "Blog post rewards",
+        "choose_default_comment_payout": "Comment post rewards",
         "muted_users": "Usuarios silenciados",
         "update": "Actualizar",
+        "upload_image": "Upload an image",
+        "uploading_image": "Uploading image",
         "profile_image_url": "Link para la foto de perfil",
         "cover_image_url": "Link para la imagen de fondo",
         "profile_name": "Nombre de visualización",
         "profile_about": "Sobre",
         "profile_location": "Localización",
-        "profile_website": "Página Web"
+        "profile_website": "Página Web",
+        "saved": "Saved!"
     },
     "transfer_jsx": {
         "amount_is_in_form": "La cantidad está en el formato 99999.999",
@@ -643,9 +723,15 @@
         "asset_currently_collecting":
             "%(asset)s recolectando actualmente %(interest)s%% APR.",
         "beware_of_spam_and_phishing_links":
-            "Tenga cuidado con los enlaces de spam y phishing en los memos de transferencia. No abra enlaces de usuarios en los que no confíe. No proporcione sus claves privadas a sitios web de terceros."
+            "Tenga cuidado con los enlaces de spam y phishing en los memos de transferencia. No abra enlaces de usuarios en los que no confíe. No proporcione sus claves privadas a sitios web de terceros.",
+        "transactions_make_take_a_few_minutes":
+            "Transactions will not show until they are confirmed on the blockchain, which may take a few minutes.",
+        "autocomplete_previous_transfers": "previous transfers",
+        "autocomplete_user_following": "following",
+        "confirm_transfer": "Transfer %(amount)s from %(from)s to %(to)s?"
     },
     "userwallet_jsx": {
+        "transfer": "Transfer",
         "conversion_complete_tip": "Se completará el",
         "in_conversion": "%(amount)s en conversión",
         "transfer_to_savings": "Transferir a ahorros",
@@ -657,6 +743,8 @@
         "withdraw_DEBT_TOKENS": "Retirar %(DEBT_TOKENS)s",
         "tokens_worth_about_1_of_LIQUID_TICKER":
             "Los tokens valen alrededor de $1.00 de %(LIQUID_TICKER)s, ahora mismo recolectando %(sbdInterest)s%% APR.",
+        "tradeable_tokens_transferred":
+            "Tradeable tokens that may be transferred anywhere at anytime.",
         "savings": "AHORROS",
         "estimated_account_value": "Valor de cuenta aproximado",
         "next_power_down_is_scheduled_to_happen":
@@ -674,5 +762,36 @@
         "ownership_changed_on": "Pertenencia cambio el",
         "deadline_for_recovery_is": "La fecha límite para la recuperación es",
         "i_understand_dont_show_again": "Lo entiendo, no mostrarmelo de nuevo."
+    },
+    "termsagree_jsx": {
+        "please_review": "Please review our terms to continue",
+        "hi_user": "Hi %(username)s,",
+        "blurb":
+            "Our Terms of Service set the rules and guidelines that you must accept and follow in order to use Steemit and our Privacy Policy explains the type of information we collect and what we do with it. Don't worry, we don't sell your data to anyone. We do use it to meet legal requirements and to learn how to make Steemit better.",
+        "i_agree_to_steemits": "I agree to Steemit's",
+        "terms_of_service": "Terms of Service",
+        "privacy_policy": "Privacy Policy",
+        "continue": "Continue",
+        "cancel": "Cancel"
+    },
+    "confirmtransactionform_jsx": {
+        "confirm": "Confirm %(transactionType)s"
+    },
+    "modals_jsx": {
+        "your_transaction_failed": "Your transaction failed to process",
+        "out_of_bandwidth_title": "Why? You've run out of Resource Credits",
+        "out_of_bandwidth_reason":
+            "Actions such as posting and voting use computing resources, placing a real cost on the community members who run the Steem blockchain for everyone.",
+        "out_of_bandwidth_reason_2":
+            "To keep things free, Steem intelligently allocates Resource Credits to each user based on their Steem Power holdings, which can be used to submit a limited number of feeless transactions. When a user runs low on Resource Credits, they will either need to wait for them to recharge, or purchase additional Steem Power. This system prioritizes actions by good community members while limiting spam.",
+        "out_of_bandwidth_option_title": "To keep interacting on Steemit:",
+        "out_of_bandwidth_option_1": "Buy and hold more Steem Power",
+        "out_of_bandwidth_option_2":
+            "Wait until your Resource Credits recharge",
+        "out_of_bandwidth_option_3": "Wait until the network usage decreases"
+    },
+    "sanitizedlink_jsx": {
+        "phishylink_caution": "Link hidden; phishing attempt",
+        "phishylink_reveal": "show link"
     }
 }

--- a/src/app/locales/fr.json
+++ b/src/app/locales/fr.json
@@ -12,6 +12,7 @@
         "blog": "Blog",
         "browse": "Naviguer",
         "buy": "Acheter",
+        "buy_steem_power": "Buy Steem Power",
         "buy_or_sell": "Acheter ou vendre",
         "by": "par",
         "cancel": "Annuler",
@@ -28,6 +29,10 @@
         "dismiss": "Ignorer",
         "edit": "Editer",
         "email": "Email",
+        "external_link_message":
+            "This link will take you away from steemit.com",
+        "affiliation_steemit": "Steemit Team",
+        "affiliation_sm": "Steem Monsters Team",
         "feed": "Flux",
         "follow": "S'abonner",
         "for": "pour",
@@ -38,8 +43,8 @@
         "in_reply_to": "en réponse à",
         "insufficient_balance": "Solde insuffisant",
         "invalid_amount": "Montant invalide",
-        "joined": "Inscrit en",
         "links": "Liens",
+        "joined": "Inscrit en",
         "loading": "Chargement en cours",
         "login": "Se connecter",
         "logout": "Déconnexion",
@@ -64,7 +69,7 @@
         "phishy_message":
             "Link expanded to plain text; beware of a potential phishing attempt",
         "post": "Poster",
-        "post_as": "Poster en tant que",
+        "post_as_user": "Post as %(username)s",
         "posts": "Articles",
         "powered_up_100": "Converti en influence à 100%%",
         "preview": "Prévisualiser",
@@ -75,6 +80,7 @@
         "promoted": "promu",
         "re": "RE",
         "re_to": "RE :%(topic)s",
+        "read_offical_blog": "Steemit Blog",
         "recent_password": "Mot de passe antérieur",
         "receive": "Recevoir",
         "remove": "Enlever",
@@ -89,6 +95,7 @@
         },
         "reputation": "Réputation",
         "reveal_comment": "Révéler le commentaire",
+        "will_be_hidden_due_to_low_rating": "Will be hidden due to low rating",
         "request": "requête",
         "required": "Requis",
         "rewards": "Gains",
@@ -107,9 +114,13 @@
         "submit_a_story": "Poster",
         "tag": "Mot clé",
         "to": "vers",
+        "topics": "Topics",
+        "toggle_nightmode": "Toggle Night Mode",
         "all_tags": "Tous les clés",
+        "all_tags_mobile": "All content",
         "transfer": "Transférer",
         "trending_topics": "Sujets en vogue",
+        "try_again": "Try Again",
         "type": "Genre",
         "unfollow": "Se désabonner",
         "unmute": "Ne plus ignorer",
@@ -247,19 +258,22 @@
             "warning":
                 "Legitimate users, including employees of Steemit Inc., will never ask you for a private key or master password.",
             "checkbox": "I understand"
-        }
+        },
+        "post_as": "Poster en tant que"
     },
     "navigation": {
         "about": "A propos",
         "explore": "Explorer",
         "APP_NAME_whitepaper": "%(APP_NAME)s livre blanc",
+        "third_party_exchanges": "Third-party exchanges:",
         "buy_LIQUID_TOKEN": "Acheter %(LIQUID_TOKEN)s",
         "sell_LIQUID_TOKEN": "Vendre %(LIQUID_TOKEN)s",
         "currency_market": "Marché des devises",
         "stolen_account_recovery": "Récupération de comptes dérobés",
         "change_account_password": "Changement de mot de passe",
-        "witnesses": "Témoins",
         "vote_for_witnesses": "Voter pour les témoins",
+        "advertise": "Advertise",
+        "media_kit": "Media Kit",
         "privacy_policy": "Politique de confidentialité",
         "terms_of_service": "Conditions d'utilisation",
         "sign_up": "Rejoindre",
@@ -270,12 +284,15 @@
         "app_center": "Centre d'applications Steemit",
         "business_center": "Businesses Accepting Steem",
         "api_docs": "Documentation API sur Steemit",
-        "whitepaper": "Livre blanc sur le Steem",
         "bluepaper": "Steem Bluepaper",
         "smt_whitepaper": "Livre blanc sur le SMT",
+        "whitepaper": "Livre blanc sur le Steem",
         "intro_tagline": "Présentations sur la monnaie",
         "intro_paragraph":
-            "Votre voix vaut quelque chose. Rejoignez la communauté qui vous rémunère pour vos articles et participez à la curation du contenu de qualité."
+            "Votre voix vaut quelque chose. Rejoignez la communauté qui vous rémunère pour vos articles et participez à la curation du contenu de qualité.",
+        "jobs": "Jobs at Steemit",
+        "steem_proposals": "Steem Proposals",
+        "witnesses": "Témoins"
     },
     "main_menu": {
         "hot": "chaud",
@@ -353,6 +370,7 @@
             "Cet article n'est pas disponible en raison d'une requête de droits d'auteur.",
         "share_on_facebook": "Partager sur Facebook",
         "share_on_twitter": "Partager sur Twitter",
+        "share_on_reddit": "Share on Reddit",
         "share_on_linkedin": "Partager sur Linkedin",
         "recent_password": "Mot de passe antérieur",
         "in_week_convert_DEBT_TOKEN_to_LIQUID_TOKEN":
@@ -408,7 +426,13 @@
             "Affichant à présent les commentaires de faible évaluation",
         "sort_order": "Classer les ordres",
         "comments_were_hidden_due_to_low_ratings":
-            "Certains commentaires sont masqués en raison de leur faible évaluation"
+            "Certains commentaires sont masqués en raison de leur faible évaluation",
+        "comment_sort_order": {
+            "trending": "Trending",
+            "votes": "Votes",
+            "age": "Age",
+            "reputation": "Reputation"
+        }
     },
     "voting_jsx": {
         "flagging_post_can_remove_rewards_the_flag_should_be_used_for_the_following":
@@ -425,17 +449,28 @@
         "past_payouts": "Gains antérieurs: %(value)s$",
         "past_payouts_author": "- Auteur: %(value)s$",
         "past_payouts_curators": "Curateurs: %(value)s$",
-        "we_will_reset_curation_rewards_for_this_post":
-            "cela annulera vos potentiels gains de curation pour cet article",
         "removing_your_vote": "Enlever votre vote",
+        "removing_your_vote_will_reset_curation_rewards_for_this_post":
+            "Removing your vote will reset your curation rewards for this post",
         "changing_to_an_upvote": "Modifier pour un vote positif",
+        "changing_to_an_upvote_will_reset_curation_rewards_for_this_post":
+            "Changing to an Up-Vote will reset your curation rewards for this post",
         "changing_to_a_downvote": "Modifier pour un vote négatif",
+        "changing_to_a_downvote_will_reset_curation_rewards_for_this_post":
+            "Changing to a Down-Vote will reset your curation rewards for this post",
         "confirm_flag": "Confirmer la signalisation",
         "and_more": "et %(count)s en plus",
         "votes_plural": {
             "one": "%(count)s vote",
             "other": "%(count)s votes"
-        }
+        },
+        "must_reached_minimum_payout": "(amount must reach $0.02 for payout)",
+        "payout": "Payout",
+        "breakdown": "Breakdown",
+        "voting_power": "Voting Power",
+        "estimated_vote": "Estimated Vote Value",
+        "we_will_reset_curation_rewards_for_this_post":
+            "cela annulera vos potentiels gains de curation pour cet article"
     },
     "votesandcomments_jsx": {
         "no_responses_yet_click_to_respond":
@@ -537,7 +572,8 @@
         "empty_feed_3": "Explorer les articles en vogue",
         "empty_feed_4": "Lire le guide de prise en main rapide",
         "empty_feed_5": "Parcourir la FAQ",
-        "my_feed": "Mon Flux"
+        "my_feed": "Mon Flux",
+        "accountnames_feed": "%(account_name)s's Feed"
     },
     "explorepost_jsx": {
         "copied": "Copié!",
@@ -599,15 +635,42 @@
         "amazing_community": "communauté extraordinaire",
         "to_comment_and_reward_others":
             " pour commenter et récompenser les autres.",
-        "sign_up_get_steem": "Sign up. Get STEEM",
         "signup_button": "Sign up now to earn ",
         "signup_button_emphasis": "FREE STEEM!",
+        "sign_up_get_steem": "Sign up. Get STEEM",
         "returning_users": "Utilisateurs de retour: ",
+        "login_warning_title": "Logging in with non-posting key",
+        "login_warning_body":
+            "You are attempting to use a key with more permissions than required for everyday Steemit.com use. Since keys and passwords are more likely to get compromised the more they are used, it is strongly recommended to only use your Posting Key to log in.",
+        "continue_anyway": "Continue Anyway",
+        "login_warning_link_text":
+            "Open my Steemit Wallet to access and view my posting key",
         "join_our": "Rejoignez notre",
         "sign_transfer": "Sign to complete transfer",
         "use_keychain": "Use keychain extension"
     },
     "chainvalidation_js": {
+        "account_name_should_not_be_empty": "Account name should not be empty.",
+        "account_name_should_be_longer": "Account name should be longer.",
+        "account_name_should_be_shorter": "Account name should be shorter.",
+        "each_account_segment_should_start_with_a_letter":
+            "Each account segment should start with a letter.",
+        "each_account_segment_should_have_only_letters_digits_or_dashes":
+            "Each account segment should have only letters, digits, or dashes.",
+        "each_account_segment_should_have_only_one_dash_in_a_row":
+            "Each account segment should have only one dash in a row.",
+        "each_account_segment_should_end_with_a_letter_or_digit":
+            "Each account segment should end with a letter or digit.",
+        "each_account_segment_should_be_longer":
+            "Each account segment should be longer.",
+        "verified_exchange_no_memo":
+            "Vous devez inclure un mémo pour votre transfert vers un marché d'échanges.",
+        "badactor":
+            "Use caution sending to this account. Please double check your spelling for possible phishing.",
+        "memo_has_privatekey":
+            "Please do not include what appears to be a private key or password.",
+        "memo_is_privatekey": "Do not use private keys in memos.",
+        "memo_is_password": "Do not use passwords in memos.",
         "account_name_should": "Le nom du compte doit ",
         "not_be_empty": "ne peut pas être vide.",
         "be_longer": "être plus long.",
@@ -617,9 +680,7 @@
         "have_only_letters_digits_or_dashes":
             "ne comporter que des lettres, des chiffres ou des traits d'union.",
         "have_only_one_dash_in_a_row": "n'avoir qu'un seul trait d'union.",
-        "end_with_a_letter_or_digit": "terminer par une lettre ou un chiffre.",
-        "verified_exchange_no_memo":
-            "Vous devez inclure un mémo pour votre transfert vers un marché d'échanges."
+        "end_with_a_letter_or_digit": "terminer par une lettre ou un chiffre."
     },
     "settings_jsx": {
         "invalid_url": "L'URL est invalide",
@@ -635,14 +696,19 @@
         "always_hide": "Toujours masquer",
         "always_warn": "Toujours avertir",
         "always_show": "Toujours montrer",
+        "choose_default_blog_payout": "Blog post rewards",
+        "choose_default_comment_payout": "Comment post rewards",
         "muted_users": "Utilisateurs ignorés",
         "update": "Mise à jour",
+        "upload_image": "Upload an image",
+        "uploading_image": "Uploading image",
         "profile_image_url": "URL de la photo de profil",
         "cover_image_url": "URL de l'image de couverture",
         "profile_name": "Nom à afficher",
         "profile_about": "A propos",
         "profile_location": "Lieu",
-        "profile_website": "Site internet"
+        "profile_website": "Site internet",
+        "saved": "Saved!"
     },
     "transfer_jsx": {
         "amount_is_in_form": "Montant dans le format 99999.999",
@@ -667,9 +733,15 @@
         "asset_currently_collecting":
             "%(asset)s collectant actuellement %(interest)s %% d'APR.",
         "beware_of_spam_and_phishing_links":
-            "Beware of spam and phishing links in transfer memos. Do not open links from users you do not trust. Do not provide your private keys to any third party websites."
+            "Beware of spam and phishing links in transfer memos. Do not open links from users you do not trust. Do not provide your private keys to any third party websites.",
+        "transactions_make_take_a_few_minutes":
+            "Transactions will not show until they are confirmed on the blockchain, which may take a few minutes.",
+        "autocomplete_previous_transfers": "previous transfers",
+        "autocomplete_user_following": "following",
+        "confirm_transfer": "Transfer %(amount)s from %(from)s to %(to)s?"
     },
     "userwallet_jsx": {
+        "transfer": "Transfer",
         "conversion_complete_tip": "S'achèvera le",
         "in_conversion": "%(amount)s en conversion",
         "transfer_to_savings": "Transfert vers l'épargne",
@@ -681,6 +753,8 @@
         "withdraw_DEBT_TOKENS": "Retirer %(DEBT_TOKENS)s",
         "tokens_worth_about_1_of_LIQUID_TICKER":
             "Des jetons d'environ 1.00$ de %(LIQUID_TICKER)s, actuellement donnant lieu à %(sbdInterest)s %% d'APR.",
+        "tradeable_tokens_transferred":
+            "Tradeable tokens that may be transferred anywhere at anytime.",
         "savings": "EPARGNE",
         "estimated_account_value": "Valeur estimée du compte",
         "next_power_down_is_scheduled_to_happen":
@@ -700,5 +774,36 @@
         "deadline_for_recovery_is": "La date limite de récupération est",
         "i_understand_dont_show_again":
             "J'ai compris, ne me le montrez plus jamais"
+    },
+    "termsagree_jsx": {
+        "please_review": "Please review our terms to continue",
+        "hi_user": "Hi %(username)s,",
+        "blurb":
+            "Our Terms of Service set the rules and guidelines that you must accept and follow in order to use Steemit and our Privacy Policy explains the type of information we collect and what we do with it. Don't worry, we don't sell your data to anyone. We do use it to meet legal requirements and to learn how to make Steemit better.",
+        "i_agree_to_steemits": "I agree to Steemit's",
+        "terms_of_service": "Terms of Service",
+        "privacy_policy": "Privacy Policy",
+        "continue": "Continue",
+        "cancel": "Cancel"
+    },
+    "confirmtransactionform_jsx": {
+        "confirm": "Confirm %(transactionType)s"
+    },
+    "modals_jsx": {
+        "your_transaction_failed": "Your transaction failed to process",
+        "out_of_bandwidth_title": "Why? You've run out of Resource Credits",
+        "out_of_bandwidth_reason":
+            "Actions such as posting and voting use computing resources, placing a real cost on the community members who run the Steem blockchain for everyone.",
+        "out_of_bandwidth_reason_2":
+            "To keep things free, Steem intelligently allocates Resource Credits to each user based on their Steem Power holdings, which can be used to submit a limited number of feeless transactions. When a user runs low on Resource Credits, they will either need to wait for them to recharge, or purchase additional Steem Power. This system prioritizes actions by good community members while limiting spam.",
+        "out_of_bandwidth_option_title": "To keep interacting on Steemit:",
+        "out_of_bandwidth_option_1": "Buy and hold more Steem Power",
+        "out_of_bandwidth_option_2":
+            "Wait until your Resource Credits recharge",
+        "out_of_bandwidth_option_3": "Wait until the network usage decreases"
+    },
+    "sanitizedlink_jsx": {
+        "phishylink_caution": "Link hidden; phishing attempt",
+        "phishylink_reveal": "show link"
     }
 }

--- a/src/app/locales/it.json
+++ b/src/app/locales/it.json
@@ -12,6 +12,7 @@
         "blog": "Blog",
         "browse": "Naviga",
         "buy": "Acquista",
+        "buy_steem_power": "Buy Steem Power",
         "buy_or_sell": "Acquista o vendi",
         "by": "da",
         "cancel": "Cancella",
@@ -28,6 +29,10 @@
         "dismiss": "Abbandona",
         "edit": "Modifica",
         "email": "Email",
+        "external_link_message":
+            "This link will take you away from steemit.com",
+        "affiliation_steemit": "Steemit Team",
+        "affiliation_sm": "Steem Monsters Team",
         "feed": "Feed",
         "follow": "Segui",
         "for": "per",
@@ -38,12 +43,18 @@
         "in_reply_to": "in risposta a",
         "insufficient_balance": "Credito insufficiente",
         "invalid_amount": "Importo errato",
+        "links": "Links",
         "joined": "Connesso",
         "loading": "Caricamento",
         "login": "Login",
         "logout": "Logout",
         "memo": "Memo",
         "mute": "Silenzia",
+        "my_blog": "My blog",
+        "my_comments": "My comments",
+        "my_feed": "My feed",
+        "my_replies": "Replies to me",
+        "my_wallet": "My wallet",
         "new": "Nuovo",
         "newer": "Più recente",
         "next": "Prossimo",
@@ -58,7 +69,7 @@
         "phishy_message":
             "Link expanded to plain text; beware of a potential phishing attempt",
         "post": "Post",
-        "post_as": "Pubblica come",
+        "post_as_user": "Post as %(username)s",
         "posts": "Posts",
         "powered_up_100": "Powered Up 100%%",
         "preview": "Anteprima",
@@ -69,6 +80,7 @@
         "promoted": "promosso",
         "re": "RE",
         "re_to": "RE: %(topic)s",
+        "read_offical_blog": "Steemit Blog",
         "recent_password": "Password Recente",
         "receive": "Ricevi",
         "remove": "Rimuovi",
@@ -83,6 +95,7 @@
         },
         "reputation": "Reputazione",
         "reveal_comment": "Mostra Commento",
+        "will_be_hidden_due_to_low_rating": "Will be hidden due to low rating",
         "request": "richiesta",
         "required": "Richiesto",
         "rewards": "Ricompense",
@@ -101,9 +114,13 @@
         "submit_a_story": "Post",
         "tag": "Tag",
         "to": "a",
+        "topics": "Topics",
+        "toggle_nightmode": "Toggle Night Mode",
         "all_tags": "All tags",
+        "all_tags_mobile": "All content",
         "transfer": "Trasferisci",
         "trending_topics": "Trending Topics",
+        "try_again": "Try Again",
         "type": "Scrivi",
         "unfollow": "Non seguire più",
         "unmute": "Unmute",
@@ -239,19 +256,22 @@
             "warning":
                 "Legitimate users, including employees of Steemit Inc., will never ask you for a private key or master password.",
             "checkbox": "I understand"
-        }
+        },
+        "post_as": "Pubblica come"
     },
     "navigation": {
         "about": "Circa",
         "explore": "Esplora",
         "APP_NAME_whitepaper": "%(APP_NAME)s Whitepaper",
+        "third_party_exchanges": "Third-party exchanges:",
         "buy_LIQUID_TOKEN": "Compra %(LIQUID_TOKEN)s",
         "sell_LIQUID_TOKEN": "Vendi %(LIQUID_TOKEN)s",
         "currency_market": "Mercato della valuta",
         "stolen_account_recovery": "Recupero degli Account Rubati",
         "change_account_password": "Cambia la password dell'account",
-        "witnesses": "Witness",
         "vote_for_witnesses": "Vota per i Witness",
+        "advertise": "Advertise",
+        "media_kit": "Media Kit",
         "privacy_policy": "Privacy Policy",
         "terms_of_service": "Condizioni di servizio",
         "sign_up": "Entra",
@@ -267,7 +287,10 @@
         "whitepaper": "Steem Whitepaper",
         "intro_tagline": "Il denaro parla",
         "intro_paragraph":
-            "La tua voce vale qualcosa. Entra nella community che ti paga per pubblicare e curare contenuti di alta qualità."
+            "La tua voce vale qualcosa. Entra nella community che ti paga per pubblicare e curare contenuti di alta qualità.",
+        "jobs": "Jobs at Steemit",
+        "steem_proposals": "Steem Proposals",
+        "witnesses": "Witness"
     },
     "main_menu": {
         "hot": "hot",
@@ -342,6 +365,7 @@
             "Questo post non è disponibile per violazione del copyright.",
         "share_on_facebook": "Condividi su Facebook",
         "share_on_twitter": "Condividi su Twitter",
+        "share_on_reddit": "Share on Reddit",
         "share_on_linkedin": "Condividi su Linkedin",
         "recent_password": "Password recente",
         "in_week_convert_DEBT_TOKEN_to_LIQUID_TOKEN":
@@ -396,7 +420,13 @@
             "Commenti con voti bassi rivelati",
         "sort_order": "Ordinamento",
         "comments_were_hidden_due_to_low_ratings":
-            "Commenti nascosti a causa del basso rating"
+            "Commenti nascosti a causa del basso rating",
+        "comment_sort_order": {
+            "trending": "Trending",
+            "votes": "Votes",
+            "age": "Age",
+            "reputation": "Reputation"
+        }
     },
     "voting_jsx": {
         "flagging_post_can_remove_rewards_the_flag_should_be_used_for_the_following":
@@ -414,17 +444,28 @@
         "past_payouts": "Pagamenti precedenti di %(value)s $",
         "past_payouts_author": "- Autore %(value)s $",
         "past_payouts_curators": "- Curatori %(value)s $",
-        "we_will_reset_curation_rewards_for_this_post":
-            "sarà effettuato il reset delle ricompense del curatore in questo post. ",
         "removing_your_vote": "Rimuovi il tuo voto",
+        "removing_your_vote_will_reset_curation_rewards_for_this_post":
+            "Removing your vote will reset your curation rewards for this post",
         "changing_to_an_upvote": "Cambia in un upvote",
+        "changing_to_an_upvote_will_reset_curation_rewards_for_this_post":
+            "Changing to an Up-Vote will reset your curation rewards for this post",
         "changing_to_a_downvote": "Cambia in un downvote",
+        "changing_to_a_downvote_will_reset_curation_rewards_for_this_post":
+            "Changing to a Down-Vote will reset your curation rewards for this post",
         "confirm_flag": "Conferma il flag",
         "and_more": "e %(count)s in più",
         "votes_plural": {
             "one": "%(count)s voto",
             "other": "%(count)s voti"
-        }
+        },
+        "must_reached_minimum_payout": "(amount must reach $0.02 for payout)",
+        "payout": "Payout",
+        "breakdown": "Breakdown",
+        "voting_power": "Voting Power",
+        "estimated_vote": "Estimated Vote Value",
+        "we_will_reset_curation_rewards_for_this_post":
+            "sarà effettuato il reset delle ricompense del curatore in questo post. "
     },
     "votesandcomments_jsx": {
         "no_responses_yet_click_to_respond":
@@ -523,7 +564,9 @@
             "Se hai da poco aggiunto nuovi utenti da seguire, quando ci saranno nuovi contenuti disponibili li vedrai nel tuo feed personalizzato.",
         "empty_feed_3": "Esplora gli Articoli in Trending",
         "empty_feed_4": "Leggi la Guida di Avvio Rapido",
-        "empty_feed_5": "Leggi le FAQ"
+        "empty_feed_5": "Leggi le FAQ",
+        "my_feed": "My Feed",
+        "accountnames_feed": "%(account_name)s's Feed"
     },
     "explorepost_jsx": {
         "copied": "Copiato!",
@@ -584,15 +627,42 @@
         "keep_me_logged_in": "Voglio restare connesso",
         "amazing_community": "una comunità incredibile",
         "to_comment_and_reward_others": "per commentare e premiare gli altri. ",
-        "sign_up_get_steem": "Sign up. Get STEEM",
         "signup_button": "Sign up now to earn ",
         "signup_button_emphasis": "FREE STEEM!",
+        "sign_up_get_steem": "Sign up. Get STEEM",
         "returning_users": "Utenti di ritorno:",
+        "login_warning_title": "Logging in with non-posting key",
+        "login_warning_body":
+            "You are attempting to use a key with more permissions than required for everyday Steemit.com use. Since keys and passwords are more likely to get compromised the more they are used, it is strongly recommended to only use your Posting Key to log in.",
+        "continue_anyway": "Continue Anyway",
+        "login_warning_link_text":
+            "Open my Steemit Wallet to access and view my posting key",
         "join_our": "Unisciti al nostro",
         "sign_transfer": "Sign to complete transfer",
         "use_keychain": "Use keychain extension"
     },
     "chainvalidation_js": {
+        "account_name_should_not_be_empty": "Account name should not be empty.",
+        "account_name_should_be_longer": "Account name should be longer.",
+        "account_name_should_be_shorter": "Account name should be shorter.",
+        "each_account_segment_should_start_with_a_letter":
+            "Each account segment should start with a letter.",
+        "each_account_segment_should_have_only_letters_digits_or_dashes":
+            "Each account segment should have only letters, digits, or dashes.",
+        "each_account_segment_should_have_only_one_dash_in_a_row":
+            "Each account segment should have only one dash in a row.",
+        "each_account_segment_should_end_with_a_letter_or_digit":
+            "Each account segment should end with a letter or digit.",
+        "each_account_segment_should_be_longer":
+            "Each account segment should be longer.",
+        "verified_exchange_no_memo":
+            "Devi includere una memo per il trasferimento.",
+        "badactor":
+            "Use caution sending to this account. Please double check your spelling for possible phishing.",
+        "memo_has_privatekey":
+            "Please do not include what appears to be a private key or password.",
+        "memo_is_privatekey": "Do not use private keys in memos.",
+        "memo_is_password": "Do not use passwords in memos.",
         "account_name_should": "Il nome account",
         "not_be_empty": "non deve essere vuoto.",
         "be_longer": "essere più lungo.",
@@ -602,9 +672,7 @@
         "have_only_letters_digits_or_dashes":
             "avere solo lettere, cifre o trattini.",
         "have_only_one_dash_in_a_row": "avere solo un trattino per riga. ",
-        "end_with_a_letter_or_digit": "terminare con una lettera o una cifra.",
-        "verified_exchange_no_memo":
-            "Devi includere una memo per il trasferimento."
+        "end_with_a_letter_or_digit": "terminare con una lettera o una cifra."
     },
     "settings_jsx": {
         "invalid_url": "URL invalido",
@@ -620,14 +688,19 @@
         "always_hide": "Nascondi sempre",
         "always_warn": "Avverti sempre",
         "always_show": "Mostra sempre",
+        "choose_default_blog_payout": "Blog post rewards",
+        "choose_default_comment_payout": "Comment post rewards",
         "muted_users": "Utenti mutati",
         "update": "Aggiornamento",
+        "upload_image": "Upload an image",
+        "uploading_image": "Uploading image",
         "profile_image_url": "Url immagine profilo",
         "cover_image_url": "Url immagine di copertina",
         "profile_name": "Mostra nome",
         "profile_about": "About",
         "profile_location": "Località",
-        "profile_website": "Sito"
+        "profile_website": "Sito",
+        "saved": "Saved!"
     },
     "transfer_jsx": {
         "amount_is_in_form": "La quantita deve essere della forma 99999.999",
@@ -651,9 +724,15 @@
         "asset_currently_collecting":
             "%(asset)s attualmente percepiscono %(interest)s%% ISC.",
         "beware_of_spam_and_phishing_links":
-            "Beware of spam and phishing links in transfer memos. Do not open links from users you do not trust. Do not provide your private keys to any third party websites."
+            "Beware of spam and phishing links in transfer memos. Do not open links from users you do not trust. Do not provide your private keys to any third party websites.",
+        "transactions_make_take_a_few_minutes":
+            "Transactions will not show until they are confirmed on the blockchain, which may take a few minutes.",
+        "autocomplete_previous_transfers": "previous transfers",
+        "autocomplete_user_following": "following",
+        "confirm_transfer": "Transfer %(amount)s from %(from)s to %(to)s?"
     },
     "userwallet_jsx": {
+        "transfer": "Transfer",
         "conversion_complete_tip": "Si completerà su",
         "in_conversion": "%(amount)s in conversione",
         "transfer_to_savings": "Sposta nei Risparmi",
@@ -665,6 +744,8 @@
         "withdraw_DEBT_TOKENS": "Preleva %(DEBT_TOKENS)s",
         "tokens_worth_about_1_of_LIQUID_TICKER":
             "I token valgono circa $1.00 di %(LIQUID_TICKER)s, attualmente percepiscono %(sbdInterest)s%% ISC.",
+        "tradeable_tokens_transferred":
+            "Tradeable tokens that may be transferred anywhere at anytime.",
         "savings": "RISPARMI",
         "estimated_account_value": "Valore stimato dell'account",
         "next_power_down_is_scheduled_to_happen":
@@ -683,5 +764,36 @@
         "ownership_changed_on": "Proprietà Cambiata Su",
         "deadline_for_recovery_is": "Il termine per il ripristino è",
         "i_understand_dont_show_again": "Ho capito, non mostrare nuovamente"
+    },
+    "termsagree_jsx": {
+        "please_review": "Please review our terms to continue",
+        "hi_user": "Hi %(username)s,",
+        "blurb":
+            "Our Terms of Service set the rules and guidelines that you must accept and follow in order to use Steemit and our Privacy Policy explains the type of information we collect and what we do with it. Don't worry, we don't sell your data to anyone. We do use it to meet legal requirements and to learn how to make Steemit better.",
+        "i_agree_to_steemits": "I agree to Steemit's",
+        "terms_of_service": "Terms of Service",
+        "privacy_policy": "Privacy Policy",
+        "continue": "Continue",
+        "cancel": "Cancel"
+    },
+    "confirmtransactionform_jsx": {
+        "confirm": "Confirm %(transactionType)s"
+    },
+    "modals_jsx": {
+        "your_transaction_failed": "Your transaction failed to process",
+        "out_of_bandwidth_title": "Why? You've run out of Resource Credits",
+        "out_of_bandwidth_reason":
+            "Actions such as posting and voting use computing resources, placing a real cost on the community members who run the Steem blockchain for everyone.",
+        "out_of_bandwidth_reason_2":
+            "To keep things free, Steem intelligently allocates Resource Credits to each user based on their Steem Power holdings, which can be used to submit a limited number of feeless transactions. When a user runs low on Resource Credits, they will either need to wait for them to recharge, or purchase additional Steem Power. This system prioritizes actions by good community members while limiting spam.",
+        "out_of_bandwidth_option_title": "To keep interacting on Steemit:",
+        "out_of_bandwidth_option_1": "Buy and hold more Steem Power",
+        "out_of_bandwidth_option_2":
+            "Wait until your Resource Credits recharge",
+        "out_of_bandwidth_option_3": "Wait until the network usage decreases"
+    },
+    "sanitizedlink_jsx": {
+        "phishylink_caution": "Link hidden; phishing attempt",
+        "phishylink_reveal": "show link"
     }
 }

--- a/src/app/locales/ja.json
+++ b/src/app/locales/ja.json
@@ -12,6 +12,7 @@
         "blog": "ブログ",
         "browse": "ブラウズ",
         "buy": "買う",
+        "buy_steem_power": "Buy Steem Power",
         "buy_or_sell": "購入または売却",
         "by": "by",
         "cancel": "キャンセル",
@@ -28,6 +29,10 @@
         "dismiss": "閉じる",
         "edit": "編集",
         "email": "メールアドレス",
+        "external_link_message":
+            "This link will take you away from steemit.com",
+        "affiliation_steemit": "Steemit Team",
+        "affiliation_sm": "Steem Monsters Team",
         "feed": "フィード",
         "follow": "フォロー",
         "for": " : ",
@@ -38,12 +43,18 @@
         "in_reply_to": "in reply to",
         "insufficient_balance": "残高が不足しています",
         "invalid_amount": "入力が不正です",
+        "links": "Links",
         "joined": "登録年月：",
         "loading": "ロード中",
         "login": "ログイン",
         "logout": "ログアウト",
         "memo": "メモ",
         "mute": "ミュート",
+        "my_blog": "My blog",
+        "my_comments": "My comments",
+        "my_feed": "My feed",
+        "my_replies": "Replies to me",
+        "my_wallet": "My wallet",
         "new": "新着",
         "newer": "新しい",
         "next": "次へ",
@@ -58,7 +69,7 @@
         "phishy_message":
             "リンクをプレーンテキストに拡張しました。潜在的なフィッシングに注意してください。",
         "post": "投稿",
-        "post_as": "投稿します:",
+        "post_as_user": "Post as %(username)s",
         "posts": "投稿数",
         "powered_up_100": "パワーアップ 100%%",
         "preview": "プレビュー",
@@ -69,6 +80,7 @@
         "promoted": "プロモート",
         "re": "RE",
         "re_to": "RE: %(topic)s",
+        "read_offical_blog": "Steemit Blog",
         "recent_password": "直近のパスワード",
         "receive": "受信 ",
         "remove": "削除",
@@ -83,6 +95,7 @@
         },
         "reputation": "評価",
         "reveal_comment": "コメントを表示する",
+        "will_be_hidden_due_to_low_rating": "Will be hidden due to low rating",
         "request": "リクエスト",
         "required": "必須です",
         "rewards": "報酬",
@@ -104,8 +117,10 @@
         "topics": "トピック",
         "toggle_nightmode": "ナイトモード切替",
         "all_tags": "すべてのタグ",
+        "all_tags_mobile": "All content",
         "transfer": "送信 ",
         "trending_topics": "トレンドトピック",
+        "try_again": "Try Again",
         "type": "売買",
         "unfollow": "フォロー解除",
         "unmute": "ミュート解除",
@@ -237,19 +252,22 @@
             "warning":
                 "Steemit Inc.の従業員を含む正当なユーザーは秘密キーまたはマスターパスワードを要求することはありません。",
             "checkbox": "理解しました。"
-        }
+        },
+        "post_as": "投稿します:"
     },
     "navigation": {
         "about": "Steemについて",
         "explore": "投稿を探す",
         "APP_NAME_whitepaper": "%(APP_NAME)sホワイトペーパー",
+        "third_party_exchanges": "Third-party exchanges:",
         "buy_LIQUID_TOKEN": "%(LIQUID_TOKEN)sを買う",
         "sell_LIQUID_TOKEN": "%(LIQUID_TOKEN)sを売る",
         "currency_market": "内部取引所",
         "stolen_account_recovery": "盗難アカウントの回復",
         "change_account_password": "パスワードの変更",
-        "witnesses": "証人",
         "vote_for_witnesses": "証人に投票する",
+        "advertise": "Advertise",
+        "media_kit": "Media Kit",
         "privacy_policy": "プライバシーポリシー",
         "terms_of_service": "利用規約",
         "sign_up": "登録",
@@ -261,10 +279,14 @@
         "business_center": "Businesses Accepting Steem",
         "api_docs": "Steemit API資料",
         "bluepaper": "Steemブルーペーパー",
+        "smt_whitepaper": "SMT Whitepaper",
         "whitepaper": "Steemホワイトペーパー",
         "intro_tagline": "金がものを言う",
         "intro_paragraph":
-            "あなたの声には価値があります。あなたのハイクオリティな投稿やキュレーションに報酬を出すコミュニティに参加しましょう。"
+            "あなたの声には価値があります。あなたのハイクオリティな投稿やキュレーションに報酬を出すコミュニティに参加しましょう。",
+        "jobs": "Jobs at Steemit",
+        "steem_proposals": "Steem Proposals",
+        "witnesses": "証人"
     },
     "main_menu": {
         "hot": "ホット",
@@ -340,6 +362,7 @@
             "この投稿は著作権上の問題により表示されません。",
         "share_on_facebook": "Facebookでシェア",
         "share_on_twitter": "Twitterでシェア",
+        "share_on_reddit": "Share on Reddit",
         "share_on_linkedin": "Linkedinでシェア",
         "recent_password": "直近のパスワード",
         "in_week_convert_DEBT_TOKEN_to_LIQUID_TOKEN":
@@ -394,7 +417,13 @@
             "評価の低いコメントを表示しています。",
         "sort_order": "並べ替え",
         "comments_were_hidden_due_to_low_ratings":
-            "コメントは評価が低いため表示されません。"
+            "コメントは評価が低いため表示されません。",
+        "comment_sort_order": {
+            "trending": "Trending",
+            "votes": "Votes",
+            "age": "Age",
+            "reputation": "Reputation"
+        }
     },
     "voting_jsx": {
         "flagging_post_can_remove_rewards_the_flag_should_be_used_for_the_following":
@@ -411,17 +440,28 @@
         "past_payouts": "支払い済み $%(value)s",
         "past_payouts_author": " - 投稿者 $%(value)s",
         "past_payouts_curators": " - キュレーター $%(value)s",
-        "we_will_reset_curation_rewards_for_this_post":
-            "ことにより、この投稿へのキュレーション報酬はリセットされます",
         "removing_your_vote": "投票を削除する",
+        "removing_your_vote_will_reset_curation_rewards_for_this_post":
+            "Removing your vote will reset your curation rewards for this post",
         "changing_to_an_upvote": "Upvoteに変更する",
+        "changing_to_an_upvote_will_reset_curation_rewards_for_this_post":
+            "Changing to an Up-Vote will reset your curation rewards for this post",
         "changing_to_a_downvote": "Downvoteに変更する",
+        "changing_to_a_downvote_will_reset_curation_rewards_for_this_post":
+            "Changing to a Down-Vote will reset your curation rewards for this post",
         "confirm_flag": "フラグの確認",
         "and_more": "他%(count)s人",
         "votes_plural": {
             "one": "%(count)s件の投票",
             "other": "%(count)s件の投票"
-        }
+        },
+        "must_reached_minimum_payout": "(amount must reach $0.02 for payout)",
+        "payout": "Payout",
+        "breakdown": "Breakdown",
+        "voting_power": "Voting Power",
+        "estimated_vote": "Estimated Vote Value",
+        "we_will_reset_curation_rewards_for_this_post":
+            "ことにより、この投稿へのキュレーション報酬はリセットされます"
     },
     "votesandcomments_jsx": {
         "no_responses_yet_click_to_respond":
@@ -508,13 +548,13 @@
     "postsummary_jsx": {
         "resteemed": "Resteemしました",
         "resteemed_by": "Resteemed by",
-        "this_post_is": "この投稿は",
-        "you_can": "You can",
         "reveal_it": "この投稿を表示する、",
         "adjust_your": "を変更してください。",
         "display_preferences": "表示設定",
         "create_an_account": "アカウントを作成して",
-        "to_save_your_preferences": "表示設定を行ってください。"
+        "to_save_your_preferences": "表示設定を行ってください。",
+        "this_post_is": "この投稿は",
+        "you_can": "You can"
     },
     "posts_index": {
         "empty_feed_1": "あなたはまだ誰もフォローしていないようです。",
@@ -522,7 +562,9 @@
             "最近新しいユーザーをフォローした場合、新しいコンテンツが有効になると個々のフィードに追加されます。",
         "empty_feed_3": "トレンド記事を検索する",
         "empty_feed_4": "クイックスタートガイドを読む",
-        "empty_feed_5": "FAQを参照する"
+        "empty_feed_5": "FAQを参照する",
+        "my_feed": "My Feed",
+        "accountnames_feed": "%(account_name)s's Feed"
     },
     "explorepost_jsx": {
         "copied": "コピーしました！",
@@ -587,11 +629,37 @@
         "signup_button_emphasis": "STEEMを手に入れよう！",
         "sign_up_get_steem": "登録してSTEEMを手に入れよう！",
         "returning_users": "再",
+        "login_warning_title": "Logging in with non-posting key",
+        "login_warning_body":
+            "You are attempting to use a key with more permissions than required for everyday Steemit.com use. Since keys and passwords are more likely to get compromised the more they are used, it is strongly recommended to only use your Posting Key to log in.",
+        "continue_anyway": "Continue Anyway",
+        "login_warning_link_text":
+            "Open my Steemit Wallet to access and view my posting key",
         "join_our": "",
         "sign_transfer": "Sign to complete transfer",
         "use_keychain": "Use keychain extension"
     },
     "chainvalidation_js": {
+        "account_name_should_not_be_empty": "Account name should not be empty.",
+        "account_name_should_be_longer": "Account name should be longer.",
+        "account_name_should_be_shorter": "Account name should be shorter.",
+        "each_account_segment_should_start_with_a_letter":
+            "Each account segment should start with a letter.",
+        "each_account_segment_should_have_only_letters_digits_or_dashes":
+            "Each account segment should have only letters, digits, or dashes.",
+        "each_account_segment_should_have_only_one_dash_in_a_row":
+            "Each account segment should have only one dash in a row.",
+        "each_account_segment_should_end_with_a_letter_or_digit":
+            "Each account segment should end with a letter or digit.",
+        "each_account_segment_should_be_longer":
+            "Each account segment should be longer.",
+        "verified_exchange_no_memo": "取引所へ送信するときはメモが必要です。",
+        "badactor":
+            "Use caution sending to this account. Please double check your spelling for possible phishing.",
+        "memo_has_privatekey":
+            "Please do not include what appears to be a private key or password.",
+        "memo_is_privatekey": "Do not use private keys in memos.",
+        "memo_is_password": "Do not use passwords in memos.",
         "account_name_should": "アカウント名",
         "not_be_empty": "が入力されていません。",
         "be_longer": "が短すぎます。",
@@ -601,8 +669,7 @@
         "have_only_letters_digits_or_dashes":
             "には英数字またはダッシュのみが使用できます。",
         "have_only_one_dash_in_a_row": "にはダッシュを1つだけ使用可能です。",
-        "end_with_a_letter_or_digit": "は英数字で終わります。",
-        "verified_exchange_no_memo": "取引所へ送信するときはメモが必要です。"
+        "end_with_a_letter_or_digit": "は英数字で終わります。"
     },
     "settings_jsx": {
         "invalid_url": "無効なURL",
@@ -612,19 +679,25 @@
         "location_is_too_long": "場所が長すぎます",
         "website_url_is_too_long": "URLが長すぎます",
         "public_profile_settings": "公開プロフィール設定",
-        "private_post_display_settings": "ローカル表示設定",
+        "preferences": "Preferences",
         "not_safe_for_work_nsfw_content": "閲覧注意 (NSFW) コンテンツ",
         "always_hide": "常に非表示",
         "always_warn": "常に警告する",
         "always_show": "常に表示",
+        "choose_default_blog_payout": "Blog post rewards",
+        "choose_default_comment_payout": "Comment post rewards",
         "muted_users": "ミュートユーザー",
         "update": "更新",
+        "upload_image": "Upload an image",
+        "uploading_image": "Uploading image",
         "profile_image_url": "プロフィール画像URL",
         "cover_image_url": "カバー画像URL",
         "profile_name": "表示名",
         "profile_about": "概要",
         "profile_location": "場所",
-        "profile_website": "ウェブサイト"
+        "profile_website": "ウェブサイト",
+        "saved": "Saved!",
+        "private_post_display_settings": "ローカル表示設定"
     },
     "transfer_jsx": {
         "amount_is_in_form": "金額は99999.999の形式です",
@@ -648,9 +721,15 @@
         "asset_currently_collecting":
             "%(asset)sの現在の利子は年間%(interest)s%%です。",
         "beware_of_spam_and_phishing_links":
-            "送金メモのスパムやフィッシングに注意してください。信用していないユーザーからのリンクを開かないでください。第三者のウェブサイトに秘密キーを提供しないでください。"
+            "送金メモのスパムやフィッシングに注意してください。信用していないユーザーからのリンクを開かないでください。第三者のウェブサイトに秘密キーを提供しないでください。",
+        "transactions_make_take_a_few_minutes":
+            "Transactions will not show until they are confirmed on the blockchain, which may take a few minutes.",
+        "autocomplete_previous_transfers": "previous transfers",
+        "autocomplete_user_following": "following",
+        "confirm_transfer": "Transfer %(amount)s from %(from)s to %(to)s?"
     },
     "userwallet_jsx": {
+        "transfer": "Transfer",
         "conversion_complete_tip": "変換完了予定",
         "in_conversion": "%(amount)sが変換中です",
         "transfer_to_savings": "貯蓄口座に送る",
@@ -662,6 +741,8 @@
         "withdraw_DEBT_TOKENS": "%(DEBT_TOKENS)sを引き出す",
         "tokens_worth_about_1_of_LIQUID_TICKER":
             "約$1.00の%(LIQUID_TICKER)sと同じ価値のトークンです。現在、利子が年間%(sbdInterest)s%%つきます。",
+        "tradeable_tokens_transferred":
+            "Tradeable tokens that may be transferred anywhere at anytime.",
         "savings": "貯蓄口座",
         "estimated_account_value": "推定アカウント価格",
         "next_power_down_is_scheduled_to_happen":
@@ -680,5 +761,36 @@
         "ownership_changed_on": "所有権変更：",
         "deadline_for_recovery_is": "アカウント回復の期限は",
         "i_understand_dont_show_again": "理解しました。再表示は不要です。"
+    },
+    "termsagree_jsx": {
+        "please_review": "Please review our terms to continue",
+        "hi_user": "Hi %(username)s,",
+        "blurb":
+            "Our Terms of Service set the rules and guidelines that you must accept and follow in order to use Steemit and our Privacy Policy explains the type of information we collect and what we do with it. Don't worry, we don't sell your data to anyone. We do use it to meet legal requirements and to learn how to make Steemit better.",
+        "i_agree_to_steemits": "I agree to Steemit's",
+        "terms_of_service": "Terms of Service",
+        "privacy_policy": "Privacy Policy",
+        "continue": "Continue",
+        "cancel": "Cancel"
+    },
+    "confirmtransactionform_jsx": {
+        "confirm": "Confirm %(transactionType)s"
+    },
+    "modals_jsx": {
+        "your_transaction_failed": "Your transaction failed to process",
+        "out_of_bandwidth_title": "Why? You've run out of Resource Credits",
+        "out_of_bandwidth_reason":
+            "Actions such as posting and voting use computing resources, placing a real cost on the community members who run the Steem blockchain for everyone.",
+        "out_of_bandwidth_reason_2":
+            "To keep things free, Steem intelligently allocates Resource Credits to each user based on their Steem Power holdings, which can be used to submit a limited number of feeless transactions. When a user runs low on Resource Credits, they will either need to wait for them to recharge, or purchase additional Steem Power. This system prioritizes actions by good community members while limiting spam.",
+        "out_of_bandwidth_option_title": "To keep interacting on Steemit:",
+        "out_of_bandwidth_option_1": "Buy and hold more Steem Power",
+        "out_of_bandwidth_option_2":
+            "Wait until your Resource Credits recharge",
+        "out_of_bandwidth_option_3": "Wait until the network usage decreases"
+    },
+    "sanitizedlink_jsx": {
+        "phishylink_caution": "Link hidden; phishing attempt",
+        "phishylink_reveal": "show link"
     }
 }

--- a/src/app/locales/ko.json
+++ b/src/app/locales/ko.json
@@ -12,6 +12,7 @@
         "blog": "블로그",
         "browse": "Browse",
         "buy": "구매",
+        "buy_steem_power": "Buy Steem Power",
         "buy_or_sell": "구입/판매",
         "by": "by",
         "cancel": "취소",
@@ -28,6 +29,10 @@
         "dismiss": "확인",
         "edit": "수정",
         "email": "Email",
+        "external_link_message":
+            "This link will take you away from steemit.com",
+        "affiliation_steemit": "Steemit Team",
+        "affiliation_sm": "Steem Monsters Team",
         "feed": "피드",
         "follow": "팔로우",
         "for": " for ",
@@ -38,6 +43,7 @@
         "in_reply_to": "in reply to",
         "insufficient_balance": "잔고 부족",
         "invalid_amount": "잘못된 금액",
+        "links": "Links",
         "joined": "가입일",
         "loading": "로딩중..",
         "login": "로그인",
@@ -46,7 +52,9 @@
         "mute": "차단",
         "my_blog": "내 블로그",
         "my_comments": "내가 쓴 댓글",
+        "my_feed": "My feed",
         "my_replies": "받은 댓글",
+        "my_wallet": "My wallet",
         "new": "최신글",
         "newer": "최근",
         "next": "다음",
@@ -61,7 +69,7 @@
         "phishy_message":
             "Link expanded to plain text; beware of a potential phishing attempt",
         "post": "글쓰기",
-        "post_as": "Post as",
+        "post_as_user": "Post as %(username)s",
         "posts": "Posts",
         "powered_up_100": "Powered Up 100%%",
         "preview": "Preview",
@@ -72,6 +80,7 @@
         "promoted": "홍보글",
         "re": "RE",
         "re_to": "RE: %(topic)s",
+        "read_offical_blog": "Steemit Blog",
         "recent_password": "Recent Password",
         "receive": "Receive ",
         "remove": "Remove",
@@ -86,6 +95,7 @@
         },
         "reputation": "평판",
         "reveal_comment": "댓글 보이기",
+        "will_be_hidden_due_to_low_rating": "Will be hidden due to low rating",
         "request": "request",
         "required": "Required",
         "rewards": "보상",
@@ -107,8 +117,10 @@
         "topics": "Topics",
         "toggle_nightmode": "야간모드",
         "all_tags": "전체 태그",
+        "all_tags_mobile": "All content",
         "transfer": "송금 ",
         "trending_topics": "Trending Topics",
+        "try_again": "Try Again",
         "type": "Type",
         "unfollow": "언팔로우",
         "unmute": "차단 해제",
@@ -236,19 +248,22 @@
             "warning":
                 "Steemit Inc.의 직원을 포함한 합법적 인 사용자는 어떠한 경우에도 개인 키 또는 마스터 비밀번호를 요구하지 않습니다.",
             "checkbox": "네 이해합니다."
-        }
+        },
+        "post_as": "Post as"
     },
     "navigation": {
         "about": "스팀이란?",
         "explore": "태그별 현황",
         "APP_NAME_whitepaper": "%(APP_NAME)s 백서",
+        "third_party_exchanges": "Third-party exchanges:",
         "buy_LIQUID_TOKEN": "%(LIQUID_TOKEN)s 구매",
         "sell_LIQUID_TOKEN": "%(LIQUID_TOKEN)s 판매",
         "currency_market": "거래소",
         "stolen_account_recovery": "도난 계정 복구",
         "change_account_password": "비밀번호 변경",
-        "witnesses": "증인",
         "vote_for_witnesses": "증인 투표",
+        "advertise": "Advertise",
+        "media_kit": "Media Kit",
         "privacy_policy": "개인정보 방침",
         "terms_of_service": "이용 약관",
         "sign_up": "가입",
@@ -264,7 +279,10 @@
         "whitepaper": "스팀 화이트페이퍼",
         "intro_tagline": "생각의 가치",
         "intro_paragraph":
-            "당신의 생각과 글은 소중합니다. 스팀잇은 고급 컨텐츠 생산자들과 큐레이터들에게 투명한 금전적 보상을 지원합니다. 지금 참여하세요."
+            "당신의 생각과 글은 소중합니다. 스팀잇은 고급 컨텐츠 생산자들과 큐레이터들에게 투명한 금전적 보상을 지원합니다. 지금 참여하세요.",
+        "jobs": "Jobs at Steemit",
+        "steem_proposals": "Steem Proposals",
+        "witnesses": "증인"
     },
     "main_menu": {
         "hot": "인기글",
@@ -338,6 +356,7 @@
             "This post is not available due to a copyright claim.",
         "share_on_facebook": "Facebook에 공유",
         "share_on_twitter": "Twitter에 공유",
+        "share_on_reddit": "Share on Reddit",
         "share_on_linkedin": "Linkedin에 공유",
         "recent_password": "최근 비밀번호",
         "in_week_convert_DEBT_TOKEN_to_LIQUID_TOKEN":
@@ -392,7 +411,13 @@
             "Now showing comments with low ratings",
         "sort_order": "정렬 순서",
         "comments_were_hidden_due_to_low_ratings":
-            "Comments were hidden due to low ratings"
+            "Comments were hidden due to low ratings",
+        "comment_sort_order": {
+            "trending": "Trending",
+            "votes": "Votes",
+            "age": "Age",
+            "reputation": "Reputation"
+        }
     },
     "voting_jsx": {
         "flagging_post_can_remove_rewards_the_flag_should_be_used_for_the_following":
@@ -410,17 +435,28 @@
         "past_payouts": "지급된 보상 $%(value)s",
         "past_payouts_author": " - 저자 $%(value)s",
         "past_payouts_curators": " - 큐레이터 $%(value)s",
-        "we_will_reset_curation_rewards_for_this_post":
-            "will reset your curation rewards for this post",
         "removing_your_vote": "보팅 취소",
+        "removing_your_vote_will_reset_curation_rewards_for_this_post":
+            "Removing your vote will reset your curation rewards for this post",
         "changing_to_an_upvote": "Changing to an Up-Vote",
+        "changing_to_an_upvote_will_reset_curation_rewards_for_this_post":
+            "Changing to an Up-Vote will reset your curation rewards for this post",
         "changing_to_a_downvote": "Changing to a Down-Vote",
+        "changing_to_a_downvote_will_reset_curation_rewards_for_this_post":
+            "Changing to a Down-Vote will reset your curation rewards for this post",
         "confirm_flag": "Confirm Flag",
         "and_more": "and %(count)s more",
         "votes_plural": {
             "one": "%(count)s 보팅",
             "other": "%(count)s 보팅"
-        }
+        },
+        "must_reached_minimum_payout": "(amount must reach $0.02 for payout)",
+        "payout": "Payout",
+        "breakdown": "Breakdown",
+        "voting_power": "보팅 파워",
+        "estimated_vote": "보팅 가치(추정치)",
+        "we_will_reset_curation_rewards_for_this_post":
+            "will reset your curation rewards for this post"
     },
     "votesandcomments_jsx": {
         "no_responses_yet_click_to_respond":
@@ -519,7 +555,9 @@
             "If you recently added new users to follow, your personalized feed will populate once new content is available",
         "empty_feed_3": "Explore Trending Articles",
         "empty_feed_4": "Read The Quick Start Guide",
-        "empty_feed_5": "Browse The FAQ"
+        "empty_feed_5": "Browse The FAQ",
+        "my_feed": "My Feed",
+        "accountnames_feed": "%(account_name)s's Feed"
     },
     "explorepost_jsx": {
         "copied": "Copied!",
@@ -585,11 +623,38 @@
         "sign_up_get_steem":
             "계정을 만들고 가상화폐 STEEM 을 보상으로 받으세요.",
         "returning_users": "Returning Users: ",
+        "login_warning_title": "Logging in with non-posting key",
+        "login_warning_body":
+            "You are attempting to use a key with more permissions than required for everyday Steemit.com use. Since keys and passwords are more likely to get compromised the more they are used, it is strongly recommended to only use your Posting Key to log in.",
+        "continue_anyway": "Continue Anyway",
+        "login_warning_link_text":
+            "Open my Steemit Wallet to access and view my posting key",
         "join_our": "Join our",
         "sign_transfer": "Sign to complete transfer",
         "use_keychain": "Use keychain extension"
     },
     "chainvalidation_js": {
+        "account_name_should_not_be_empty": "Account name should not be empty.",
+        "account_name_should_be_longer": "Account name should be longer.",
+        "account_name_should_be_shorter": "Account name should be shorter.",
+        "each_account_segment_should_start_with_a_letter":
+            "Each account segment should start with a letter.",
+        "each_account_segment_should_have_only_letters_digits_or_dashes":
+            "Each account segment should have only letters, digits, or dashes.",
+        "each_account_segment_should_have_only_one_dash_in_a_row":
+            "Each account segment should have only one dash in a row.",
+        "each_account_segment_should_end_with_a_letter_or_digit":
+            "Each account segment should end with a letter or digit.",
+        "each_account_segment_should_be_longer":
+            "Each account segment should be longer.",
+        "verified_exchange_no_memo":
+            "You must include a memo for your exchange transfer.",
+        "badactor":
+            "Use caution sending to this account. Please double check your spelling for possible phishing.",
+        "memo_has_privatekey":
+            "Please do not include what appears to be a private key or password.",
+        "memo_is_privatekey": "Do not use private keys in memos.",
+        "memo_is_password": "Do not use passwords in memos.",
         "account_name_should": "Account name should ",
         "not_be_empty": "not be empty.",
         "be_longer": "be longer.",
@@ -599,9 +664,7 @@
         "have_only_letters_digits_or_dashes":
             "have only letters, digits, or dashes.",
         "have_only_one_dash_in_a_row": "have only one dash in a row.",
-        "end_with_a_letter_or_digit": "end with a letter or digit.",
-        "verified_exchange_no_memo":
-            "You must include a memo for your exchange transfer."
+        "end_with_a_letter_or_digit": "end with a letter or digit."
     },
     "settings_jsx": {
         "invalid_url": "잘못된 URL 입니다",
@@ -616,14 +679,19 @@
         "always_hide": "항상 숨기기",
         "always_warn": "항상 경고하기",
         "always_show": "항상 보이기",
+        "choose_default_blog_payout": "Blog post rewards",
+        "choose_default_comment_payout": "Comment post rewards",
         "muted_users": "내가 차단한 사용자",
         "update": "저장",
+        "upload_image": "Upload an image",
+        "uploading_image": "Uploading image",
         "profile_image_url": "프로파일 사진 경로",
         "cover_image_url": "커버이미지 사진 경로",
         "profile_name": "닉네임",
         "profile_about": "한 줄 소개",
         "profile_location": "지역",
-        "profile_website": "웹사이트"
+        "profile_website": "웹사이트",
+        "saved": "Saved!"
     },
     "transfer_jsx": {
         "amount_is_in_form": "Amount is in the form 99999.999",
@@ -646,9 +714,15 @@
         "asset_currently_collecting":
             "%(asset)s의 연이율은 현재 %(interest)s%% 입니다.",
         "beware_of_spam_and_phishing_links":
-            "메모에는 스팸과 피싱 링크가 포함 될 수 있으니 주의하십시오. 신뢰할 수없는 사용자의 링크를 열지 마십시오. 또한 다른 어떤 웹 사이트에도 개인키를 공개하지 마십시오."
+            "메모에는 스팸과 피싱 링크가 포함 될 수 있으니 주의하십시오. 신뢰할 수없는 사용자의 링크를 열지 마십시오. 또한 다른 어떤 웹 사이트에도 개인키를 공개하지 마십시오.",
+        "transactions_make_take_a_few_minutes":
+            "Transactions will not show until they are confirmed on the blockchain, which may take a few minutes.",
+        "autocomplete_previous_transfers": "previous transfers",
+        "autocomplete_user_following": "following",
+        "confirm_transfer": "Transfer %(amount)s from %(from)s to %(to)s?"
     },
     "userwallet_jsx": {
+        "transfer": "Transfer",
         "conversion_complete_tip": "Will complete on",
         "in_conversion": "%(amount)s in conversion",
         "transfer_to_savings": "금고로 전송",
@@ -660,6 +734,8 @@
         "withdraw_DEBT_TOKENS": "%(DEBT_TOKENS)s 출금",
         "tokens_worth_about_1_of_LIQUID_TICKER":
             "%(LIQUID_TICKER)s의 1달러 가치가 있는 토큰입니다. 현재 연이율은 %(sbdInterest)s%% 입니다.",
+        "tradeable_tokens_transferred":
+            "Tradeable tokens that may be transferred anywhere at anytime.",
         "savings": "예금",
         "estimated_account_value": "추정 자산가치",
         "next_power_down_is_scheduled_to_happen": "다음 파워다운 예정:",
@@ -677,5 +753,36 @@
         "ownership_changed_on": "Ownership Changed On ",
         "deadline_for_recovery_is": "Deadline for recovery is",
         "i_understand_dont_show_again": "이 메시지를 다시 보지 않기"
+    },
+    "termsagree_jsx": {
+        "please_review": "Please review our terms to continue",
+        "hi_user": "Hi %(username)s,",
+        "blurb":
+            "Our Terms of Service set the rules and guidelines that you must accept and follow in order to use Steemit and our Privacy Policy explains the type of information we collect and what we do with it. Don't worry, we don't sell your data to anyone. We do use it to meet legal requirements and to learn how to make Steemit better.",
+        "i_agree_to_steemits": "I agree to Steemit's",
+        "terms_of_service": "Terms of Service",
+        "privacy_policy": "Privacy Policy",
+        "continue": "Continue",
+        "cancel": "Cancel"
+    },
+    "confirmtransactionform_jsx": {
+        "confirm": "Confirm %(transactionType)s"
+    },
+    "modals_jsx": {
+        "your_transaction_failed": "Your transaction failed to process",
+        "out_of_bandwidth_title": "Why? You've run out of Resource Credits",
+        "out_of_bandwidth_reason":
+            "Actions such as posting and voting use computing resources, placing a real cost on the community members who run the Steem blockchain for everyone.",
+        "out_of_bandwidth_reason_2":
+            "To keep things free, Steem intelligently allocates Resource Credits to each user based on their Steem Power holdings, which can be used to submit a limited number of feeless transactions. When a user runs low on Resource Credits, they will either need to wait for them to recharge, or purchase additional Steem Power. This system prioritizes actions by good community members while limiting spam.",
+        "out_of_bandwidth_option_title": "To keep interacting on Steemit:",
+        "out_of_bandwidth_option_1": "Buy and hold more Steem Power",
+        "out_of_bandwidth_option_2":
+            "Wait until your Resource Credits recharge",
+        "out_of_bandwidth_option_3": "Wait until the network usage decreases"
+    },
+    "sanitizedlink_jsx": {
+        "phishylink_caution": "Link hidden; phishing attempt",
+        "phishylink_reveal": "show link"
     }
 }

--- a/src/app/locales/pl.json
+++ b/src/app/locales/pl.json
@@ -12,6 +12,7 @@
         "blog": "Blog",
         "browse": "Przeglądaj",
         "buy": "Kup",
+        "buy_steem_power": "Buy Steem Power",
         "buy_or_sell": "Kup lub Sprzedaj",
         "by": "przez",
         "cancel": "Anuluj",
@@ -28,6 +29,10 @@
         "dismiss": "Odrzuć",
         "edit": "Edytuj",
         "email": "Email",
+        "external_link_message":
+            "This link will take you away from steemit.com",
+        "affiliation_steemit": "Steemit Team",
+        "affiliation_sm": "Steem Monsters Team",
         "feed": "Strumień",
         "follow": "Obserwuj",
         "for": "za",
@@ -38,6 +43,7 @@
         "in_reply_to": "w odpowiedzi do",
         "insufficient_balance": "Niewystarczające środki",
         "invalid_amount": "Niepoprawna ilość",
+        "links": "Links",
         "joined": "Dołączył",
         "loading": "Wczytywanie",
         "login": "Zaloguj",
@@ -46,7 +52,9 @@
         "mute": "Blokuj",
         "my_blog": "mój blog",
         "my_comments": "moje komentarze",
+        "my_feed": "My feed",
         "my_replies": "odpowiada mi",
+        "my_wallet": "My wallet",
         "new": "nowe",
         "newer": "Nowsze",
         "next": "Następny",
@@ -58,8 +66,10 @@
         "password": "Hasło",
         "payouts": "Płatności",
         "permissions": "Uprawnienia",
+        "phishy_message":
+            "Link expanded to plain text; beware of a potential phishing attempt",
         "post": "Napisz",
-        "post_as": "Napisz jako",
+        "post_as_user": "Post as %(username)s",
         "posts": "Posty",
         "powered_up_100": "Zwiększono moc 100%%",
         "preview": "Podgląd",
@@ -70,6 +80,7 @@
         "promoted": "promowane",
         "re": "ODP",
         "re_to": "ODP: %(topic)s",
+        "read_offical_blog": "Steemit Blog",
         "recent_password": "Niedawne hasło",
         "receive": "Odbierz",
         "remove": "Usuń",
@@ -84,6 +95,7 @@
         },
         "reputation": "Reputacja",
         "reveal_comment": "Odsłoń komentarz",
+        "will_be_hidden_due_to_low_rating": "Will be hidden due to low rating",
         "request": "prośba",
         "required": "Wymagany",
         "rewards": "Nagrody",
@@ -103,8 +115,12 @@
         "tag": "Tag",
         "to": "do",
         "topics": "Tematy",
+        "toggle_nightmode": "Toggle Night Mode",
+        "all_tags": "All tags",
+        "all_tags_mobile": "All content",
         "transfer": "Prześlij",
         "trending_topics": "Popularne tematy",
+        "try_again": "Try Again",
         "type": "Typ",
         "unfollow": "Przestań obserwować",
         "unmute": "Odblokuj",
@@ -228,19 +244,29 @@
             "zero": "Brak odpowiedzi",
             "one": "%(count)sodpowiedź",
             "other": "%(count)sodpowiedzi"
-        }
+        },
+        "post_key_warning": {
+            "confirm":
+                "You are about to publish a STEEM private key or master password. You will probably lose control of the associated account and all its funds.",
+            "warning":
+                "Legitimate users, including employees of Steemit Inc., will never ask you for a private key or master password.",
+            "checkbox": "I understand"
+        },
+        "post_as": "Napisz jako"
     },
     "navigation": {
         "about": "O Steem",
         "explore": "Przeglądaj",
         "APP_NAME_whitepaper": "%(APP_NAME)s Whitepaper",
+        "third_party_exchanges": "Third-party exchanges:",
         "buy_LIQUID_TOKEN": "Kup %(LIQUID_TOKEN)s",
         "sell_LIQUID_TOKEN": "Sprzedaj %(LIQUID_TOKEN)s",
         "currency_market": "Wymiana tokenów",
         "stolen_account_recovery": "Odzyskiwanie skradzionych kont",
         "change_account_password": "Zmiana hasła dla konta",
-        "witnesses": "Delegaci",
         "vote_for_witnesses": "Głosuj na delegatów",
+        "advertise": "Advertise",
+        "media_kit": "Media Kit",
         "privacy_policy": "Polityka prywatności",
         "terms_of_service": "Warunki korzystania z usługi",
         "sign_up": "Dołącz",
@@ -251,10 +277,15 @@
         "app_center": "Steemit App Center",
         "business_center": "Businesses Accepting Steem",
         "api_docs": "Dokumentacja Steemit API",
+        "bluepaper": "Steem Bluepaper",
+        "smt_whitepaper": "SMT Whitepaper",
         "whitepaper": "Steem Whitepaper",
         "intro_tagline": "Pieniądze mają głos.",
         "intro_paragraph":
-            "Twój głos ma wartość. Dołącz do społeczności, która płaci za publikowanie i głosowanie na wysokiej jakości treści."
+            "Twój głos ma wartość. Dołącz do społeczności, która płaci za publikowanie i głosowanie na wysokiej jakości treści.",
+        "jobs": "Jobs at Steemit",
+        "steem_proposals": "Steem Proposals",
+        "witnesses": "Delegaci"
     },
     "main_menu": {
         "hot": "gorące",
@@ -329,6 +360,7 @@
             "Ten wpis jest niedostępny z powodu roszczeń do praw autorskich.",
         "share_on_facebook": "Podziel się na Facebooku",
         "share_on_twitter": "Podziel się na Twitterze",
+        "share_on_reddit": "Share on Reddit",
         "share_on_linkedin": "Podziel się na Linkedin",
         "recent_password": "Ostatnie hasło",
         "in_week_convert_DEBT_TOKEN_to_LIQUID_TOKEN":
@@ -352,6 +384,12 @@
             "Wygląda na to, że użytkownik %(name)s jeszcze nikogo nie obserwuje. Jeśli %(name)s zaczął(ęła) obserwować nowych użytkowników jego(jej) osobisty strumień zacznie się zapełniać, gdy powstaną nowe treści.  ",
         "user_hasnt_had_any_replies_yet":
             "%(name)s nie ma jeszcze żadnych odpowiedzi",
+        "looks_like_you_havent_posted_anything_yet":
+            "Looks like you haven't posted anything yet.",
+        "create_a_post": "Create a Post",
+        "explore_trending_articles": "Explore Trending Articles",
+        "read_the_quick_start_guide": "Read The Quick Start Guide",
+        "browse_the_faq": "Browse The FAQ",
         "followers": "Obserwujący",
         "this_is_users_reputations_score_it_is_based_on_history_of_votes":
             "To są punkty reputacji użytkownika %(name)s.\n\nSystem punktów reputacji bazuje na historii otrzymanych przez użytkownika głosów i jest używany do ukrywania wpisów o niskiej jakości.",
@@ -378,7 +416,13 @@
             "Od teraz komentarze o niskich ocenach będą wyświetlane",
         "sort_order": "Kolejność sortowania",
         "comments_were_hidden_due_to_low_ratings":
-            "Komentarze zostały ukryte z powodu otrzymania niskich ocen"
+            "Komentarze zostały ukryte z powodu otrzymania niskich ocen",
+        "comment_sort_order": {
+            "trending": "Trending",
+            "votes": "Votes",
+            "age": "Age",
+            "reputation": "Reputation"
+        }
     },
     "voting_jsx": {
         "flagging_post_can_remove_rewards_the_flag_should_be_used_for_the_following":
@@ -396,17 +440,28 @@
         "past_payouts": "Wcześniejsze wypłaty $%(value)s",
         "past_payouts_author": "- Autor $%(value)s",
         "past_payouts_curators": "- Kuratorzy $%(value)s",
-        "we_will_reset_curation_rewards_for_this_post":
-            "wyzeruje twoje wynagrodzenie kuratorskie dla tego wpisu",
         "removing_your_vote": "Wycofanie twojego głosu",
+        "removing_your_vote_will_reset_curation_rewards_for_this_post":
+            "Removing your vote will reset your curation rewards for this post",
         "changing_to_an_upvote": "Zmień na głos za",
+        "changing_to_an_upvote_will_reset_curation_rewards_for_this_post":
+            "Changing to an Up-Vote will reset your curation rewards for this post",
         "changing_to_a_downvote": "Zmień na głos przeciw",
+        "changing_to_a_downvote_will_reset_curation_rewards_for_this_post":
+            "Changing to a Down-Vote will reset your curation rewards for this post",
         "confirm_flag": "Potwierdź oznaczenie flagą",
         "and_more": "i %(count)s więcej",
         "votes_plural": {
             "one": "%(count)s głos",
             "other": "%(count)s głosów"
-        }
+        },
+        "must_reached_minimum_payout": "(amount must reach $0.02 for payout)",
+        "payout": "Payout",
+        "breakdown": "Breakdown",
+        "voting_power": "Voting Power",
+        "estimated_vote": "Estimated Vote Value",
+        "we_will_reset_curation_rewards_for_this_post":
+            "wyzeruje twoje wynagrodzenie kuratorskie dla tego wpisu"
     },
     "votesandcomments_jsx": {
         "no_responses_yet_click_to_respond":
@@ -493,13 +548,13 @@
     "postsummary_jsx": {
         "resteemed": "Resteemowane",
         "resteemed_by": "Resteemowane przez",
-        "this_post_is": "Ten post jest",
-        "you_can": "Możesz",
         "reveal_it": "pokaż to",
         "adjust_your": "dostosuj twój",
         "display_preferences": "wyświetl ustawienia",
         "create_an_account": "utwórz konto",
-        "to_save_your_preferences": "by zapisać twoje preferencje"
+        "to_save_your_preferences": "by zapisać twoje preferencje",
+        "this_post_is": "Ten post jest",
+        "you_can": "Możesz"
     },
     "posts_index": {
         "empty_feed_1": "Wygląda na to, że jeszcze nikogo nie obserwujesz",
@@ -507,7 +562,9 @@
             "Jeżeli dopiero zacząłeś kogoś obserwować, twój strumień zaktualizuje się, gdy pojawią się nowe treści",
         "empty_feed_3": "Przeglądaj aktywne posty",
         "empty_feed_4": "Przeczytaj Quick Start Guide",
-        "empty_feed_5": "Przeglądaj FAQ"
+        "empty_feed_5": "Przeglądaj FAQ",
+        "my_feed": "My Feed",
+        "accountnames_feed": "%(account_name)s's Feed"
     },
     "explorepost_jsx": {
         "copied": "Skopiowano!",
@@ -568,14 +625,43 @@
         "keep_me_logged_in": "Nie wylogowuj mnie",
         "amazing_community": "niesamowitej społeczności",
         "to_comment_and_reward_others": " aby komentować i nagradzać innych.",
-        "sign_up_now_to_earn": "Zarejestruj się aby zarabiać ",
-        "free_money": "DARMOWY STEEM!",
+        "signup_button": "Sign up now to earn ",
+        "signup_button_emphasis": "FREE STEEM!",
+        "sign_up_get_steem": "Sign up. Get STEEM!",
         "returning_users": "Powracający użytkownicy: ",
+        "login_warning_title": "Logging in with non-posting key",
+        "login_warning_body":
+            "You are attempting to use a key with more permissions than required for everyday Steemit.com use. Since keys and passwords are more likely to get compromised the more they are used, it is strongly recommended to only use your Posting Key to log in.",
+        "continue_anyway": "Continue Anyway",
+        "login_warning_link_text":
+            "Open my Steemit Wallet to access and view my posting key",
         "join_our": "Dołącz do",
         "sign_transfer": "Sign to complete transfer",
-        "use_keychain": "Use keychain extension"
+        "use_keychain": "Use keychain extension",
+        "sign_up_now_to_earn": "Zarejestruj się aby zarabiać ",
+        "free_money": "DARMOWY STEEM!"
     },
     "chainvalidation_js": {
+        "account_name_should_not_be_empty": "Account name should not be empty.",
+        "account_name_should_be_longer": "Account name should be longer.",
+        "account_name_should_be_shorter": "Account name should be shorter.",
+        "each_account_segment_should_start_with_a_letter":
+            "Each account segment should start with a letter.",
+        "each_account_segment_should_have_only_letters_digits_or_dashes":
+            "Each account segment should have only letters, digits, or dashes.",
+        "each_account_segment_should_have_only_one_dash_in_a_row":
+            "Each account segment should have only one dash in a row.",
+        "each_account_segment_should_end_with_a_letter_or_digit":
+            "Each account segment should end with a letter or digit.",
+        "each_account_segment_should_be_longer":
+            "Each account segment should be longer.",
+        "verified_exchange_no_memo": "Musisz dodać memo w swoim transferze.",
+        "badactor":
+            "Use caution sending to this account. Please double check your spelling for possible phishing.",
+        "memo_has_privatekey":
+            "Please do not include what appears to be a private key or password.",
+        "memo_is_privatekey": "Do not use private keys in memos.",
+        "memo_is_password": "Do not use passwords in memos.",
         "account_name_should": "Nazwa konta powinna ",
         "not_be_empty": "nie być pusta.",
         "be_longer": "być dłuższa.",
@@ -585,8 +671,7 @@
         "have_only_letters_digits_or_dashes":
             "posiadać tylko litery, cyfry lub myślniki.",
         "have_only_one_dash_in_a_row": "posiadać tylko jeden myślnik pod rząd.",
-        "end_with_a_letter_or_digit": "kończyć się literą lub cyfrą.",
-        "verified_exchange_no_memo": "Musisz dodać memo w swoim transferze."
+        "end_with_a_letter_or_digit": "kończyć się literą lub cyfrą."
     },
     "settings_jsx": {
         "invalid_url": "Nieprawidłowy URL",
@@ -601,14 +686,19 @@
         "always_hide": "Zawsze ukrywaj",
         "always_warn": "Zawsze ostrzegaj",
         "always_show": "Zawsze pokazuj",
+        "choose_default_blog_payout": "Blog post rewards",
+        "choose_default_comment_payout": "Comment post rewards",
         "muted_users": "Blokowani użytkownicy",
         "update": "Aktualizuj",
+        "upload_image": "Upload an image",
+        "uploading_image": "Uploading image",
         "profile_image_url": "URL obrazka profilowego",
         "cover_image_url": "URL tła profilowego",
         "profile_name": "Wyświetlana nazwa",
         "profile_about": "Opis",
         "profile_location": "Lokalizacja",
-        "profile_website": "Strona www"
+        "profile_website": "Strona www",
+        "saved": "Saved!"
     },
     "transfer_jsx": {
         "amount_is_in_form": "Podana kwota musi być w formacie 99999.999",
@@ -630,9 +720,17 @@
         "from": "Od",
         "to": "Do",
         "asset_currently_collecting":
-            "%(asset)s aktualnie zbierający %(interest)s%% APR."
+            "%(asset)s aktualnie zbierający %(interest)s%% APR.",
+        "beware_of_spam_and_phishing_links":
+            "Beware of spam and phishing links in transfer memos. Do not open links from users you do not trust. Do not provide your private keys to any third party websites.",
+        "transactions_make_take_a_few_minutes":
+            "Transactions will not show until they are confirmed on the blockchain, which may take a few minutes.",
+        "autocomplete_previous_transfers": "previous transfers",
+        "autocomplete_user_following": "following",
+        "confirm_transfer": "Transfer %(amount)s from %(from)s to %(to)s?"
     },
     "userwallet_jsx": {
+        "transfer": "Transfer",
         "conversion_complete_tip": "Zakończy się",
         "in_conversion": "%(amount)s po zamianie",
         "transfer_to_savings": "Transfer do oszczędności",
@@ -644,6 +742,8 @@
         "withdraw_DEBT_TOKENS": "Wypłać %(DEBT_TOKENS)s",
         "tokens_worth_about_1_of_LIQUID_TICKER":
             "Tokeny warte około $1.00 z %(LIQUID_TICKER)s, aktualnie zbierają %(sbdInterest)s%% APR.",
+        "tradeable_tokens_transferred":
+            "Tradeable tokens that may be transferred anywhere at anytime.",
         "savings": "OSZCZĘDNOŚCI",
         "estimated_account_value": "Szacowana wartość konta",
         "next_power_down_is_scheduled_to_happen":
@@ -661,5 +761,36 @@
         "ownership_changed_on": "Nastąpiła zmiana właściciela",
         "deadline_for_recovery_is": "Ostateczny czas na odzyskanie",
         "i_understand_dont_show_again": "Rozumiem, nie pokazuj mi tego ponownie"
+    },
+    "termsagree_jsx": {
+        "please_review": "Please review our terms to continue",
+        "hi_user": "Hi %(username)s,",
+        "blurb":
+            "Our Terms of Service set the rules and guidelines that you must accept and follow in order to use Steemit and our Privacy Policy explains the type of information we collect and what we do with it. Don't worry, we don't sell your data to anyone. We do use it to meet legal requirements and to learn how to make Steemit better.",
+        "i_agree_to_steemits": "I agree to Steemit's",
+        "terms_of_service": "Terms of Service",
+        "privacy_policy": "Privacy Policy",
+        "continue": "Continue",
+        "cancel": "Cancel"
+    },
+    "confirmtransactionform_jsx": {
+        "confirm": "Confirm %(transactionType)s"
+    },
+    "modals_jsx": {
+        "your_transaction_failed": "Your transaction failed to process",
+        "out_of_bandwidth_title": "Why? You've run out of Resource Credits",
+        "out_of_bandwidth_reason":
+            "Actions such as posting and voting use computing resources, placing a real cost on the community members who run the Steem blockchain for everyone.",
+        "out_of_bandwidth_reason_2":
+            "To keep things free, Steem intelligently allocates Resource Credits to each user based on their Steem Power holdings, which can be used to submit a limited number of feeless transactions. When a user runs low on Resource Credits, they will either need to wait for them to recharge, or purchase additional Steem Power. This system prioritizes actions by good community members while limiting spam.",
+        "out_of_bandwidth_option_title": "To keep interacting on Steemit:",
+        "out_of_bandwidth_option_1": "Buy and hold more Steem Power",
+        "out_of_bandwidth_option_2":
+            "Wait until your Resource Credits recharge",
+        "out_of_bandwidth_option_3": "Wait until the network usage decreases"
+    },
+    "sanitizedlink_jsx": {
+        "phishylink_caution": "Link hidden; phishing attempt",
+        "phishylink_reveal": "show link"
     }
 }

--- a/src/app/locales/ru.json
+++ b/src/app/locales/ru.json
@@ -12,6 +12,7 @@
         "blog": "Блог",
         "browse": "Посмотреть",
         "buy": "Купить",
+        "buy_steem_power": "Buy Steem Power",
         "buy_or_sell": "Купить или Продать",
         "by": "от",
         "cancel": "Отмена",
@@ -28,6 +29,10 @@
         "dismiss": "Скрыть",
         "edit": "Редактировать",
         "email": "Электронная почта",
+        "external_link_message":
+            "This link will take you away from steemit.com",
+        "affiliation_steemit": "Steemit Team",
+        "affiliation_sm": "Steem Monsters Team",
         "feed": "Лента",
         "follow": "Подписаться",
         "for": " для ",
@@ -38,12 +43,18 @@
         "in_reply_to": "в ответ на",
         "insufficient_balance": "Недостаточный баланс",
         "invalid_amount": "Недостаточно средств",
+        "links": "Links",
         "joined": "Присоединился",
         "loading": "Загрузка",
         "login": "Войти",
         "logout": "Выйти",
         "memo": "Примечание",
         "mute": "Заблокировать",
+        "my_blog": "My blog",
+        "my_comments": "My comments",
+        "my_feed": "My feed",
+        "my_replies": "Replies to me",
+        "my_wallet": "My wallet",
         "new": "новое",
         "newer": "Новее",
         "next": "Следующий",
@@ -58,7 +69,7 @@
         "phishy_message":
             "Link expanded to plain text; beware of a potential phishing attempt",
         "post": "Пост",
-        "post_as": "Запостить как",
+        "post_as_user": "Post as %(username)s",
         "posts": "Посты",
         "powered_up_100": "100%% в Силе Голоса",
         "preview": "Предварительный просмотр",
@@ -69,6 +80,7 @@
         "promoted": "продвигаемое",
         "re": "RE",
         "re_to": "RE: %(topic)s",
+        "read_offical_blog": "Steemit Blog",
         "recent_password": "Недавний пароль",
         "receive": "Получено ",
         "remove": "Удалить",
@@ -79,12 +91,13 @@
         "reply_count": {
             "zero": "нет ответов",
             "one": "1 ответ",
+            "other": "%(count)s ответов",
             "few": "%(count)s ответа",
-            "many": "%(count)s ответов",
-            "other": "%(count)s ответов"
+            "many": "%(count)s ответов"
         },
         "reputation": "Репутация",
         "reveal_comment": "Показать комментарий",
+        "will_be_hidden_due_to_low_rating": "Will be hidden due to low rating",
         "request": "запрос",
         "required": "Обязательно",
         "rewards": "вознаграждение",
@@ -103,9 +116,13 @@
         "submit_a_story": "Добавить пост",
         "tag": "Тег",
         "to": " к ",
+        "topics": "Topics",
+        "toggle_nightmode": "Toggle Night Mode",
         "all_tags": "All tags",
+        "all_tags_mobile": "All content",
         "transfer": "Перевод ",
         "trending_topics": "Популярное",
+        "try_again": "Try Again",
         "type": "Тип",
         "unfollow": "Отписаться",
         "unmute": "Разблокировать",
@@ -222,16 +239,16 @@
         "views": {
             "zero": "Нет просмотров",
             "one": "%(count)s просмотр",
+            "other": "%(count)s просмотров",
             "few": "%(count)s просмотра",
-            "many": "%(count)s просмотров",
-            "other": "%(count)s просмотров"
+            "many": "%(count)s просмотров"
         },
         "responses": {
             "zero": "Нет ответов",
             "one": "%(count)s ответ",
+            "other": "%(count)s ответов",
             "few": "%(count)s ответа",
-            "many": "%(count)s ответов",
-            "other": "%(count)s ответов"
+            "many": "%(count)s ответов"
         },
         "post_key_warning": {
             "confirm":
@@ -239,19 +256,22 @@
             "warning":
                 "Если кто-то попросил вас опубликовать или показать ваш приватный ключ, это возможно злоумышленник, который пытается украсть ваши токены.",
             "checkbox": "Я понял"
-        }
+        },
+        "post_as": "Запостить как"
     },
     "navigation": {
         "about": "О проекте",
         "explore": "Исследовать",
         "APP_NAME_whitepaper": "Белая книга %(APP_NAME)s",
+        "third_party_exchanges": "Third-party exchanges:",
         "buy_LIQUID_TOKEN": "Купить %(LIQUID_TOKEN)s",
         "sell_LIQUID_TOKEN": "Продать %(LIQUID_TOKEN)s",
         "currency_market": "Биржа",
         "stolen_account_recovery": "Восстановление украденного аккаунта",
         "change_account_password": "Изменить пароль аккаунта",
-        "witnesses": "Делегаты",
         "vote_for_witnesses": "Проголосовать за делегатов",
+        "advertise": "Advertise",
+        "media_kit": "Media Kit",
         "privacy_policy": "Политика Конфиденциальности",
         "terms_of_service": "Условия пользования",
         "sign_up": "Присоединиться",
@@ -267,7 +287,10 @@
         "whitepaper": "Белая книга Steem",
         "intro_tagline": "Здесь говорят деньги.",
         "intro_paragraph":
-            "Ваше мнение имеет цену. Присоединяйтесь к сообществу, которое платит за контент и за работу по отбору самого лучшего контента."
+            "Ваше мнение имеет цену. Присоединяйтесь к сообществу, которое платит за контент и за работу по отбору самого лучшего контента.",
+        "jobs": "Jobs at Steemit",
+        "steem_proposals": "Steem Proposals",
+        "witnesses": "Делегаты"
     },
     "main_menu": {
         "hot": "актуальное",
@@ -344,6 +367,7 @@
             "Этот пост недоступен из-за жалобы о нарушении авторских прав.",
         "share_on_facebook": "Поделитесь в Facebook",
         "share_on_twitter": "Поделиться в Twitter",
+        "share_on_reddit": "Share on Reddit",
         "share_on_linkedin": "Поделиться в Linkedin",
         "recent_password": "Недавний пароль",
         "in_week_convert_DEBT_TOKEN_to_LIQUID_TOKEN":
@@ -379,23 +403,23 @@
         "follower_count": {
             "zero": "Нет подписчиков",
             "one": "1 подписчик",
+            "other": "%(count)s подписчиков",
             "few": "%(count)s подписчика",
-            "many": "%(count)s подписчиков",
-            "other": "%(count)s подписчиков"
+            "many": "%(count)s подписчиков"
         },
         "followed_count": {
             "zero": "Ни на кого не подписан",
             "one": "1 подписок",
+            "other": "%(count)s подписок",
             "few": "%(count)s подписки",
-            "many": "%(count)s подписок",
-            "other": "%(count)s подписок"
+            "many": "%(count)s подписок"
         },
         "post_count": {
             "zero": "Постов нет",
             "one": "1 пост",
+            "other": "%(count)s постов",
             "few": "%(count)s поста",
-            "many": "%(count)s постов",
-            "other": "%(count)s постов"
+            "many": "%(count)s постов"
         },
         "hide_resteems": "Hide Resteems",
         "show_all": "Show All"
@@ -405,7 +429,13 @@
             "Отображаем комментарии с низким рейтингом",
         "sort_order": "Порядок сортировки",
         "comments_were_hidden_due_to_low_ratings":
-            "Комментарии были скрыты из-за низкого рейтинга"
+            "Комментарии были скрыты из-за низкого рейтинга",
+        "comment_sort_order": {
+            "trending": "Trending",
+            "votes": "Votes",
+            "age": "Age",
+            "reputation": "Reputation"
+        }
     },
     "voting_jsx": {
         "flagging_post_can_remove_rewards_the_flag_should_be_used_for_the_following":
@@ -424,19 +454,30 @@
         "past_payouts": "Предыдущие выплаты $%(value)s",
         "past_payouts_author": " - Авторские $%(value)s",
         "past_payouts_curators": " - Кураторские $%(value)s",
-        "we_will_reset_curation_rewards_for_this_post":
-            "это сбросит выплаты за курирование",
         "removing_your_vote": "Удаление голоса",
+        "removing_your_vote_will_reset_curation_rewards_for_this_post":
+            "Removing your vote will reset your curation rewards for this post",
         "changing_to_an_upvote": "Изменить на голосование 'за'",
+        "changing_to_an_upvote_will_reset_curation_rewards_for_this_post":
+            "Changing to an Up-Vote will reset your curation rewards for this post",
         "changing_to_a_downvote": "Изменить на голосование 'против'",
+        "changing_to_a_downvote_will_reset_curation_rewards_for_this_post":
+            "Changing to a Down-Vote will reset your curation rewards for this post",
         "confirm_flag": "Подтвердить голос 'против'",
         "and_more": "и %(count)s больше",
         "votes_plural": {
             "one": "%(count)s голоса",
+            "other": "%(count)s голосов",
             "few": "%(count)s голоса",
-            "many": "%(count)s голосов",
-            "other": "%(count)s голосов"
-        }
+            "many": "%(count)s голосов"
+        },
+        "must_reached_minimum_payout": "(amount must reach $0.02 for payout)",
+        "payout": "Payout",
+        "breakdown": "Breakdown",
+        "voting_power": "Voting Power",
+        "estimated_vote": "Estimated Vote Value",
+        "we_will_reset_curation_rewards_for_this_post":
+            "это сбросит выплаты за курирование"
     },
     "votesandcomments_jsx": {
         "no_responses_yet_click_to_respond":
@@ -444,16 +485,16 @@
         "response_count_tooltip": {
             "zero": "ответов пока нет. Нажмите чтобы ответить.",
             "one": "1 ответ. Нажмите чтобы ответить.",
+            "other": "%(count)s ответов. Нажмите чтобы ответить.",
             "few": "%(count)s ответа. Нажмите чтобы ответить.",
-            "many": "%(count)s ответов. Нажмите чтобы ответить.",
-            "other": "%(count)s ответов. Нажмите чтобы ответить."
+            "many": "%(count)s ответов. Нажмите чтобы ответить."
         },
         "vote_count": {
             "zero": "нет голосов",
             "one": "1 голос",
+            "other": "%(count)s голосов",
             "few": "%(count)s голоса",
-            "many": "%(count)s голосов",
-            "other": "%(count)s голосов"
+            "many": "%(count)s голосов"
         }
     },
     "userkeys_jsx": {
@@ -539,7 +580,9 @@
             "Если Вы недавно подписались на новых пользователей, Ваша персональная лента будет заполняться, когда будет доступен новый контент",
         "empty_feed_3": "Посмотреть статьи, набирающие популярность",
         "empty_feed_4": "Прочтите краткое руководство",
-        "empty_feed_5": "Просмотреть ЧаВО"
+        "empty_feed_5": "Просмотреть ЧаВО",
+        "my_feed": "My Feed",
+        "accountnames_feed": "%(account_name)s's Feed"
     },
     "explorepost_jsx": {
         "copied": "Скопировано!",
@@ -602,15 +645,42 @@
         "amazing_community": "удивительное сообщество",
         "to_comment_and_reward_others":
             " комментировать и вознаграждать других.",
-        "sign_up_get_steem": "Sign up. Get STEEM",
         "signup_button": "Зарегистрируйтесь",
         "signup_button_emphasis": " сейчас!",
+        "sign_up_get_steem": "Sign up. Get STEEM",
         "returning_users": "Вернувшиеся пользователи: ",
+        "login_warning_title": "Logging in with non-posting key",
+        "login_warning_body":
+            "You are attempting to use a key with more permissions than required for everyday Steemit.com use. Since keys and passwords are more likely to get compromised the more they are used, it is strongly recommended to only use your Posting Key to log in.",
+        "continue_anyway": "Continue Anyway",
+        "login_warning_link_text":
+            "Open my Steemit Wallet to access and view my posting key",
         "join_our": "Присоединяйтесь к нашему",
         "sign_transfer": "Sign to complete transfer",
         "use_keychain": "Use keychain extension"
     },
     "chainvalidation_js": {
+        "account_name_should_not_be_empty": "Account name should not be empty.",
+        "account_name_should_be_longer": "Account name should be longer.",
+        "account_name_should_be_shorter": "Account name should be shorter.",
+        "each_account_segment_should_start_with_a_letter":
+            "Each account segment should start with a letter.",
+        "each_account_segment_should_have_only_letters_digits_or_dashes":
+            "Each account segment should have only letters, digits, or dashes.",
+        "each_account_segment_should_have_only_one_dash_in_a_row":
+            "Each account segment should have only one dash in a row.",
+        "each_account_segment_should_end_with_a_letter_or_digit":
+            "Each account segment should end with a letter or digit.",
+        "each_account_segment_should_be_longer":
+            "Each account segment should be longer.",
+        "verified_exchange_no_memo":
+            "Для перевода на биржу Вы должны указать примечание.",
+        "badactor":
+            "Use caution sending to this account. Please double check your spelling for possible phishing.",
+        "memo_has_privatekey":
+            "Please do not include what appears to be a private key or password.",
+        "memo_is_privatekey": "Do not use private keys in memos.",
+        "memo_is_password": "Do not use passwords in memos.",
         "account_name_should": "Имя аккаунта должно быть ",
         "not_be_empty": "не может быть пустым.",
         "be_longer": "длиннее.",
@@ -620,9 +690,7 @@
         "have_only_letters_digits_or_dashes":
             "должно должно состоять только из букв, цифр или дефисов.",
         "have_only_one_dash_in_a_row": "иметь только одно тире в строке.",
-        "end_with_a_letter_or_digit": "заканчиваться буквой или цифрой.",
-        "verified_exchange_no_memo":
-            "Для перевода на биржу Вы должны указать примечание."
+        "end_with_a_letter_or_digit": "заканчиваться буквой или цифрой."
     },
     "settings_jsx": {
         "invalid_url": "Недопустимый URL-адрес",
@@ -638,14 +706,19 @@
         "always_hide": "Всегда скрывать",
         "always_warn": "Всегда предупреждать",
         "always_show": "Отображать всегда",
+        "choose_default_blog_payout": "Blog post rewards",
+        "choose_default_comment_payout": "Comment post rewards",
         "muted_users": "Заблокированные пользователи",
         "update": "Обновить",
+        "upload_image": "Upload an image",
+        "uploading_image": "Uploading image",
         "profile_image_url": "Добавьте url вашего изображения",
         "cover_image_url": "URL-адрес изображения обложки",
         "profile_name": "Отображаемое имя",
         "profile_about": "О себе",
         "profile_location": "Местоположение",
-        "profile_website": "Веб-сайт"
+        "profile_website": "Веб-сайт",
+        "saved": "Saved!"
     },
     "transfer_jsx": {
         "amount_is_in_form": "Сумма должна быть в формате 99999.999",
@@ -669,9 +742,15 @@
         "asset_currently_collecting":
             "начисляемые годовые на %(asset)s: %(interest)s%%.",
         "beware_of_spam_and_phishing_links":
-            "Остерегайтесь спама и фишинговых ссылок в передачах. Не открывайте ссылки от пользователей, которым вы не доверяете. Не предоставляйте свои личные ключи третьим сторонам."
+            "Остерегайтесь спама и фишинговых ссылок в передачах. Не открывайте ссылки от пользователей, которым вы не доверяете. Не предоставляйте свои личные ключи третьим сторонам.",
+        "transactions_make_take_a_few_minutes":
+            "Transactions will not show until they are confirmed on the blockchain, which may take a few minutes.",
+        "autocomplete_previous_transfers": "previous transfers",
+        "autocomplete_user_following": "following",
+        "confirm_transfer": "Transfer %(amount)s from %(from)s to %(to)s?"
     },
     "userwallet_jsx": {
+        "transfer": "Transfer",
         "conversion_complete_tip": "Завершается",
         "in_conversion": "%(amount)s на конвертации",
         "transfer_to_savings": "Отправить в сейф",
@@ -683,6 +762,8 @@
         "withdraw_DEBT_TOKENS": "Снять %(DEBT_TOKENS)s",
         "tokens_worth_about_1_of_LIQUID_TICKER":
             "Стоимость токенов $1.00 в %(LIQUID_TICKER)s, начисляемые годовые %(sbdInterest)s%%.",
+        "tradeable_tokens_transferred":
+            "Tradeable tokens that may be transferred anywhere at anytime.",
         "savings": "Сберегательный счет",
         "estimated_account_value": "Приблизительная стоимость аккаунта",
         "next_power_down_is_scheduled_to_happen":
@@ -700,5 +781,36 @@
         "ownership_changed_on": "Владелец аккаунта или пароль были изменены ",
         "deadline_for_recovery_is": "Вы можете восстановить доступ до ",
         "i_understand_dont_show_again": "Понятно, больше не показывать"
+    },
+    "termsagree_jsx": {
+        "please_review": "Please review our terms to continue",
+        "hi_user": "Hi %(username)s,",
+        "blurb":
+            "Our Terms of Service set the rules and guidelines that you must accept and follow in order to use Steemit and our Privacy Policy explains the type of information we collect and what we do with it. Don't worry, we don't sell your data to anyone. We do use it to meet legal requirements and to learn how to make Steemit better.",
+        "i_agree_to_steemits": "I agree to Steemit's",
+        "terms_of_service": "Terms of Service",
+        "privacy_policy": "Privacy Policy",
+        "continue": "Continue",
+        "cancel": "Cancel"
+    },
+    "confirmtransactionform_jsx": {
+        "confirm": "Confirm %(transactionType)s"
+    },
+    "modals_jsx": {
+        "your_transaction_failed": "Your transaction failed to process",
+        "out_of_bandwidth_title": "Why? You've run out of Resource Credits",
+        "out_of_bandwidth_reason":
+            "Actions such as posting and voting use computing resources, placing a real cost on the community members who run the Steem blockchain for everyone.",
+        "out_of_bandwidth_reason_2":
+            "To keep things free, Steem intelligently allocates Resource Credits to each user based on their Steem Power holdings, which can be used to submit a limited number of feeless transactions. When a user runs low on Resource Credits, they will either need to wait for them to recharge, or purchase additional Steem Power. This system prioritizes actions by good community members while limiting spam.",
+        "out_of_bandwidth_option_title": "To keep interacting on Steemit:",
+        "out_of_bandwidth_option_1": "Buy and hold more Steem Power",
+        "out_of_bandwidth_option_2":
+            "Wait until your Resource Credits recharge",
+        "out_of_bandwidth_option_3": "Wait until the network usage decreases"
+    },
+    "sanitizedlink_jsx": {
+        "phishylink_caution": "Link hidden; phishing attempt",
+        "phishylink_reveal": "show link"
     }
 }

--- a/src/app/locales/zh.json
+++ b/src/app/locales/zh.json
@@ -12,6 +12,7 @@
         "blog": "博客",
         "browse": "浏览",
         "buy": "购买",
+        "buy_steem_power": "Buy Steem Power",
         "buy_or_sell": "买或卖",
         "by": "by",
         "cancel": "取消",
@@ -28,6 +29,10 @@
         "dismiss": "关闭",
         "edit": "编辑",
         "email": "邮件",
+        "external_link_message":
+            "This link will take you away from steemit.com",
+        "affiliation_steemit": "Steemit Team",
+        "affiliation_sm": "Steem Monsters Team",
         "feed": "动态",
         "follow": "关注",
         "for": "对于",
@@ -38,12 +43,18 @@
         "in_reply_to": "回复",
         "insufficient_balance": "余额不足",
         "invalid_amount": "金额无效",
+        "links": "Links",
         "joined": "加入",
         "loading": "正在载入",
         "login": "登录",
         "logout": "登出",
         "memo": "备注",
         "mute": "屏蔽",
+        "my_blog": "My blog",
+        "my_comments": "My comments",
+        "my_feed": "My feed",
+        "my_replies": "Replies to me",
+        "my_wallet": "My wallet",
         "new": "最新",
         "newer": "较新的",
         "next": "下一个",
@@ -55,8 +66,10 @@
         "password": "密码",
         "payouts": "赏金",
         "permissions": "权限",
+        "phishy_message":
+            "Link expanded to plain text; beware of a potential phishing attempt",
         "post": "发布",
-        "post_as": "发布为",
+        "post_as_user": "Post as %(username)s",
         "posts": "文章",
         "powered_up_100": "Power Up 100%%",
         "preview": "预览",
@@ -67,6 +80,7 @@
         "promoted": "推广",
         "re": "回复",
         "re_to": "回复%(topic)s",
+        "read_offical_blog": "Steemit Blog",
         "recent_password": "最近的密码",
         "receive": "收到",
         "remove": "取消",
@@ -81,6 +95,7 @@
         },
         "reputation": "声誉",
         "reveal_comment": "显示评论",
+        "will_be_hidden_due_to_low_rating": "Will be hidden due to low rating",
         "request": "请求",
         "required": "需要",
         "rewards": "奖励",
@@ -101,10 +116,11 @@
         "to": "至",
         "topics": "主题",
         "toggle_nightmode": "切换夜间模式",
-
         "all_tags": "所有标签",
+        "all_tags_mobile": "All content",
         "transfer": "转账",
         "trending_topics": "热门话题",
+        "try_again": "Try Again",
         "type": "类型",
         "unfollow": "取消关注",
         "unmute": "取消屏蔽",
@@ -218,19 +234,29 @@
             "zero": "没有回复",
             "one": "%(count)s回复",
             "other": "%(count)s个回复"
-        }
+        },
+        "post_key_warning": {
+            "confirm":
+                "You are about to publish a STEEM private key or master password. You will probably lose control of the associated account and all its funds.",
+            "warning":
+                "Legitimate users, including employees of Steemit Inc., will never ask you for a private key or master password.",
+            "checkbox": "I understand"
+        },
+        "post_as": "发布为"
     },
     "navigation": {
         "about": "关于",
         "explore": "探索",
         "APP_NAME_whitepaper": "%(APP_NAME)s的白皮书",
+        "third_party_exchanges": "Third-party exchanges:",
         "buy_LIQUID_TOKEN": "购买%(LIQUID_TOKEN)s",
         "sell_LIQUID_TOKEN": "出售%(LIQUID_TOKEN)s",
         "currency_market": "货币市场",
         "stolen_account_recovery": "被盗账户恢复",
         "change_account_password": "更改帐户密码",
-        "witnesses": "见证人",
         "vote_for_witnesses": "投票给见证人",
+        "advertise": "Advertise",
+        "media_kit": "Media Kit",
         "privacy_policy": "隐私政策",
         "terms_of_service": "服务条款",
         "sign_up": "注册",
@@ -241,10 +267,15 @@
         "app_center": "Steemit应用中心",
         "business_center": "Businesses Accepting Steem",
         "api_docs": "Steemit API文档",
+        "bluepaper": "Steem Bluepaper",
+        "smt_whitepaper": "SMT Whitepaper",
         "whitepaper": "Steem白皮书",
         "intro_tagline": "妙笔生金",
         "intro_paragraph":
-            "你的思想是有有价值的。赶快加入发表文章获得赏金的社区。"
+            "你的思想是有有价值的。赶快加入发表文章获得赏金的社区。",
+        "jobs": "Jobs at Steemit",
+        "steem_proposals": "Steem Proposals",
+        "witnesses": "见证人"
     },
     "main_menu": {
         "hot": "热门",
@@ -311,6 +342,7 @@
             "由于版权限制，暂不能显示这篇文章。",
         "share_on_facebook": "分享到脸书",
         "share_on_twitter": "分享到推特",
+        "share_on_reddit": "Share on Reddit",
         "share_on_linkedin": "分享到Linkedin",
         "recent_password": "最近的密码",
         "in_week_convert_DEBT_TOKEN_to_LIQUID_TOKEN":
@@ -331,6 +363,12 @@
         "user_hasnt_followed_anything_yet":
             "看起来%(name)s还没有关注任何人!如果%(name)s最近添加关注了新的用户，他们的个性化主页上将会有显示。",
         "user_hasnt_had_any_replies_yet": "%(name)s目前还没有回复",
+        "looks_like_you_havent_posted_anything_yet":
+            "Looks like you haven't posted anything yet.",
+        "create_a_post": "Create a Post",
+        "explore_trending_articles": "Explore Trending Articles",
+        "read_the_quick_start_guide": "Read The Quick Start Guide",
+        "browse_the_faq": "Browse The FAQ",
         "followers": "关注者",
         "this_is_users_reputations_score_it_is_based_on_history_of_votes":
             "这是%(name)s的声誉分数。声誉分数取决于账户收到的历史投票记录, 用于隐藏低质量的内容。",
@@ -355,7 +393,13 @@
     "post_jsx": {
         "now_showing_comments_with_low_ratings": "正在显示低评级的评论",
         "sort_order": "排序",
-        "comments_were_hidden_due_to_low_ratings": "评论由于评级不足而被隐藏"
+        "comments_were_hidden_due_to_low_ratings": "评论由于评级不足而被隐藏",
+        "comment_sort_order": {
+            "trending": "Trending",
+            "votes": "Votes",
+            "age": "Age",
+            "reputation": "Reputation"
+        }
     },
     "voting_jsx": {
         "flagging_post_can_remove_rewards_the_flag_should_be_used_for_the_following":
@@ -372,17 +416,28 @@
         "past_payouts": "累计赏金$%(value)s",
         "past_payouts_author": "- 作者收入 $%(value)s",
         "past_payouts_curators": " - 审查收入 $%(value)s",
-        "we_will_reset_curation_rewards_for_this_post":
-            "将重置你对这篇帖子的审查奖励",
         "removing_your_vote": "取消你的投票",
+        "removing_your_vote_will_reset_curation_rewards_for_this_post":
+            "Removing your vote will reset your curation rewards for this post",
         "changing_to_an_upvote": "改为投票",
+        "changing_to_an_upvote_will_reset_curation_rewards_for_this_post":
+            "Changing to an Up-Vote will reset your curation rewards for this post",
         "changing_to_a_downvote": "改为差评",
+        "changing_to_a_downvote_will_reset_curation_rewards_for_this_post":
+            "Changing to a Down-Vote will reset your curation rewards for this post",
         "confirm_flag": "确认差评",
         "and_more": "还有%(count)s次",
         "votes_plural": {
             "one": "%(count)s个投票",
             "other": "%(count)s个投票"
-        }
+        },
+        "must_reached_minimum_payout": "(amount must reach $0.02 for payout)",
+        "payout": "Payout",
+        "breakdown": "Breakdown",
+        "voting_power": "Voting Power",
+        "estimated_vote": "Estimated Vote Value",
+        "we_will_reset_curation_rewards_for_this_post":
+            "将重置你对这篇帖子的审查奖励"
     },
     "votesandcomments_jsx": {
         "no_responses_yet_click_to_respond": "暂无回复。点击回复。",
@@ -462,13 +517,13 @@
     "postsummary_jsx": {
         "resteemed": "已转发的",
         "resteemed_by": "被转发的",
-        "this_post_is": "这篇帖子是",
-        "you_can": "你可以",
         "reveal_it": "显示它",
         "adjust_your": "调整你的",
         "display_preferences": "显示偏好",
         "create_an_account": "创建帐户",
-        "to_save_your_preferences": "保存你的偏好"
+        "to_save_your_preferences": "保存你的偏好",
+        "this_post_is": "这篇帖子是",
+        "you_can": "你可以"
     },
     "posts_index": {
         "empty_feed_1": "看起来你还没有关注任何人",
@@ -476,7 +531,9 @@
             "如果你最近关注了新的用户，更新内容将会显示在你的个性化主页",
         "empty_feed_3": "浏览流行文章",
         "empty_feed_4": "阅读快速入门指南",
-        "empty_feed_5": "浏览常见问题解答"
+        "empty_feed_5": "浏览常见问题解答",
+        "my_feed": "My Feed",
+        "accountnames_feed": "%(account_name)s's Feed"
     },
     "explorepost_jsx": {
         "copied": "已复制！",
@@ -532,14 +589,43 @@
         "keep_me_logged_in": "保持登录状态",
         "amazing_community": "神奇的社区",
         "to_comment_and_reward_others": "评论和奖励他人。",
-        "sign_up_now_to_earn": "现在就来注册赚取",
-        "free_money": "免费的钱！",
+        "signup_button": "Sign up now to earn ",
+        "signup_button_emphasis": "FREE STEEM!",
+        "sign_up_get_steem": "Sign up. Get STEEM!",
         "returning_users": "返回用户:",
+        "login_warning_title": "Logging in with non-posting key",
+        "login_warning_body":
+            "You are attempting to use a key with more permissions than required for everyday Steemit.com use. Since keys and passwords are more likely to get compromised the more they are used, it is strongly recommended to only use your Posting Key to log in.",
+        "continue_anyway": "Continue Anyway",
+        "login_warning_link_text":
+            "Open my Steemit Wallet to access and view my posting key",
         "join_our": "加入我们",
         "sign_transfer": "Sign to complete transfer",
-        "use_keychain": "Use keychain extension"
+        "use_keychain": "Use keychain extension",
+        "sign_up_now_to_earn": "现在就来注册赚取",
+        "free_money": "免费的钱！"
     },
     "chainvalidation_js": {
+        "account_name_should_not_be_empty": "Account name should not be empty.",
+        "account_name_should_be_longer": "Account name should be longer.",
+        "account_name_should_be_shorter": "Account name should be shorter.",
+        "each_account_segment_should_start_with_a_letter":
+            "Each account segment should start with a letter.",
+        "each_account_segment_should_have_only_letters_digits_or_dashes":
+            "Each account segment should have only letters, digits, or dashes.",
+        "each_account_segment_should_have_only_one_dash_in_a_row":
+            "Each account segment should have only one dash in a row.",
+        "each_account_segment_should_end_with_a_letter_or_digit":
+            "Each account segment should end with a letter or digit.",
+        "each_account_segment_should_be_longer":
+            "Each account segment should be longer.",
+        "verified_exchange_no_memo": "如果你要转账到交易所，你必须填写备注。",
+        "badactor":
+            "Use caution sending to this account. Please double check your spelling for possible phishing.",
+        "memo_has_privatekey":
+            "Please do not include what appears to be a private key or password.",
+        "memo_is_privatekey": "Do not use private keys in memos.",
+        "memo_is_password": "Do not use passwords in memos.",
         "account_name_should": "帐户名称应该",
         "not_be_empty": "不是空的。",
         "be_longer": "更长。",
@@ -548,8 +634,7 @@
         "start_with_a_letter": "从一个字母开始。",
         "have_only_letters_digits_or_dashes": "只有字母、数字或破折号",
         "have_only_one_dash_in_a_row": "一行只有一个破折号",
-        "end_with_a_letter_or_digit": "字母或数字结尾",
-        "verified_exchange_no_memo": "如果你要转账到交易所，你必须填写备注。"
+        "end_with_a_letter_or_digit": "字母或数字结尾"
     },
     "settings_jsx": {
         "invalid_url": "无效的URL",
@@ -564,14 +649,19 @@
         "always_hide": "总是隐藏",
         "always_warn": "总是警告",
         "always_show": "总是显示",
+        "choose_default_blog_payout": "Blog post rewards",
+        "choose_default_comment_payout": "Comment post rewards",
         "muted_users": "屏蔽的用户",
         "update": "更新",
+        "upload_image": "Upload an image",
+        "uploading_image": "Uploading image",
         "profile_image_url": "个人头像的网址",
         "cover_image_url": "封面图片的网址",
         "profile_name": "显示名称",
         "profile_about": "关于",
         "profile_location": "位置",
-        "profile_website": "网站"
+        "profile_website": "网站",
+        "saved": "Saved!"
     },
     "transfer_jsx": {
         "amount_is_in_form": "金额以99999.999的形式出现",
@@ -591,9 +681,17 @@
             "需要在3天的等待期后提取资金。",
         "from": "从",
         "to": "到",
-        "asset_currently_collecting": "%(asset)s目前获得%(interest)s%%利息"
+        "asset_currently_collecting": "%(asset)s目前获得%(interest)s%%利息",
+        "beware_of_spam_and_phishing_links":
+            "Beware of spam and phishing links in transfer memos. Do not open links from users you do not trust. Do not provide your private keys to any third party websites.",
+        "transactions_make_take_a_few_minutes":
+            "Transactions will not show until they are confirmed on the blockchain, which may take a few minutes.",
+        "autocomplete_previous_transfers": "previous transfers",
+        "autocomplete_user_following": "following",
+        "confirm_transfer": "Transfer %(amount)s from %(from)s to %(to)s?"
     },
     "userwallet_jsx": {
+        "transfer": "Transfer",
         "conversion_complete_tip": "将完成在",
         "in_conversion": "%(amount)s在转换",
         "transfer_to_savings": "转移到储蓄",
@@ -605,6 +703,8 @@
         "withdraw_DEBT_TOKENS": "取出%(DEBT_TOKENS)s",
         "tokens_worth_about_1_of_LIQUID_TICKER":
             "价值约为1.00美金的%(LIQUID_TICKER)s，目前正在获得%(sbdInterest)s%%的利息。",
+        "tradeable_tokens_transferred":
+            "Tradeable tokens that may be transferred anywhere at anytime.",
         "savings": "储蓄",
         "estimated_account_value": "账户估值",
         "next_power_down_is_scheduled_to_happen":
@@ -620,5 +720,36 @@
         "ownership_changed_on": "所有权变更",
         "deadline_for_recovery_is": "恢复的截止日期是",
         "i_understand_dont_show_again": "我明白，不要再显示"
+    },
+    "termsagree_jsx": {
+        "please_review": "Please review our terms to continue",
+        "hi_user": "Hi %(username)s,",
+        "blurb":
+            "Our Terms of Service set the rules and guidelines that you must accept and follow in order to use Steemit and our Privacy Policy explains the type of information we collect and what we do with it. Don't worry, we don't sell your data to anyone. We do use it to meet legal requirements and to learn how to make Steemit better.",
+        "i_agree_to_steemits": "I agree to Steemit's",
+        "terms_of_service": "Terms of Service",
+        "privacy_policy": "Privacy Policy",
+        "continue": "Continue",
+        "cancel": "Cancel"
+    },
+    "confirmtransactionform_jsx": {
+        "confirm": "Confirm %(transactionType)s"
+    },
+    "modals_jsx": {
+        "your_transaction_failed": "Your transaction failed to process",
+        "out_of_bandwidth_title": "Why? You've run out of Resource Credits",
+        "out_of_bandwidth_reason":
+            "Actions such as posting and voting use computing resources, placing a real cost on the community members who run the Steem blockchain for everyone.",
+        "out_of_bandwidth_reason_2":
+            "To keep things free, Steem intelligently allocates Resource Credits to each user based on their Steem Power holdings, which can be used to submit a limited number of feeless transactions. When a user runs low on Resource Credits, they will either need to wait for them to recharge, or purchase additional Steem Power. This system prioritizes actions by good community members while limiting spam.",
+        "out_of_bandwidth_option_title": "To keep interacting on Steemit:",
+        "out_of_bandwidth_option_1": "Buy and hold more Steem Power",
+        "out_of_bandwidth_option_2":
+            "Wait until your Resource Credits recharge",
+        "out_of_bandwidth_option_3": "Wait until the network usage decreases"
+    },
+    "sanitizedlink_jsx": {
+        "phishylink_caution": "Link hidden; phishing attempt",
+        "phishylink_reveal": "show link"
     }
 }

--- a/src/app/redux/FetchDataSaga.js
+++ b/src/app/redux/FetchDataSaga.js
@@ -19,6 +19,7 @@ const REQUEST_DATA = 'fetchDataSaga/REQUEST_DATA';
 const GET_CONTENT = 'fetchDataSaga/GET_CONTENT';
 const FETCH_STATE = 'fetchDataSaga/FETCH_STATE';
 const GET_ACCOUNTS = 'fetchDataSaga/GET_ACCOUNTS';
+const GET_REWARD_FUND = 'fetchDataSaga/GET_REWARD_FUND';
 
 export const fetchDataWatches = [
     takeLatest(REQUEST_DATA, fetchData),
@@ -27,6 +28,7 @@ export const fetchDataWatches = [
     takeLatest(FETCH_STATE, fetchState),
     takeEvery('global/FETCH_JSON', fetchJson),
     takeEvery(GET_ACCOUNTS, getAccountsCaller),
+    takeEvery(GET_REWARD_FUND, getRewardFund),
 ];
 
 export function* getContentCaller(action) {
@@ -35,6 +37,11 @@ export function* getContentCaller(action) {
 
 export function* getAccountsCaller(action) {
     yield getAccounts(action.payload);
+}
+
+export function* getRewardFund(action) {
+    const rewardFund = yield call([api, api.getRewardFundAsync], 'post');
+    yield put(globalActions.set({ key: ['rewardFund'], value: rewardFund }));
 }
 
 let is_initial_state = true;
@@ -350,6 +357,11 @@ export const actions = {
 
     getAccounts: payload => ({
         type: GET_ACCOUNTS,
+        payload,
+    }),
+
+    getRewardFund: payload => ({
+        type: GET_REWARD_FUND,
         payload,
     }),
 };

--- a/src/app/redux/FetchDataSaga.js
+++ b/src/app/redux/FetchDataSaga.js
@@ -18,6 +18,7 @@ import { getStateAsync } from 'app/utils/steemApi';
 const REQUEST_DATA = 'fetchDataSaga/REQUEST_DATA';
 const GET_CONTENT = 'fetchDataSaga/GET_CONTENT';
 const FETCH_STATE = 'fetchDataSaga/FETCH_STATE';
+const GET_ACCOUNTS = 'fetchDataSaga/GET_ACCOUNTS';
 
 export const fetchDataWatches = [
     takeLatest(REQUEST_DATA, fetchData),
@@ -25,10 +26,15 @@ export const fetchDataWatches = [
     takeLatest('@@router/LOCATION_CHANGE', fetchState),
     takeLatest(FETCH_STATE, fetchState),
     takeEvery('global/FETCH_JSON', fetchJson),
+    takeEvery(GET_ACCOUNTS, getAccountsCaller),
 ];
 
 export function* getContentCaller(action) {
     yield getContent(action.payload);
+}
+
+export function* getAccountsCaller(action) {
+    yield getAccounts(action.payload);
 }
 
 let is_initial_state = true;
@@ -339,6 +345,11 @@ export const actions = {
 
     fetchState: payload => ({
         type: FETCH_STATE,
+        payload,
+    }),
+
+    getAccounts: payload => ({
+        type: GET_ACCOUNTS,
         payload,
     }),
 };

--- a/src/app/utils/VoteValues.js
+++ b/src/app/utils/VoteValues.js
@@ -1,3 +1,5 @@
+import { parsePayoutAmount } from 'app/utils/ParsersAndFormatters';
+
 function parseVests(vestsStr) {
     return Math.round(parseFloat(vestsStr) * 1000000);
 }
@@ -17,14 +19,52 @@ function getEffectiveVestingShares(account) {
     return effectiveVestingShares;
 }
 
-// https://github.com/steemit/steem/blob/master/libraries/chain/steem_evaluator.cpp
-// hf20_vote_evaluator
-export const computeVoteRshares = (account, weight, comment) => {
+function regenerateMana(mana, maxMana, updateTime) {
+    return Math.min(
+        maxMana,
+        mana +
+            maxMana *
+                (new Date() - new Date(updateTime * 1000)) /
+                (1000 * 60 * 60 * 24 * 5)
+    );
+}
+
+export const computeVotingPower = account => {
+    if (!account || !account.voting_manabar || !account.downvote_manabar) {
+        return null;
+    }
     const maxUpvoteMana = getEffectiveVestingShares(account);
     const maxDownvoteMana = maxUpvoteMana / 4;
-    let usedMana = currentUpvoteMana;
+    const currentUpvoteMana = regenerateMana(
+        parseInt(account.voting_manabar.current_mana),
+        maxUpvoteMana,
+        account.voting_manabar.last_update_time
+    );
+    const upvotePower = currentUpvoteMana / maxUpvoteMana * 100;
+    const currentDownvoteMana = regenerateMana(
+        parseInt(account.downvote_manabar.current_mana),
+        maxDownvoteMana,
+        account.downvote_manabar.last_update_time
+    );
+    const downvotePower = currentDownvoteMana / maxDownvoteMana * 100;
+    return {
+        up: upvotePower,
+        down: downvotePower,
+        maxUpvoteMana,
+        currentUpvoteMana,
+        maxDownvoteMana,
+        currentDownvoteMana,
+    };
+};
+
+// https://github.com/steemit/steem/blob/master/libraries/chain/steem_evaluator.cpp
+// hf20_vote_evaluator
+export const computeVoteRshares = (votingPower, weight, cashout_time) => {
+    const maxUpvoteMana = votingPower.maxUpvoteMana;
+    const maxDownvoteMana = votingPower.maxDownvoteMana;
+    let usedMana = votingPower.currentUpvoteMana;
     if (weight < 0) {
-        usedMana = Math.max(usedMana, currentDownvoteMana * 4);
+        usedMana = Math.max(usedMana, votingPower.currentDownvoteMana * 4);
     }
     usedMana *= Math.abs(weight) * 60 * 60 * 24 / 10000;
     const denom = 10 * 60 * 60 * 24 * 5;
@@ -33,10 +73,24 @@ export const computeVoteRshares = (account, weight, comment) => {
     usedMana = Math.max(0, usedMana - 50000000);
 
     const lockoutTimeMillis = 12 * 60 * 60 * 1000;
-    const cashoutDeltaMillis = new Date(comment.cashout_time) - new Date();
+    const cashoutDeltaMillis = new Date(cashout_time) - new Date();
     if (cashoutDeltaMillis < lockoutTimeMillis) {
         usedMana /= cashoutDeltaMillis / lockoutTimeMillis;
     }
 
-    return usedMana;
+    return weight >= 0 ? usedMana : -usedMana;
+};
+
+// https://github.com/steemit/steem/blob/master/libraries/chain/util/reward.cpp
+export const applyRewardsCurve = (rewardFund, r) => {
+    if (!rewardFund || r <= 0) {
+        return 0;
+    }
+    const s = rewardFund.content_constant;
+    const claims = (Math.pow(r, 2) + 2 * r * s) / (r + 4 * s);
+    return (
+        parsePayoutAmount(rewardFund.reward_balance) *
+        claims /
+        parseInt(rewardFund.recent_claims)
+    );
 };

--- a/src/app/utils/VoteValues.js
+++ b/src/app/utils/VoteValues.js
@@ -1,0 +1,42 @@
+function parseVests(vestsStr) {
+    return Math.round(parseFloat(vestsStr) * 1000000);
+}
+
+// https://github.com/steemit/steem/blob/master/libraries/chain/include/steem/chain/util/manabar.hpp
+function getEffectiveVestingShares(account) {
+    let effectiveVestingShares =
+        parseVests(account.vesting_shares) +
+        parseVests(account.received_vesting_shares) -
+        parseVests(account.delegated_vesting_shares);
+    if (new Date(account.next_vesting_withdrawal) >= new Date()) {
+        effectiveVestingShares -= Math.min(
+            parseVests(account.vesting_withdraw_rate),
+            parseInt(account.to_withdraw) - parseInt(account.withdrawn)
+        );
+    }
+    return effectiveVestingShares;
+}
+
+// https://github.com/steemit/steem/blob/master/libraries/chain/steem_evaluator.cpp
+// hf20_vote_evaluator
+export const computeVoteRshares = (account, weight, comment) => {
+    const maxUpvoteMana = getEffectiveVestingShares(account);
+    const maxDownvoteMana = maxUpvoteMana / 4;
+    let usedMana = currentUpvoteMana;
+    if (weight < 0) {
+        usedMana = Math.max(usedMana, currentDownvoteMana * 4);
+    }
+    usedMana *= Math.abs(weight) * 60 * 60 * 24 / 10000;
+    const denom = 10 * 60 * 60 * 24 * 5;
+    usedMana = (usedMana + denom - 1) / denom;
+
+    usedMana = Math.max(0, usedMana - 50000000);
+
+    const lockoutTimeMillis = 12 * 60 * 60 * 1000;
+    const cashoutDeltaMillis = new Date(comment.cashout_time) - new Date();
+    if (cashoutDeltaMillis < lockoutTimeMillis) {
+        usedMana /= cashoutDeltaMillis / lockoutTimeMillis;
+    }
+
+    return usedMana;
+};


### PR DESCRIPTION
Adds fetching the current logged in account and fetching of reward fund to show voting power and vote estimates.

Modifies the pending payout computation as well, which may be slightly confusing in the current state as it flips between cached and computed values. Can be mitigated by either not computing on the fly and only using it for vote estimate or fetching reward fund earlier in the flow (on getState).

I also am not 100% sure how to explain differences in computed vs freshly updated posts at the moment when testing. Thought it might be precision but I double-checked using bignums anyway without much change. 

In any case, this may or may not be desirable as is, will leave as reference at the least and make any  suggested changes if this feature is desired.

