### PR TITLE
fix(images): proxy only first-party via /p

### DIFF
--- a/src/app/utils/Links.test.js
+++ b/src/app/utils/Links.test.js
@@ -314,7 +314,7 @@ describe('Performance', () => {
     it('threespeakImageLink', () => {
         match(
             links.threespeakImageLink,
-            '<a href="https://3speak.online/watch?v=artemislives/tvxkobat" rel="noopener" title="This link will take you away from steemit.com" class="steem-keychain-checked"><img src="https://steemitimages.com/640x0/https://img.3speakcontent.online/tvxkobat/post.png"></a>'
+            '<a href="https://3speak.online/watch?v=artemislives/tvxkobat" rel="noopener" title="This link will take you away from steemit.com" class="steem-keychain-checked"><img src="https://img.3speakcontent.online/tvxkobat/post.png"></a>'
         );
     });
 });

--- a/src/app/utils/ProxifyUrl.js
+++ b/src/app/utils/ProxifyUrl.js
@@ -1,4 +1,6 @@
 /*global $STM_Config:false*/
+import base58 from 'bs58';
+
 /**
  * this regular expression should capture all possible proxy domains
  * Possible URL schemes are:
@@ -10,18 +12,67 @@
  */
 const rProxyDomain = /^http(s)?:\/\/steemit(dev|stage)?images.com\//g;
 const rProxyDomainsDimensions = /http(s)?:\/\/steemit(dev|stage)?images.com\/([0-9]+x[0-9]+)\//g;
-/** Only URLs from this domain get the img_proxy_prefix applied */
-const rCdnSteemitImages = /^https?:\/\/cdn\.steemitimages\.com\//i;
 const NATURAL_SIZE = '0x0/';
 const CAPPED_SIZE = '640x0/';
 const DOUBLE_CAPPED_SIZE = '1280x0/';
 
 export const imageProxy = () => $STM_Config.img_proxy_prefix;
-export const defaultSrcSet = url =>
-    `${url} 1x, ${url.replace(CAPPED_SIZE, DOUBLE_CAPPED_SIZE)} 2x`;
-export const isDefaultImageSize = url =>
-    url.startsWith(`${imageProxy()}${CAPPED_SIZE}`);
+export const defaultSrcSet = url => {
+    // Back-compat: legacy path-based sizing
+    if (typeof url === 'string' && url.includes(CAPPED_SIZE)) {
+        return `${url} 1x, ${url.replace(CAPPED_SIZE, DOUBLE_CAPPED_SIZE)} 2x`;
+    }
+    // New: /p/:base58url?width=640 => 2x is width=1280
+    try {
+        const u = new URL(url);
+        const width = Number.parseInt(u.searchParams.get('width'), 10);
+        if (!Number.isFinite(width) || width <= 0) return `${url} 1x`;
+        u.searchParams.set('width', String(width * 2));
+        return `${url} 1x, ${u.toString()} 2x`;
+    } catch (e) {
+        return `${url} 1x`;
+    }
+};
+export const isDefaultImageSize = url => {
+    // Back-compat: legacy path-based sizing
+    if (url && url.startsWith(`${imageProxy()}${CAPPED_SIZE}`)) return true;
+    try {
+        const u = new URL(url);
+        return (
+            u.pathname.includes('/p/') &&
+            u.searchParams.get('width') === String(defaultWidth())
+        );
+    } catch (e) {
+        return false;
+    }
+};
 export const defaultWidth = () => Number.parseInt(CAPPED_SIZE.split('x')[0]);
