### PR TITLE
Post template management

### DIFF
--- a/src/app/components/cards/PostTemplateSelector.jsx
+++ b/src/app/components/cards/PostTemplateSelector.jsx
@@ -1,0 +1,88 @@
+import React from 'react';
+import tt from 'counterpart';
+
+class PostTemplateSelector extends React.Component {
+    static propTypes = {
+        username: React.PropTypes.string.isRequired,
+        onChange: React.PropTypes.func.isRequired,
+    };
+
+    render() {
+        const { username } = this.props;
+        if (!username || typeof window === 'undefined') {
+            return null;
+        }
+
+        const lsEntryName = `steemPostTemplates-${username}`;
+        let userTemplates = window.localStorage.getItem(lsEntryName);
+        if (userTemplates) {
+            userTemplates = JSON.parse(userTemplates);
+        } else {
+            userTemplates = null;
+        }
+
+        const handleTemplateSelection = (event, create = false) => {
+            const selectedTemplateName = event.target.value;
+            this.props.onChange(
+                create ? `create_${selectedTemplateName}` : selectedTemplateName
+            );
+        };
+
+        return (
+            <div>
+                <div className="row">
+                    <div className="column">
+                        <h4>{tt('post_template_selector_jsx.templates')}</h4>
+                        <p>
+                            {tt(
+                                'post_template_selector_jsx.templates_description'
+                            )}
+                        </p>
+                    </div>
+                </div>
+                <div className="row">
+                    <div className="small-12 medium-6 large-12 columns">
+                        {userTemplates && (
+                            <select onChange={handleTemplateSelection}>
+                                <option value="">
+                                    {tt(
+                                        'post_template_selector_jsx.choose_template'
+                                    )}
+                                </option>
+                                {userTemplates.map((template, idx) => (
+                                    <option value={template.name} key={idx}>
+                                        {template.name}
+                                    </option>
+                                ))}
+                            </select>
+                        )}
+                        {!userTemplates && (
+                            <span>
+                                {tt(
+                                    'post_template_selector_jsx.create_template_first'
+                                )}
+                            </span>
+                        )}
+                    </div>
+                </div>
+                <div className="row">
+                    <div className="small-12 medium-6 large-12 columns">
+                        <input
+                            id="new_template_name"
+                            type="text"
+                            className="input-group-field bold"
+                            placeholder={tt(
+                                'post_template_selector_jsx.new_template_name'
+                            )}
+                            onChange={event => {
+                                handleTemplateSelection(event, true);
+                            }}
+                        />
+                    </div>
+                </div>
+            </div>
+        );
+    }
+}
+
+export default PostTemplateSelector;

