### PR TITLE
Streamrail Video AD through BSA's optimize

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -56,6 +56,7 @@
   "google_ad_test": "GOOGLE_AD_TEST",
   "google_ad_client": "GOOGLE_AD_CLIENT",
   "gpt_enabled": "GPT_ENABLED",
+  "video_ads_enabled": "VIDEO_ADS_ENABLED",
   "steem_market_endpoint": "STEEM_MARKET_ENDPOINT",
   "steem_market_token": "STEEM_MARKET_TOKEN",
   "cookie_consent_enabled": "SDC_ENABLE_COOKIE_CONSENT",

--- a/config/default.json
+++ b/config/default.json
@@ -5,7 +5,7 @@
     "directives": {
       "childSrc": "'self' emb.d.tube player.twitch.tv www.youtube.com staticxx.facebook.com w.soundcloud.com player.vimeo.com",
       "connectSrc": "https://steemitimages.com securepubads.g.doubleclick.net 'self' steemit.com https://api.steemit.com api.blocktrades.us",
-      "defaultSrc": "tpc.googlesyndication.com 'self' emb.d.tube www.youtube.com staticxx.facebook.com player.vimeo.com",
+      "defaultSrc": "tpc.googlesyndication.com 'self' emb.d.tube www.youtube.com staticxx.facebook.com player.vimeo.com *.streamrail.com",
       "fontSrc": "data: fonts.gstatic.com",
       "frameAncestors": "'none'",
       "frameSrc": "'self' googleads.g.doubleclick.net https:",

--- a/config/default.json
+++ b/config/default.json
@@ -72,6 +72,7 @@
       "every": 15
     }
   },
