### PR TITLE
3665 bugfix notifications mark as read

### DIFF
--- a/src/app/components/cards/NotificationsList.jsx
+++ b/src/app/components/cards/NotificationsList.jsx
@@ -204,7 +204,6 @@ export default connect(
         },
         markAsRead: (username, timeNow) => {
             const successCallback = (user, time) => {
-                console.log('...waiting 10 seconds...');
                 setTimeout(() => {
                     dispatch(
                         globalActions.receiveUnreadNotifications({
@@ -216,7 +215,7 @@ export default connect(
                         })
                     );
                     dispatch(globalActions.notificationsLoading(false));
-                }, 10000);
+                }, 6000);
             };
 
             return dispatch(

--- a/src/app/components/cards/NotificationsList.jsx
+++ b/src/app/components/cards/NotificationsList.jsx
@@ -4,7 +4,6 @@ import { connect } from 'react-redux';
 import TimeAgoWrapper from 'app/components/elements/TimeAgoWrapper';
 import LoadingIndicator from 'app/components/elements/LoadingIndicator';
 import { actions as fetchDataSagaActions } from 'app/redux/FetchDataSaga';
-import * as transactionActions from 'app/redux/TransactionReducer';
 import * as globalActions from 'app/redux/GlobalReducer';
 import ClaimBox from 'app/components/elements/ClaimBox';
 import Callout from 'app/components/elements/Callout';
@@ -66,6 +65,7 @@ class NotificationsList extends React.Component {
     onClickMarkAsRead = e => {
         e.preventDefault();
         const { username, markAsRead } = this.props;
+        debugger;
         markAsRead(username, new Date().toISOString().slice(0, 19));
     };
 
@@ -206,16 +206,22 @@ export default connect(
         },
         markAsRead: (username, timeNow) => {
             const successCallback = (user, time) => {
-                dispatch(
-                    globalActions.receiveUnreadNotifications({
-                        name: user,
-                        unreadNotifications: {
-                            lastread: time,
-                            unread: 0,
-                        },
-                    })
+                console.log(
+                    'mark as read success callback...wait 10 seconds...'
                 );
-                dispatch(globalActions.notificationsLoading(false));
+                setTimeout(() => {
+                    dispatch(
+                        globalActions.receiveUnreadNotifications({
+                            name: user,
+                            unreadNotifications: {
+                                lastread: time,
+                                unread: 0,
+                            },
+                        })
+                    );
+                    dispatch(globalActions.notificationsLoading(false));
+                    console.log('mark as read 10 seconds over');
+                }, 10000);
             };
 
             return dispatch(

--- a/src/app/components/cards/NotificationsList.jsx
+++ b/src/app/components/cards/NotificationsList.jsx
@@ -65,7 +65,6 @@ class NotificationsList extends React.Component {
     onClickMarkAsRead = e => {
         e.preventDefault();
         const { username, markAsRead } = this.props;
-        debugger;
         markAsRead(username, new Date().toISOString().slice(0, 19));
     };
 
@@ -84,7 +83,6 @@ class NotificationsList extends React.Component {
         const renderItem = item => {
             const unRead =
                 Date.parse(`${lastRead}Z`) <= Date.parse(`${item.date}Z`);
-            console.log(unRead);
             return (
                 <div
                     key={item.id}
@@ -206,9 +204,7 @@ export default connect(
         },
         markAsRead: (username, timeNow) => {
             const successCallback = (user, time) => {
-                console.log(
-                    'mark as read success callback...wait 10 seconds...'
-                );
+                console.log('...waiting 10 seconds...');
                 setTimeout(() => {
                     dispatch(
                         globalActions.receiveUnreadNotifications({
@@ -220,7 +216,6 @@ export default connect(
                         })
                     );
                     dispatch(globalActions.notificationsLoading(false));
-                    console.log('mark as read 10 seconds over');
                 }, 10000);
             };
 

--- a/src/app/components/modules/Header/index.jsx
+++ b/src/app/components/modules/Header/index.jsx
@@ -7,7 +7,6 @@ import Headroom from 'react-headroom';
 import resolveRoute from 'app/ResolveRoute';
 import tt from 'counterpart';
 import { APP_NAME } from 'app/client_config';
-import SortOrder from 'app/components/elements/SortOrder';
 import ElasticSearchInput from 'app/components/elements/ElasticSearchInput';
 import IconButton from 'app/components/elements/IconButton';
 import DropdownMenu from 'app/components/elements/DropdownMenu';
@@ -22,6 +21,7 @@ import Announcement from 'app/components/elements/Announcement';
 import GptAd from 'app/components/elements/GptAd';
 import { Map } from 'immutable';
 import ReactMutationObserver from '../../utils/ReactMutationObserver';
+import LoadingIndicator from 'app/components/elements/LoadingIndicator';
 
 class Header extends React.Component {
     static propTypes = {
@@ -120,16 +120,11 @@ class Header extends React.Component {
 
     render() {
         const {
-            category,
-            order,
             pathname,
-            current_account_name,
             username,
             showLogin,
             logout,
             loggedIn,
-            vertical,
-            nightmodeEnabled,
             toggleNightmode,
             showSidePanel,
             navigate,
@@ -137,6 +132,7 @@ class Header extends React.Component {
             content,
             walletUrl,
             unreadNotificationCount,
+            notificationActionPending,
         } = this.props;
 
         let { showAd, showAnnouncement } = this.state;
@@ -267,7 +263,6 @@ class Header extends React.Component {
         const replies_link = `/@${username}/replies`;
         const account_link = `/@${username}`;
         const comments_link = `/@${username}/comments`;
-        const settings_link = `/@${username}/settings`;
         const notifs_link = `/@${username}/notifications`;
         const wallet_link = `${walletUrl}/@${username}`;
         const notif_label =
@@ -393,17 +388,32 @@ class Header extends React.Component {
                                         <li className={'Header__userpic '}>
                                             <Userpic account={username} />
                                         </li>
-                                        {unreadNotificationCount > 0 && (
-                                            <div
-                                                className={
-                                                    'Header__notification'
-                                                }
-                                            >
-                                                <span>
-                                                    {unreadNotificationCount}
-                                                </span>
-                                            </div>
-                                        )}
+                                        {!notificationActionPending &&
+                                            unreadNotificationCount > 0 && (
+                                                <div
+                                                    className={
+                                                        'Header__notification'
+                                                    }
+                                                >
+                                                    <span>
+                                                        {
+                                                            unreadNotificationCount
+                                                        }
+                                                    </span>
+                                                </div>
+                                            )}
+                                        {unreadNotificationCount > 0 &&
+                                            notificationActionPending && (
+                                                <div
+                                                    className={
+                                                        'Header__notification Header__notification--loading'
+                                                    }
+                                                >
+                                                    <span>
+                                                        <LoadingIndicator type="circle" />
+                                                    </span>
+                                                </div>
+                                            )}
                                     </DropdownMenu>
                                 )}
                                 {/*HAMBURGER*/}
@@ -487,6 +497,10 @@ const mapStateToProps = (state, ownProps) => {
         gptEnabled,
         content,
         unreadNotificationCount,
+        notificationActionPending: state.global.getIn([
+            'notifications',
+            'loading',
+        ]),
         ...ownProps,
     };
 };

--- a/src/app/components/modules/Header/index.jsx
+++ b/src/app/components/modules/Header/index.jsx
@@ -402,18 +402,6 @@ class Header extends React.Component {
                                                     </span>
                                                 </div>
                                             )}
-                                        {unreadNotificationCount > 0 &&
-                                            notificationActionPending && (
-                                                <div
-                                                    className={
-                                                        'Header__notification Header__notification--loading'
-                                                    }
-                                                >
-                                                    <span>
-                                                        <LoadingIndicator type="circle" />
-                                                    </span>
-                                                </div>
-                                            )}
                                     </DropdownMenu>
                                 )}
                                 {/*HAMBURGER*/}

--- a/src/app/components/modules/Header/styles.scss
+++ b/src/app/components/modules/Header/styles.scss
@@ -123,6 +123,9 @@
     > span {
         color: white;
     }
+    &--loading {
+     background: transparent; 
+    }
 }
 
 span.Header__hamburger.toggle-menu {

--- a/src/app/redux/FetchDataSaga.js
+++ b/src/app/redux/FetchDataSaga.js
@@ -305,6 +305,9 @@ export function* markNotificationsAsReadSaga(action) {
                     successCallback(username, timeNow);
                 },
                 errorCallback: () => {
+                    console.log(
+                        'There was an error marking notifications as read!'
+                    );
                     globalActions.notificationsLoading(false);
                 },
             })


### PR DESCRIPTION
Closes #3665 was being caused by:
1. Front-end marks notifications as read.
2. Hivemind responds that mark-as-read action was successful.
3. Front-end immediately makes a request for all 'unread notifications'.
4. Hivemind responds with the previously unread notifications count because the action in 2. has not propagated to the db-layer/blockchain yet.
5. User thinks the unread notifications count is wrong and instead refreshes the browser, (F5).

This PR adds a *10s* delay between 2 and 3.