### PR TITLE
Community - Fix minor error on beneficiary setting error case

### DIFF
--- a/src/app/components/modules/PostAdvancedSettings.jsx
+++ b/src/app/components/modules/PostAdvancedSettings.jsx
@@ -67,8 +67,6 @@ class PostAdvancedSettings extends Component {
                         this.props.setPayoutType(formId, payoutType);
                         this.props.setBeneficiaries(formId, data.beneficiaries);
                         this.props.hideAdvancedSettings();
-                    } else {
-                        this.setState({ beneficiaries: newBeneficiaries });
                     }
                 })}
             >


### PR DESCRIPTION
Remove clause that likely never worked. Tested locally to make sure input errors are shown properly as before.