+  "video_ads_enabled": null,
   "gpt_enabled": null,
   "gpt_basic_slots": {
     "bottom-of-post": {

--- a/src/app/assets/ads.txt
+++ b/src/app/assets/ads.txt
@@ -142,3 +142,28 @@ vdopia.com, 14057, RESELLER
 chocolateplatform.com, 14057, RESELLER
 spotxchange.com,252547,RESELLER,7842df1d2fe2db34
 spotx.tv,252547,RESELLER,7842df1d2fe2db34
+#StreamRail
+ironsrc.com, 5d99c6e0f1782100011ade7b, DIRECT
+ironsrc.com, 5a169d7d9515390002000001, DIRECT
+spotx.tv, 139784, RESELLER, 7842df1d2fe2db34
+spotxchange.com, 139784, RESELLER, 7842df1d2fe2db34
+telaria.com, h3vde-gbref, RESELLER, 1a4e959a1b50034a
+tremorhub.com, h3vde-gbref, RESELLER, 1a4e959a1b50034a
+openx.com, 537140488, RESELLER, 6a698e2ec38604c6
+Advertising.com, 8693, RESELLER
+rubiconproject.com, 15526, RESELLER, 0bfd66d529a55807
+freewheel.tv, 790865, RESELLER
+freewheel.tv, 790881, RESELLER
+appnexus.com, 2480, RESELLER
+improvedigital.com, 1114, RESELLER
+loopme.com, 5033, RESELLER, 6c8d5f95897a5a3b
+loopme.com, s-2411, RESELLER, 6c8d5f95897a5a3b
+loopme.com, 10287, RESELLER, 6c8d5f95897a5a3b
+springserve.com, 1, RESELLER, a24eb641fc82e93d
+contextweb.com, 561620, RESELLER, 89ff185a4c4e857c
+beachfront.com, 4021, RESELLER, e2541279e8e2ca4d
+rhythmone.com,1352466146,RESELLER,a670c89d4a324e47
+advertising.com, 3679, RESELLER #video
+advertising.com, 5831, RESELLER #video
+advertising.com, 8044, RESELLER #video
+advertising.com, 8022, RESELLER #video

--- a/src/app/components/all.scss
+++ b/src/app/components/all.scss
@@ -39,6 +39,7 @@
 @import "./elements/Notices";
 @import "./elements/GoogleAd";
 @import "./elements/GptAd";
+@import "./elements/VideoAd";
 
 // modules
 @import "./modules/Header/styles";

--- a/src/app/components/cards/PostsList.jsx
+++ b/src/app/components/cards/PostsList.jsx
@@ -281,7 +281,7 @@ class PostsList extends React.Component {
                                 />
                             </li>
 
-                            <div className="articles__content-block--ad text-center">
+                            <div className="articles__content-block--ad video-ad">
                                 <VideoAd id="bsa-zone_1572296522077-3_123456" />
                             </div>
                         </div>

--- a/src/app/components/cards/PostsList.jsx
+++ b/src/app/components/cards/PostsList.jsx
@@ -268,7 +268,29 @@ class PostsList extends React.Component {
         const renderSummary = items =>
             items.map((item, i) => {
                 const every = this.props.adSlots.in_feed_1.every;
-                if (this.props.shouldSeeAds && i >= every && i % every === 0) {
+                if (this.props.videoAdsEnabled && i === 4) {
+                    return (
+                        <div key={item.item}>
+                            <li>
+                                <PostSummary
+                                    account={account}
+                                    post={item.item}
+                                    thumbSize={thumbSize}
+                                    ignore={item.ignore}
+                                    nsfwPref={nsfwPref}
+                                />
+                            </li>
+
+                            <div className="articles__content-block--ad text-center">
+                                <VideoAd id="bsa-zone_1572296522077-3_123456" />
+                            </div>
+                        </div>
+                    );
+                } else if (
+                    this.props.shouldSeeAds &&
+                    i >= every &&
+                    i % every === 0
+                ) {
                     return (
                         <div key={item.item}>
                             <li>
@@ -290,27 +312,6 @@ class PostsList extends React.Component {
                             </div>
                         </div>
                     );
-                }
-                else if (this.props.videoAdsEnabled && i === 4) {
-                    return (
-                        <div key={item.item}>
-                            <li>
-                                <PostSummary
-                                    account={account}
-                                    post={item.item}
-                                    thumbSize={thumbSize}
-                                    ignore={item.ignore}
-                                    nsfwPref={nsfwPref}
-                                />
-                            </li>
-
-                            <div className="articles__content-block--ad">
-                                <VideoAd
-                                    id="bsa-zone_1572296522077-3_123456"
-                                />
-                            </div>
-                        </div>
-                    ); 
                 }
                 return (
                     <li key={item.item}>
@@ -375,7 +376,10 @@ export default connect(
             .get('promoted_posts')
             .toJS();
         const shouldSeeAds = state.app.getIn(['googleAds', 'enabled']);
-        const videoAdsEnabled = state.app.getIn(['googleAds', 'videoAdsEnabled']);
+        const videoAdsEnabled = state.app.getIn([
+            'googleAds',
+            'videoAdsEnabled',
+        ]);
         const adSlots = state.app.getIn(['googleAds', 'adSlots']).toJS();
 
         return {

--- a/src/app/components/cards/PostsList.jsx
+++ b/src/app/components/cards/PostsList.jsx
@@ -268,27 +268,6 @@ class PostsList extends React.Component {
         const renderSummary = items =>
             items.map((item, i) => {
                 const every = this.props.adSlots.in_feed_1.every;
-                if (this.props.videoAdsEnabled && i === 4) {
-                    return (
-                        <div key={item.item}>
-                            <li>
-                                <PostSummary
-                                    account={account}
-                                    post={item.item}
-                                    thumbSize={thumbSize}
-                                    ignore={item.ignore}
-                                    nsfwPref={nsfwPref}
-                                />
-                            </li>
-
-                            <div className="articles__content-block--ad">
-                                <VideoAd
-                                    id="bsa-zone_1572296522077-3_123456"
-                                />
-                            </div>
-                        </div>
-                    ); 
-                }
                 if (this.props.shouldSeeAds && i >= every && i % every === 0) {
                     return (
                         <div key={item.item}>
@@ -311,6 +290,27 @@ class PostsList extends React.Component {
                             </div>
                         </div>
                     );
+                }
+                else if (this.props.videoAdsEnabled && i === 4) {
+                    return (
+                        <div key={item.item}>
+                            <li>
+                                <PostSummary
+                                    account={account}
+                                    post={item.item}
+                                    thumbSize={thumbSize}
+                                    ignore={item.ignore}
+                                    nsfwPref={nsfwPref}
+                                />
+                            </li>
+
+                            <div className="articles__content-block--ad">
+                                <VideoAd
+                                    id="bsa-zone_1572296522077-3_123456"
+                                />
+                            </div>
+                        </div>
+                    ); 
                 }
                 return (
                     <li key={item.item}>

--- a/src/app/components/cards/PostsList.jsx
+++ b/src/app/components/cards/PostsList.jsx
@@ -11,6 +11,7 @@ import debounce from 'lodash.debounce';
 import { findParent } from 'app/utils/DomUtils';
 import Icon from 'app/components/elements/Icon';
 import GptAd from 'app/components/elements/GptAd';
+import VideoAd from 'app/components/elements/VideoAd';
 
 import shouldComponentUpdate from 'app/utils/shouldComponentUpdate';
 
@@ -267,6 +268,27 @@ class PostsList extends React.Component {
         const renderSummary = items =>
             items.map((item, i) => {
                 const every = this.props.adSlots.in_feed_1.every;
+                if (this.props.videoAdsEnabled && i === 4) {
+                    return (
+                        <div key={item.item}>
+                            <li>
+                                <PostSummary
+                                    account={account}
+                                    post={item.item}
+                                    thumbSize={thumbSize}
+                                    ignore={item.ignore}
+                                    nsfwPref={nsfwPref}
+                                />
+                            </li>
+
+                            <div className="articles__content-block--ad">
+                                <VideoAd
+                                    id="bsa-zone_1572296522077-3_123456"
+                                />
+                            </div>
+                        </div>
+                    ); 
+                }
                 if (this.props.shouldSeeAds && i >= every && i % every === 0) {
                     return (
                         <div key={item.item}>
@@ -353,6 +375,7 @@ export default connect(
             .get('promoted_posts')
             .toJS();
         const shouldSeeAds = state.app.getIn(['googleAds', 'enabled']);
+        const videoAdsEnabled = state.app.getIn(['googleAds', 'videoAdsEnabled']);
         const adSlots = state.app.getIn(['googleAds', 'adSlots']).toJS();
 
         return {
@@ -365,6 +388,7 @@ export default connect(
             featured,
             promoted,
             shouldSeeAds,
+            videoAdsEnabled,
             adSlots,
         };
     },

--- a/src/app/components/elements/VideoAd.jsx
+++ b/src/app/components/elements/VideoAd.jsx
@@ -1,0 +1,57 @@
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+
+class VideoAd extends Component {
+    constructor(props) {
+        super(props);
+        const { ad_identifier, enabled } = props;
+
+        this.ad_identifier = '';
+        this.enabled = false;
+
+        if (ad_identifier != '') {
+            this.enabled = enabled;
+            this.ad_identifier = ad_identifier;
+        }
+    }
+
+    componentDidMount() {
+        if (!this.ad_identifier || !this.enabled) return;
+        const ad_identifier = this.ad_identifier;
+    }
+
+    render() {
+        if (!this.ad_identifier || !this.enabled) {
+            return <div id="disabled_video_ad" style={{ display: 'none' }} />;
+        }
+
+        return (
+            <div
+                className="video-ad"
+                id={this.ad_identifier}
+            />
+        );
+    }
+}
+
+VideoAd.propTypes = {
+    ad_identifier: PropTypes.string.isRequired,
+    enabled: PropTypes.bool.isRequired,
+};
+
+VideoAd.defaultProps = {};
+
+export default connect(
+    (state, props) => {
+        const enabled =
+            !!state.app.getIn(['googleAds', 'videoAdsEnabled']) &&
+            !!process.env.BROWSER;
+
+        return {
+            enabled,
+            ad_identifier: props.id,
+            ...props,
+        };
+    },
+    dispatch => ({})
+)(VideoAd); 

--- a/src/app/components/elements/VideoAd.jsx
+++ b/src/app/components/elements/VideoAd.jsx
@@ -25,12 +25,7 @@ class VideoAd extends Component {
             return <div id="disabled_video_ad" style={{ display: 'none' }} />;
         }
 
-        return (
-            <div
-                className="video-ad"
-                id={this.ad_identifier}
-            />
-        );
+        return <div id={this.ad_identifier} />;
     }
 }
 
@@ -54,4 +49,4 @@ export default connect(
         };
     },
     dispatch => ({})
-)(VideoAd); 
+)(VideoAd);

--- a/src/app/components/elements/VideoAd.scss
+++ b/src/app/components/elements/VideoAd.scss
@@ -1,0 +1,3 @@
+.video-ad {
+    text-align: center;
+}

--- a/src/app/components/elements/VideoAd.scss
+++ b/src/app/components/elements/VideoAd.scss
@@ -1,3 +1,3 @@
 .video-ad {
-    text-align: center;
+    div {margin: 0 auto;}
 }

--- a/src/server/app_render.jsx
+++ b/src/server/app_render.jsx
@@ -65,6 +65,7 @@ async function appRender(ctx, locales = false, resolvedAssets = false) {
             gptCategorySlots: config.gpt_category_slots,
             gptBiddingSlots: config.gpt_bidding_slots,
             gptBannedTags: config.gpt_banned_tags,
+            videoAdsEnabled: !!config.video_ads_enabled,
         };
         const cookieConsent = {
             enabled: !!config.cookie_consent_enabled,
@@ -109,6 +110,7 @@ async function appRender(ctx, locales = false, resolvedAssets = false) {
             shouldSeeAds: googleAds.enabled,
             gptEnabled: googleAds.gptEnabled,
             adClient: googleAds.client,
+            videoAdsEnabled: googleAds.videoAdsEnabled,
             gptBidding: googleAds.gptBidding,
             shouldSeeCookieConsent: cookieConsent.enabled,
             cookieConsentApiKey: cookieConsent.api_key,

--- a/src/server/server-html.jsx
+++ b/src/server/server-html.jsx
@@ -234,14 +234,7 @@ export default function ServerHTML({
                     />
                 ) : null}
                 {videoAdsEnabled ? (
-                    <script
-                        dangerouslySetInnerHTML={{
-                            __html: `
-                            <!-- Steemit_S2S_1x1 -->
-                            <div id="bsa-zone_1572296522077-3_123456"></div>
-                        `,
-                        }}
-                    />
+                            <div id="bsa-zone_1572296522077-3_123456" />
                 ) : null}
             </body>
         </html>

--- a/src/server/server-html.jsx
+++ b/src/server/server-html.jsx
@@ -10,6 +10,7 @@ export default function ServerHTML({
     shouldSeeAds,
     adClient,
     gptEnabled,
+    videoAdsEnabled,
     gptBannedTags,
     gptBidding,
     shouldSeeCookieConsent,
@@ -228,6 +229,16 @@ export default function ServerHTML({
                                 _bsa.init('fancybar', 'CE7D653L', 'placement:steemitcom');
                               }
                             })();
+                        `,
+                        }}
+                    />
+                ) : null}
+                {videoAdsEnabled ? (
+                    <script
+                        dangerouslySetInnerHTML={{
+                            __html: `
+                            <!-- Steemit_S2S_1x1 -->
+                            <div id="bsa-zone_1572296522077-3_123456"></div>
                         `,
                         }}
                     />

--- a/src/server/server-html.jsx
+++ b/src/server/server-html.jsx
@@ -10,7 +10,6 @@ export default function ServerHTML({
     shouldSeeAds,
     adClient,
     gptEnabled,
-    videoAdsEnabled,
     gptBannedTags,
     gptBidding,
     shouldSeeCookieConsent,
@@ -232,9 +231,6 @@ export default function ServerHTML({
                         `,
                         }}
                     />
-                ) : null}
-                {videoAdsEnabled ? (
-                            <div id="bsa-zone_1572296522077-3_123456" />
                 ) : null}
             </body>
         </html>


### PR DESCRIPTION
This adds a video ad after the 5th post in a post list when turned on via environment variable `VIDEO_ADS_ENABLED`. It adds *.streamrail.com as a default source for media streaming. I added this because we just use the default for media sources and do not set them via environment variable as they don't change very often.

These three hosts are required to be added to the `connect-src` CSP directives, but can be added via environment variable: `sdk.streamrail.com api.vidiom.net *.streamrail.net`.

![Screen Shot 2019-12-02 at 2 42 08 PM](https://user-images.githubusercontent.com/23157604/69989795-6bc6b280-1512-11ea-8aed-d647b08d9281.png)