+
+function ensureTrailingSlash(s) {
+    return typeof s === 'string' && s.endsWith('/') ? s : `${s}/`;
+}
+
+function registrableDomain(hostname) {
+    if (!hostname) return '';
+    const parts = hostname
+        .toLowerCase()
+        .split('.')
+        .filter(Boolean);
+    if (parts.length <= 2) return parts.join('.');
+    // Good enough for our current configs (e.g. steemitimages.com).
+    return parts.slice(-2).join('.');
+}
+
+function isFirstPartyImageHost(hostname) {
+    try {
+        const proxyHost = new URL(imageProxy()).hostname;
+        const base = registrableDomain(proxyHost);
+        const h = (hostname || '').toLowerCase();
+        return h === base || h.endsWith(`.${base}`);
+    } catch (e) {
+        return false;
+    }
+}
 
 /**
  * Strips all proxy domains from the beginning of the url. Adds the global proxy if dimension is specified
@@ -38,6 +89,8 @@ export function proxifyImageUrl(url, dimensions = false) {
         const lastProxy = proxyList[proxyList.length - 1];
         respUrl = url.substring(url.lastIndexOf(lastProxy) + lastProxy.length);
     }
+    if (!dimensions) return respUrl;
+
     if (dimensions && $STM_Config && $STM_Config.img_proxy_prefix) {
         let dims =
             typeof dimensions === 'string' && dimensions.endsWith('/')
@@ -55,9 +108,31 @@ export function proxifyImageUrl(url, dimensions = false) {
             dims = CAPPED_SIZE;
         }
 
-        // Only add proxy prefix for images from cdn.steemitimages.com
-        if (rCdnSteemitImages.test(respUrl)) {
-            return $STM_Config.img_proxy_prefix + dims + respUrl;
+        // Third-party images: never proxy/transform. Only first-party domains can go via /p/.
+        try {
+            const target = new URL(respUrl);
+            if (!isFirstPartyImageHost(target.hostname)) return respUrl;
+
+            const dimsNoSlash = dims.endsWith('/') ? dims.slice(0, -1) : dims;
+            const [wStr, hStr] = String(dimsNoSlash).split('x');
+            const width = Number.parseInt(wStr, 10);
+            const height = Number.parseInt(hStr, 10);
+
+            const b58 = base58.encode(Buffer.from(respUrl, 'utf8'));
+            const pBase = `${ensureTrailingSlash(imageProxy())}p/${b58}`;
+            const pUrl = new URL(pBase);
+            pUrl.searchParams.set('mode', 'fit');
+            pUrl.searchParams.set('format', 'match');
+            if (Number.isFinite(width) && width > 0) {
+                pUrl.searchParams.set('width', String(width));
+            }
+            // Important: omit height when 0, to preserve aspect ratio (e.g. 640x0).
+            if (Number.isFinite(height) && height > 0) {
+                pUrl.searchParams.set('height', String(height));
+            }
+            return pUrl.toString();
+        } catch (e) {
+            return respUrl;
         }
     }
     return respUrl;

--- a/src/app/utils/ProxifyUrl.test.js
+++ b/src/app/utils/ProxifyUrl.test.js
@@ -1,5 +1,6 @@
 /*global describe, global, before:false, it*/
 import assert from 'assert';
