### PR TITLE
Use datalist to show the nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,12 @@ can be set using environment variables (see configuration section below for
 more information). If you need to install docker, you can get it at
 https://get.docker.com
 
+To build a docker image:
+
+```bash
+docker build -t steemit/condenser -f Dockerfile .
+```
+
 To bring up a running container it's as simple as this:
 
 ```bash
@@ -35,7 +41,7 @@ docker run -it -p 8080:8080 steemit/condenser
 Environment variables can be added like this:
 
 ```bash
-docker run -it -p 8080:8080 steemit/condenser
+docker run -it -e SDC_CLIENT_STEEMD_URL="wss://steemd.steemit.com" -p 8080:8080 steemit/condenser
 ```
 
 If you would like to modify, build, and run condenser using docker, it's as

--- a/src/app/components/modules/Settings.jsx
+++ b/src/app/components/modules/Settings.jsx
@@ -313,16 +313,17 @@ class Settings extends React.Component {
 
                         <label>{tt('settings_jsx.rpc_select')}</label>
 
-                        <select
+                        <input
+                            list="rpcNodes"
                             defaultValue={rpcNode}
                             onChange={this.handleSelectRPCNode}
-                        >
+                            className="rpc-input"
+                        />
+                        <datalist id="rpcNodes">
                             {$STM_Config.steemd_rpc_list.map((rpc, idx) => (
-                                <option key={idx} value={rpc}>
-                                    {rpc}
-                                </option>
+                                <option key={idx} value={rpc} />
                             ))}
-                        </select>
+                        </datalist>
 
                         <label>
                             {rpcError ||

--- a/src/app/components/modules/Settings.scss
+++ b/src/app/components/modules/Settings.scss
@@ -62,4 +62,25 @@
         font-family: $font-primary;
         font-size: 1.125rem!important;
     }
+    .rpc-input {
+        width: 100%;
+        padding: 0.5rem;
+        border: 1px solid #ccc;
+        border-radius: 4px;
+        font-size: 1rem;
+        background-color: #fff;
+        color: #333;
+        transition: border-color 0.2s ease;
+
+        &:focus {
+            border-color: #007bff;
+            outline: none;
+        }
+    }
+    datalist {
+        option {
+            font-size: 1rem;
+            color: #333;
+        }
+	}
 }


### PR DESCRIPTION
This PR replaces the select dropdown for selecting the Steem RPC node with an input and datalist tags improving the user experience by allowing searchable suggestions and free-text input.

## Why this change?
- Enhanced UX: Users can now type directly into the input field to quickly find RPC nodes, especially useful if the list grows.
- Flexibility: Allows advanced users to input custom RPC endpoints if needed.
- Modernization: Provides a cleaner, more responsive UI, resembling an auto-complete experience.

## Changes Made:
- Replaced the select element with an input + datalist in the Settings component.
- Updated Settings.scss to style the new input field for consistency with the existing UI.

## Testing:
- Verified that the new input shows all RPC nodes as suggestions.

Before:
![image](https://github.com/user-attachments/assets/a2aec0f3-f1fe-4d43-ac6a-88e249226328)

After: (especially that users can add their own node which is not in the list)
![image](https://github.com/user-attachments/assets/acf7da31-4dfa-48db-8c20-e3f6f585755f)
