### PR TITLE
change bt to poloniex

### DIFF
--- a/src/app/components/modules/Modals.jsx
+++ b/src/app/components/modules/Modals.jsx
@@ -79,8 +79,7 @@ class Modals extends React.Component {
             const new_window = window.open();
             new_window.opener = null;
             new_window.location =
-                'https://blocktrades.us/?input_coin_type=eth&output_coin_type=steem_power&receive_address=' +
-                username;
+                'https://poloniex.com/exchange#btc_steem';
         };
 
         return (

--- a/src/app/components/modules/SidePanel/index.jsx
+++ b/src/app/components/modules/SidePanel/index.jsx
@@ -105,13 +105,9 @@ const SidePanel = ({
         ],
         exchanges: [
             {
-                value: 'blocktrades',
-                label: 'Blocktrades',
-                link: username
-                    ? `https://blocktrades.us/?input_coin_type=eth&output_coin_type=steem&receive_address=${
-                          username
-                      }`
-                    : `https://blocktrades.us/?input_coin_type=eth&output_coin_type=steem`,
+                value: 'poloniex',
+                label: 'Poloniex',
+                link: 'https://poloniex.com/exchange#btc_steem',
             },
             {
                 value: 'gopax',


### PR DESCRIPTION
We should go forward and add poloniex when people click on Buy Steem in Steemit.com. Anyway at this time blocktrades does not support Steem purchase.