+import base58 from 'bs58';
 import { proxifyImageUrl } from './ProxifyUrl';
 
 describe('ProxifyUrl', () => {
@@ -28,19 +29,19 @@ describe('ProxifyUrl', () => {
             'https://example.com/img.png'
         );
     });
-    it('naked steemit hosted URL (steemitimages.com not cdn: no prefix)', () => {
+    it('naked steemit hosted URL (first-party domain: use /p/)', () => {
         const url =
             'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg';
-        testCase(url, '256x512', url);
+        testCase(url, '256x512', expectedP(url, { width: 256, height: 512 }));
         testCase(url, false, url);
     });
-    it('proxied steemit hosted URL (strip proxy, no prefix for non-cdn)', () => {
+    it('proxied steemit hosted URL (strip proxy, then /p/ for first-party)', () => {
         const stripped =
             'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg';
         testCase(
             'https://steemitimages.com/0x0/https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
             '256x512',
-            stripped
+            expectedP(stripped, { width: 256, height: 512 })
         );
         testCase(
             'https://steemitimages.com/256x512/https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
@@ -103,14 +104,20 @@ describe('ProxifyUrl', () => {
         testCase(
             'https://steemitdevimages.com/1001x2001/https://steemitimages.com/0x0/https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
             true,
-            'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg'
+            expectedP(
+                'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
+                { width: 1001, height: 2001 }
+            )
         );
     });
     it('preserve dimensions - strip proxies when appropriate (no prefix for non-cdn)', () => {
         testCase(
             'https://steemitimages.com/0x0/https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
             true,
-            'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg'
+            expectedP(
+                'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
+                { width: 640 }
+            )
         );
         testCase(
             'https://steemitimages.com/0x0/https://example.com/img.png',
@@ -120,7 +127,10 @@ describe('ProxifyUrl', () => {
         testCase(
             'https://steemitimages.com/0x0/https://steemitimages.com/100x100/https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
             true,
-            'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg'
+            expectedP(
+                'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
+                { width: 640 }
+            )
         );
         testCase(
             'https://steemitimages.com/0x0/https://steemitimages.com/100x100/https://example.com/img.png',
@@ -128,8 +138,8 @@ describe('ProxifyUrl', () => {
             'https://example.com/img.png'
         );
     });
-    it('dimensions with trailing slash (only cdn.steemitimages.com gets prefix)', () => {
-        // Non-cdn URLs: no prefix
+    it('dimensions with trailing slash (third-party: no /p/)', () => {
+        // Third-party URLs: no /p/
         testCase(
             'https://example.com/img.png',
             '0x0/',
@@ -140,11 +150,14 @@ describe('ProxifyUrl', () => {
             '0x0/',
             'https://example.com/img.gif'
         );
-        // cdn.steemitimages.com: add prefix
+        // First-party (subdomain): use /p/ and omit height when 0 (0x0 => 640x0 cap)
         testCase(
             'https://cdn.steemitimages.com/DQmNRRrBzgpYrFfwD8wWbyPqe5MScZx59gu4sZwkfkw44qu/20220219_125403.jpg',
             '0x0/',
-            'https://steemitimages.com/640x0/https://cdn.steemitimages.com/DQmNRRrBzgpYrFfwD8wWbyPqe5MScZx59gu4sZwkfkw44qu/20220219_125403.jpg'
+            expectedP(
+                'https://cdn.steemitimages.com/DQmNRRrBzgpYrFfwD8wWbyPqe5MScZx59gu4sZwkfkw44qu/20220219_125403.jpg',
+                { width: 640 }
+            )
         );
     });
 });
@@ -158,4 +171,15 @@ const testCase = (inputUrl, outputDims, expectedUrl) => {
             expectedUrl
         }. output was ${outputUrl}`
     );
+};
+
+const expectedP = (url, { width, height } = {}) => {
+    const b58 = base58.encode(Buffer.from(url, 'utf8'));
+    const base = `https://steemitimages.com/p/${b58}`;
+    const params = [];
+    params.push('mode=fit');
+    params.push('format=match');
+    if (width) params.push(`width=${width}`);
+    if (height) params.push(`height=${height}`);
+    return params.length ? `${base}?${params.join('&')}` : base;
 };

--- a/src/app/utils/SlateEditor/Image.js
+++ b/src/app/utils/SlateEditor/Image.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import { proxifyImageUrl } from 'app/utils/ProxifyUrl';
 
 export default connect(
     (state, ownProps) => ownProps,
@@ -80,10 +81,6 @@ export default connect(
             const isFocused = state.selection.hasEdgeIn(node);
             const className = isFocused ? 'active' : null;
 
-            const prefix = $STM_Config.img_proxy_prefix
-                ? $STM_Config.img_proxy_prefix + '0x0/'
-                : '';
-
             const alt = node.data.get('alt');
             const src = node.data.get('src');
 
@@ -96,15 +93,17 @@ export default connect(
             if (!src)
                 return <small className="info">Loading Image&hellip;</small>;
 
-            if (/^https?:\/\//.test(src))
+            if (/^https?:\/\//.test(src)) {
+                const displaySrc = proxifyImageUrl(src, '0x0/');
                 return (
                     <img
                         {...attributes}
-                        src={prefix + src}
+                        src={displaySrc}
                         alt={alt}
                         className={className}
                     />
                 );
+            }
 
             const img = <img src={src} alt={alt} className={className} />;
 

--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -109,7 +109,12 @@ export default function(
                     image.parentNode.replaceChild(pre, image);
                 }
             } else {
-                if (!isProxifyImages) proxifyImages(doc);
+                // Historical note: `isProxifyImages` is used by some callers to disable
+                // proxying/transforms. Even then, we still want to strip legacy proxy shells
+                // like `https://{imagehoster}/{dims}/https://...` so environments reading
+                // cross-env chain data don't accidentally keep a wrong proxy prefix.
+                if (isProxifyImages) stripLegacyProxyImages(doc);
+                else proxifyImages(doc);
             }
         }
         // console.log('state', state)
@@ -270,6 +275,17 @@ function proxifyImages(doc) {
         const url = node.getAttribute('src');
         if (!linksRe.local.test(url))
             node.setAttribute('src', proxifyImageUrl(url, true));
+    });
+}
+
+// Strip legacy proxy wrappers but do not add any new proxy/transform prefix.
+function stripLegacyProxyImages(doc) {
+    if (!doc) return;
+    [...doc.getElementsByTagName('img')].forEach(node => {
+        const url = node.getAttribute('src');
+        if (!url) return;
+        if (!linksRe.local.test(url))
+            node.setAttribute('src', proxifyImageUrl(url, false));
     });
 }
 

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -30,6 +30,18 @@ describe('htmlready', () => {
         expect(externalDomainResult).toEqual(externalDomainDirty);
     });
 
+    it('should strip legacy proxy shells even when image proxying is disabled', () => {
+        global.$STM_Config = {
+            img_proxy_prefix: 'https://steemitdevimages.com/',
+        };
+        const legacy =
+            '<xml xmlns="http://www.w3.org/1999/xhtml"><img src="https://steemitdevimages.com/640x0/https://cdn.steemitimages.com/DQmNR3Y1QgLGEQtAPdvBchPzf6ijoJCjPKwHDq5Zt9cYR4k/1000005419.jpg" xmlns="http://www.w3.org/1999/xhtml"/></xml>';
+        const expected =
+            '<xml xmlns="http://www.w3.org/1999/xhtml"><a href="https://cdn.steemitimages.com/DQmNR3Y1QgLGEQtAPdvBchPzf6ijoJCjPKwHDq5Zt9cYR4k/1000005419.jpg" target="_blank"><img src="https://cdn.steemitimages.com/DQmNR3Y1QgLGEQtAPdvBchPzf6ijoJCjPKwHDq5Zt9cYR4k/1000005419.jpg" xmlns="http://www.w3.org/1999/xhtml"/></a></xml>';
+        const res = HtmlReady(legacy, { isProxifyImages: true }).html;
+        expect(res).toEqual(expected);
+    });
+
     it('should not allow links where the text portion contains steemit.com but the link does not', () => {
         // There isn't an easy way to mock counterpart, even with proxyquire, so we just test for the missing translation message -- ugly but ok
 


### PR DESCRIPTION
Stop proxying third-party image URLs. For first-party steemitimages domains, generate /p/:base58url URLs with width/height query parameters (omitting height=0) and update srcset/default-size logic accordingly.