### PR TITLE
Only show Follow button in user profile banner when we are sure.

### DIFF
--- a/src/app/components/elements/Follow/index.jsx
+++ b/src/app/components/elements/Follow/index.jsx
@@ -85,7 +85,12 @@ export default class Follow extends React.Component {
         }
 
         const { follower, following } = this.props; // html
+
         // Show follow preview for new users
+        if (typeof window === 'undefined') {
+            return null;
+        }
+
         if (!follower || !following)
             return (
                 <span>
@@ -107,9 +112,11 @@ export default class Follow extends React.Component {
         const cnBusy = busy ? 'disabled' : '';
         const cnActive = 'button' + (fat ? '' : ' slim');
         const cnInactive = cnActive + ' hollow secondary ' + cnBusy;
+
         return (
             <span>
                 {showFollow &&
+                    followingWhat !== null &&
                     followingWhat !== 'blog' && (
                         <label className={cnInactive} onClick={this.follow}>
                             {tt('g.follow')}


### PR DESCRIPTION
- Show "Follow" button from server side rendering
- If user is logged on, the frontend will hide the "Follow" button until it gets a definitive result from API.