### PR TITLE
Change "about" from textbox to textarea

### DIFF
--- a/src/app/components/modules/Settings.jsx
+++ b/src/app/components/modules/Settings.jsx
@@ -427,6 +427,7 @@ class Settings extends React.Component {
                                     <textarea
                                         {...about.props}
                                         maxLength="160"
+                                        rows="4"
                                         autoComplete="off"
                                     />
                                 </label>

--- a/src/app/components/modules/Settings.jsx
+++ b/src/app/components/modules/Settings.jsx
@@ -424,8 +424,7 @@ class Settings extends React.Component {
                                 </div>
                                 <label>
                                     {tt('settings_jsx.profile_about')}
-                                    <input
-                                        type="text"
+                                    <textarea
                                         {...about.props}
                                         maxLength="160"
                                         autoComplete="off"


### PR DESCRIPTION
#3949 

Tested locally. Updating "About" works fine.

![image](https://github.com/user-attachments/assets/7daf14fc-0f33-473d-9258-5c46f6ad9fee)