--- a/src/app/components/elements/ReplyEditor.jsx
+++ b/src/app/components/elements/ReplyEditor.jsx
@@ -217,9 +217,9 @@ class ReplyEditor extends React.Component {
                         name: nextProps.postTemplateName.replace('create_', ''),
                         beneficiaries,
                         payoutType,
-                        markdown: body.value,
-                        title: title.value,
-                        tags: tags.value,
+                        markdown: body !== undefined ? body.value : '',
+                        title: title !== undefined ? title.value : '',
+                        tags: tags !== undefined ? tags.value : '',
                     });
 
                     window.localStorage.setItem(

--- a/src/app/components/elements/ReplyEditor.jsx
+++ b/src/app/components/elements/ReplyEditor.jsx
@@ -75,6 +75,7 @@ class ReplyEditor extends React.Component {
         body: PropTypes.string, // initial value
         defaultPayoutType: PropTypes.string,
         payoutType: PropTypes.string,
+        postTemplateName: PropTypes.string,
     };
 
     static defaultProps = {
@@ -190,6 +191,72 @@ class ReplyEditor extends React.Component {
             const ns = nextState;
             const tp = this.props;
             const np = nextProps;
+
+            if (
+                typeof nextProps.postTemplateName !== 'undefined' &&
+                nextProps.postTemplateName !== null
+            ) {
+                const { formId } = tp;
+
+                if (nextProps.postTemplateName.indexOf('create_') === 0) {
+                    const { username } = tp;
+                    const { body, title, tags } = ns;
+                    const { payoutType, beneficiaries } = np;
+                    const lsEntryName = `steemPostTemplates-${username}`;
+
+                    let userTemplates = window.localStorage.getItem(
+                        lsEntryName
+                    );
+                    if (!userTemplates) {
+                        userTemplates = [];
+                    } else {
+                        userTemplates = JSON.parse(userTemplates);
+                    }
+
+                    userTemplates.push({
+                        name: nextProps.postTemplateName.replace('create_', ''),
+                        beneficiaries,
+                        payoutType,
+                        markdown: body.value,
+                        title: title.value,
+                        tags: tags.value,
+                    });
+
+                    window.localStorage.setItem(
+                        lsEntryName,
+                        JSON.stringify(userTemplates)
+                    );
+
+                    this.props.setPostTemplateName(formId, null);
+                } else {
+                    const lsEntryName = `steemPostTemplates-${
+                        nextProps.username
+                    }`;
+                    const userTemplates = JSON.parse(
+                        window.localStorage.getItem(lsEntryName)
+                    );
+
+                    for (let ti = 0; ti < userTemplates.length; ti += 1) {
+                        const template = userTemplates[ti];
+                        if (template.name === nextProps.postTemplateName) {
+                            this.state.body.props.onChange(template.markdown);
+                            this.state.title.props.onChange(template.title);
+                            this.state.tags.props.onChange(template.tags);
+                            this.props.setPayoutType(
+                                formId,
+                                template.payoutType
+                            );
+                            this.props.setBeneficiaries(
+                                formId,
+                                template.beneficiaries
+                            );
+
+                            this.props.setPostTemplateName(formId, null);
+                            break;
+                        }
+                    }
+                }
+            }
 
             // Save curent draft to localStorage
             if (
@@ -996,6 +1063,12 @@ export default formId =>
                 formId,
                 'beneficiaries',
             ]);
+            const postTemplateName = state.user.getIn([
+                'current',
+                'post',
+                formId,
+                'postTemplateName',
+            ]);
             beneficiaries = beneficiaries ? beneficiaries.toJS() : [];
 
             // Post full
@@ -1028,6 +1101,7 @@ export default formId =>
                 defaultPayoutType,
                 payoutType,
                 beneficiaries,
+                postTemplateName,
                 initialValues: { title, body, tags },
                 formId,
             };
@@ -1051,6 +1125,13 @@ export default formId =>
                     userActions.set({
                         key: ['current', 'post', formId, 'beneficiaries'],
                         value: fromJS(beneficiaries),
+                    })
+                ),
+            setPostTemplateName: (formId, postTemplateName) =>
+                dispatch(
+                    userActions.set({
+                        key: ['current', 'post', formId, 'postTemplateName'],
+                        value: postTemplateName,
                     })
                 ),
             reply: ({

--- a/src/app/locales/en.json
+++ b/src/app/locales/en.json
@@ -354,6 +354,15 @@
         "beneficiary_percent_total_invalid":
             "Beneficiary total percentage must be less than 100"
     },
+    "post_template_selector_jsx": {
+        "templates": "Post templates",
+        "templates_description":
+            "You can create post templates locally and load them to create a new blog post. All advanced settings will also be saved and loaded.",
+        "choose_template": "-- Choose a template to load --",
+        "create_template_first": "Please create a template first",
+        "new_template_name": "Name of a new template",
+        "template_saved": "Template saved successfully"
+    },
     "category_selector_jsx": {
         "tag_your_story":
             "Tag (up to 8 tags), the first tag is your main category.",


### PR DESCRIPTION
I've added a template management feature for blog posts.
From the Advanced Settings panel of the Reply Editor, you can now save your post (title, body, tags), its payout type and beneficiaries settings into a local storage configuration that can be reloaded for future posts of the same type.

To create a new template: in the advanced settings, give a name and click the "Save" button
To load an existing template: in the advanced settings, select a template and click the "Save" button.

![Screen Shot 2020-01-15 at 10 36 37 pm](https://user-images.githubusercontent.com/310654/72491969-b8224380-386f-11ea-8950-8638fd7435ad.jpg)

![Screen Shot 2020-01-15 at 10 37 02 pm](https://user-images.githubusercontent.com/310654/72491970-b8224380-386f-11ea-92ee-7e1432de014b.jpg)
