### PR TITLE
set the current rate vests_per_trx

### DIFF
--- a/src/shared/UniversalRender.jsx
+++ b/src/shared/UniversalRender.jsx
@@ -266,7 +266,7 @@ export async function serverRender(
         // const tronConfig = await getTronConfig();
         const tronConfig = {
             tron_reward_switch: 'on',
-            vests_per_trx: 1913,
+            vests_per_trx: 0, // currently no trx rewards
             unbind_tip_limit: 5,
         };
         if (tronConfig !== false) {


### PR DESCRIPTION
Currently no TRX rewards are paid.
The condenser still calculate TRX rewards for payout. 
The change involves updating the `tronConfig` object to reflect the current reward status.