### PR TITLE
header spacing, fixes #3729

### DIFF
--- a/src/app/components/modules/Header/index.jsx
+++ b/src/app/components/modules/Header/index.jsx
@@ -333,7 +333,7 @@ class Header extends React.Component {
                                 </Link>
                             </div>
 
-                            <div className="large-3 columns show-for-large large-centered Header__sort">
+                            <div className="large-1 columns show-for-large large-centered Header__sort">
                                 {/*
                                 <SortOrder
                                     sortOrder={order}
@@ -344,7 +344,7 @@ class Header extends React.Component {
                                 */}
                             </div>
 
-                            <div className="small-6 medium-8 large-5 columns Header__buttons">
+                            <div className="small-6 medium-8 large-7 columns Header__buttons">
                                 {/*NOT LOGGED IN SIGN IN AND SIGN UP LINKS*/}
                                 {!loggedIn && (
                                     <span className="Header__user-signup show-for-medium">


### PR DESCRIPTION
### Before
<img width="1223" alt="Screen Shot 2020-02-21 at 11 03 56 AM" src="https://user-images.githubusercontent.com/3374538/75053935-190cef00-54a0-11ea-9bd0-fcf9f8195a09.png">

### After
<img width="986" alt="Screen Shot 2020-02-21 at 11 47 16 AM" src="https://user-images.githubusercontent.com/3374538/75053947-1f02d000-54a0-11ea-84b9-8775294f9fe1.png">
