### PR TITLE
Fix reply editor when replying to a comment

### DIFF
--- a/src/app/components/cards/Comment.jsx
+++ b/src/app/components/cards/Comment.jsx
@@ -391,7 +391,7 @@ class CommentImpl extends React.Component {
                     </div>
                     <div className="Comment__footer">{controls}</div>
                 </div>
-                <div className="Comment__replies hfeed">
+                <div className="Comment__replies hfeed comment-editor">
                     {showReply && renderedEditor}
                     {replies}
                 </div>


### PR DESCRIPTION
@gl2748 here is the fix for the side-by-side editor

Bug: when replying to a comment, it's showing side-by-side while it should be one above the other for comment editing.