### PR TITLE
Make design consistent with post index

### DIFF
--- a/src/app/components/pages/CommunitiesIndex.jsx
+++ b/src/app/components/pages/CommunitiesIndex.jsx
@@ -38,7 +38,7 @@ export default class CommunitiesIndex extends React.Component {
 
         const row = comm => (
             <tr key={comm.name}>
-                <th width="600">
+                <th>
                     <Link to={`/trending/${comm.name}`}>{comm.title}</Link>
                     {role(comm)}
                     <br />
@@ -48,7 +48,7 @@ export default class CommunitiesIndex extends React.Component {
                         posters &bull; {comm.num_pending} posts
                     </small>
                 </th>
-                <td width="40">
+                <td>
                     <SubscribeButton community={comm.name} />
                 </td>
             </tr>

--- a/src/app/components/pages/CommunitiesIndex.scss
+++ b/src/app/components/pages/CommunitiesIndex.scss
@@ -7,4 +7,24 @@
     table td {vertical-align: middle; color: #666; text-align: center;}
     table small {color: #999; display: block;}
     table .button {margin: 0}
+
+    &.c-sidebar__module {
+        /* Larger than Medium */
+        @media screen and (min-width: 64.0625em) {
+            padding: 1.5em 4em;
+        }
+    }
+
+    table th {
+        width: 600px;
+
+        /* Larger than Small */
+        @media screen and (min-width: 40.0625em) {
+            padding-right: 6%;
+        }
+    }
+
+    table td {
+        width: 40px;
+    }
 }

--- a/src/app/components/pages/CommunitiesIndex.scss
+++ b/src/app/components/pages/CommunitiesIndex.scss
@@ -1,5 +1,4 @@
 .CommunitiesIndex {
-    max-width: 800px;
     table {margin-top: 1em;}
     table tbody {background: transparent;}
     table tbody tr {background: transparent !important;}

--- a/src/app/components/pages/PostsIndex.scss
+++ b/src/app/components/pages/PostsIndex.scss
@@ -199,7 +199,7 @@
 
 .articles {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
-  padding: 0.25em 1em;
+  padding: 0em 1em;
   transition: all 0.2s ease-out;
   border: transparent;
   min-width: 300px;
@@ -212,7 +212,7 @@
     font-family: sans-serif;
   }
   @include MQ(M) {
-    padding: 0.25em 1em;
+    padding: 0em 1em;
     min-width: 500px;
     max-width: 664px;
     order: 2;


### PR DESCRIPTION
- allow community content to take all available width
- align the top of each column

Desktop:
![FireShot Capture 045 - Communities — Steemit - http___steemit local_communities](https://user-images.githubusercontent.com/310654/70691087-5882c680-1d0c-11ea-9c02-be799450b783.jpg)

Mobile:
![Screen Shot 2019-12-12 at 6 13 30 pm](https://user-images.githubusercontent.com/310654/70691097-5e78a780-1d0c-11ea-9145-85768b89d370.jpg)

Tablet:
![Screen Shot 2019-12-12 at 6 19 13 pm](https://user-images.githubusercontent.com/310654/70691098-5e78a780-1d0c-11ea-8a04-aec879b3db5b.jpg)
