### PR TITLE
Voting Bug Fix

### DIFF
--- a/src/app/components/cards/PostFull.jsx
+++ b/src/app/components/cards/PostFull.jsx
@@ -110,7 +110,7 @@ class PostFull extends React.Component {
             PostFullReplyEditor: ReplyEditor(formId + '-reply'),
             PostFullEditEditor: ReplyEditor(formId + '-edit'),
         });
-        if (!community && category) {
+        if (!community && category && category.startsWith('hive-')) {
             getCommunity(category);
         }
         if (process.env.BROWSER) {


### PR DESCRIPTION
When a post isn't in a community, an "undefined" category is sent to GetCommunity which causes an error.