### PR TITLE
Allow setting of custom max_accepted_payout values...

### DIFF
--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -374,7 +374,12 @@
         "payout_option_description":
             "What type of tokens do you want as rewards from this post?",
         "current_default": "Default",
-        "update_default_in_settings": "Update"
+        "update_default_in_settings": "Update",
+        "max_accepted_payout": "Maximum Accepted Payout",
+        "max_accepted_payout_description":
+            "SBD value of the maximum payout this post will receive.",
+        "unlimited": "No limit",
+        "custom_value": "Custom value"
     },
     "postfull_jsx": {
         "this_post_is_not_available_due_to_a_copyright_claim":

--- a/src/app/locales/fr.json
+++ b/src/app/locales/fr.json
@@ -346,7 +346,12 @@
         "payout_option_description":
             "Quel type de jeton voulez-vous comme récompense pour cet article?",
         "current_default": "Défaut",
-        "update_default_in_settings": "Mettre à jour"
+        "update_default_in_settings": "Mettre à jour",
+        "max_accepted_payout": "Gains maximum acceptés",
+        "max_accepted_payout_description":
+            "Valeur max (en SBD) de gains que ce post pourra recevoir.",
+        "unlimited": "Sans limite",
+        "custom_value": "Valeur specifiée"
     },
     "postfull_jsx": {
         "this_post_is_not_available_due_to_a_copyright_claim":


### PR DESCRIPTION
...from the advanced settings when creating a post

The "decline payout" has also been moved from payout type to max accepted payout as this is where it should be.

![Screen Shot 2020-01-08 at 7 43 10 am](https://user-images.githubusercontent.com/310654/71929250-5158b680-31ed-11ea-854e-ff16a9f56326.jpg)

![Screen Shot 2020-01-08 at 7 43 16 am](https://user-images.githubusercontent.com/310654/71929248-4f8ef300-31ed-11ea-8187-6261f46dac42.jpg)

![Screen Shot 2020-01-08 at 7 43 26 am](https://user-images.githubusercontent.com/310654/71929245-4dc52f80-31ed-11ea-9eca-6fd86d372be4.jpg)
