### PR TITLE
fix(images): canonicalize cover_image host before /p/ encoding

### DIFF
--- a/src/app/utils/ProxifyUrl.js
+++ b/src/app/utils/ProxifyUrl.js
@@ -74,6 +74,30 @@ function isFirstPartyImageHost(hostname) {
     }
 }
 
+function normalizeFirstPartyUploadURL(targetUrl) {
+    try {
+        const proxyHost = new URL(imageProxy()).hostname;
+        const base = registrableDomain(proxyHost);
+        if (base !== 'steemitimages.com') return targetUrl;
+
+        const h = (targetUrl.hostname || '').toLowerCase();
+        if (h !== base) return targetUrl;
+
+        // For legacy profile cover_image values like https://steemitimages.com/D.../file.jpg,
+        // rewrite to the canonical CDN host before base58 encoding.
+        if (
+            typeof targetUrl.pathname === 'string' &&
+            targetUrl.pathname.startsWith('/D')
+        ) {
+            targetUrl.hostname = `cdn.${base}`;
+            return targetUrl;
+        }
+        return targetUrl;
+    } catch (e) {
+        return targetUrl;
+    }
+}
+
 /**
  * Strips all proxy domains from the beginning of the url. Adds the global proxy if dimension is specified
  * @param {string} url
@@ -113,6 +137,10 @@ export function proxifyImageUrl(url, dimensions = false) {
             const target = new URL(respUrl);
             if (!isFirstPartyImageHost(target.hostname)) return respUrl;
 
+            // Canonicalize first-party uploaded image host before encoding.
+            // This ensures profile cover_image values stored as steemitimages.com/D... use cdn.steemitimages.com.
+            normalizeFirstPartyUploadURL(target);
+
             const dimsNoSlash = dims.endsWith('/') ? dims.slice(0, -1) : dims;
             const [wStr, hStr] = String(dimsNoSlash).split('x');
             const width = Number.parseInt(wStr, 10);
@@ -137,7 +165,7 @@ export function proxifyImageUrl(url, dimensions = false) {
                 return target.toString();
             }
 
-            const b58 = base58.encode(Buffer.from(respUrl, 'utf8'));
+            const b58 = base58.encode(Buffer.from(target.toString(), 'utf8'));
             const pBase = `${ensureTrailingSlash(imageProxy())}p/${b58}`;
             const pUrl = new URL(pBase);
             pUrl.searchParams.set('mode', 'fit');

--- a/src/app/utils/ProxifyUrl.test.js
+++ b/src/app/utils/ProxifyUrl.test.js
@@ -32,16 +32,24 @@ describe('ProxifyUrl', () => {
     it('naked steemit hosted URL (first-party domain: use /p/)', () => {
         const url =
             'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg';
-        testCase(url, '256x512', expectedP(url, { width: 256, height: 512 }));
+        const canonical =
+            'https://cdn.steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg';
+        testCase(
+            url,
+            '256x512',
+            expectedP(canonical, { width: 256, height: 512 })
+        );
         testCase(url, false, url);
     });
     it('proxied steemit hosted URL (strip proxy, then /p/ for first-party)', () => {
         const stripped =
             'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg';
+        const strippedCanonical =
+            'https://cdn.steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg';
         testCase(
             'https://steemitimages.com/0x0/https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
             '256x512',
-            expectedP(stripped, { width: 256, height: 512 })
+            expectedP(strippedCanonical, { width: 256, height: 512 })
         );
         testCase(
             'https://steemitimages.com/256x512/https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
@@ -105,7 +113,7 @@ describe('ProxifyUrl', () => {
             'https://steemitdevimages.com/1001x2001/https://steemitimages.com/0x0/https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
             true,
             expectedP(
-                'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
+                'https://cdn.steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
                 { width: 1001, height: 2001 }
             )
         );
@@ -115,7 +123,7 @@ describe('ProxifyUrl', () => {
             'https://steemitimages.com/0x0/https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
             true,
             expectedP(
-                'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
+                'https://cdn.steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
                 { width: 640 }
             )
         );
@@ -128,7 +136,7 @@ describe('ProxifyUrl', () => {
             'https://steemitimages.com/0x0/https://steemitimages.com/100x100/https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
             true,
             expectedP(
-                'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
+                'https://cdn.steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg',
                 { width: 640 }
             )
         );
@@ -164,7 +172,9 @@ describe('ProxifyUrl', () => {
     it('already /p/ URL is idempotent and params are forced to match policy', () => {
         const orig =
             'https://steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg';
-        const b58 = base58.encode(Buffer.from(orig, 'utf8'));
+        const canonical =
+            'https://cdn.steemitimages.com/DQmaJe2Tt5kmVUaFhse1KTEr4N1g9piMgD3YjPEQhkZi3HR/30day-positivity-challenge.jpg';
+        const b58 = base58.encode(Buffer.from(canonical, 'utf8'));
 
         testCase(
             `https://steemitimages.com/p/${


### PR DESCRIPTION
## Summary
- Normalize first-party uploaded cover image URLs from `steemitimages.com/D...` to `cdn.steemitimages.com/D...` before base58 encoding for `/p/`.
- Keeps third-party images unproxied; updates `ProxifyUrl` unit tests.

## Test plan
- [x] `npm test -- ProxifyUrl.test.js`