### PR TITLE
3685 relocate pinned post badge

### DIFF
--- a/src/app/components/cards/PostSummary.jsx
+++ b/src/app/components/cards/PostSummary.jsx
@@ -108,9 +108,6 @@ class PostSummary extends React.Component {
                     {isNsfw && <span className="nsfw-flag">nsfw</span>}
                     {post.get('title')}
                 </Link>
-                {post.getIn(['stats', 'is_pinned'], false) && (
-                    <span className="FeaturedTag">Pinned</span>
-                )}
             </h2>
         );
 
@@ -155,7 +152,6 @@ class PostSummary extends React.Component {
                                     className="updated"
                                 />
                             </span>
-
                             {full_power && (
                                 <span
                                     className="articles__icon-100"
@@ -163,6 +159,9 @@ class PostSummary extends React.Component {
                                 >
                                     <Icon name="steempower" />
                                 </span>
+                            )}
+                            {post.getIn(['stats', 'is_pinned'], false) && (
+                                <span className="FeaturedTag">Pinned</span>
                             )}
                         </Link>
                     </div>

--- a/src/app/components/cards/PostsList.scss
+++ b/src/app/components/cards/PostsList.scss
@@ -10,7 +10,6 @@
         margin: 0 1rem 0 0.5rem;
         border-radius: 0.3rem;
         font-size: 0.75rem;
-        vertical-align: 15%;
         @include themify($themes) {
             background-color: themed('colorAccent');
             color: themed('buttonText');


### PR DESCRIPTION
Closes #3685
# Desktop:
<img width="827" alt="Screen Shot 2020-02-03 at 11 11 02 AM" src="https://user-images.githubusercontent.com/3374538/73670100-a239be80-4676-11ea-90dd-0dd5073b5eac.png">

# Mobile
<img width="397" alt="Screen Shot 2020-02-03 at 11 16 40 AM" src="https://user-images.githubusercontent.com/3374538/73670127-af56ad80-4676-11ea-858a-e986054422c8.png">

