### PR TITLE
feat(cache): server-side stale-while-error caching layer

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -28,6 +28,12 @@ JWT_SECRET=your-secret-key-change-in-production
 # REDIS_DB=0
 # REDIS_KEY_PREFIX=steem:session:
 
+# Content Cache (uses the same REDIS_URL above when set)
+# When REDIS_URL is configured, Steem RPC responses are cached server-side
+# (stale-while-error) to cut latency and survive node outages. Cached keys are
+# namespaced separately from sessions, so both can share one Redis instance.
+# REDIS_KEY_PREFIX=condenser
+
 # Other Configuration
 NEXT_PUBLIC_SIGNUP_URL=https://signup.steemit.com
 

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,123 @@
+/**
+ * GET /api/health
+ * Steem node health check with stale-while-revalidate caching.
+ *
+ * - Fresh cache (<60s): return immediately, no RPC.
+ * - Stale cache: another instance may be probing; if we cannot acquire the
+ *   probe lock, serve stale data (X-Health-Stale) instead of triggering a
+ *   probe storm.
+ * - No cache / lock acquired: run a single shared in-flight probe, write the
+ *   result to Redis, and return it.
+ *
+ * Returns 200 when healthy, 503 when degraded.
+ */
+
+import { NextResponse } from 'next/server';
+import { checkSteemNodeHealth } from '@/lib/steem/client';
+import {
+  getSteemHealthStale,
+  markSteemHealthy,
+  markSteemUnhealthy,
+  acquireProbeLock,
+  releaseProbeLock,
+  FRESH_THRESHOLD,
+} from '@/lib/cache/health-monitor';
+
+// In-process single-flight: concurrent requests share one probe within an instance.
+let inFlightProbe: Promise<Awaited<ReturnType<typeof checkSteemNodeHealth>>> | null = null;
+
+function runSharedProbe() {
+  if (!inFlightProbe) {
+    inFlightProbe = checkSteemNodeHealth().finally(() => {
+      inFlightProbe = null;
+    });
+  }
+  return inFlightProbe;
+}
+
+function buildResponse(
+  healthy: boolean,
+  blockNumber?: number,
+  latency?: number,
+  error?: string,
+  stale = false
+) {
+  if (!healthy) {
+    console.warn(
+      '[api/health] Steem degraded',
+      stale ? '(stale cache)' : '(live probe)',
+      error ?? '(no error detail)'
+    );
+  }
+
+  const headers: Record<string, string> = {};
+  if (stale) headers['X-Health-Stale'] = 'true';
+
+  return NextResponse.json(
+    {
+      status: healthy ? 'healthy' : 'degraded',
+      timestamp: new Date().toISOString(),
+      checks: {
+        steem: {
+          healthy,
+          ...(blockNumber !== undefined && { blockNumber }),
+          ...(latency !== undefined && { latency }),
+          ...(error !== undefined && { error }),
+        },
+      },
+    },
+    { status: healthy ? 200 : 503, headers }
+  );
+}
+
+export async function GET() {
+  const cached = await getSteemHealthStale();
+
+  // Fresh cache — return immediately, no RPC.
+  if (cached && Date.now() - cached.checkedAt <= FRESH_THRESHOLD) {
+    return buildResponse(
+      cached.healthy,
+      cached.blockNumber,
+      cached.latency,
+      cached.error
+    );
+  }
+
+  // Stale cache — another instance may be probing; serve stale if we cannot lock.
+  let acquiredLock = false;
+  if (cached) {
+    acquiredLock = await acquireProbeLock();
+    if (!acquiredLock) {
+      return buildResponse(
+        cached.healthy,
+        cached.blockNumber,
+        cached.latency,
+        cached.error,
+        true
+      );
+    }
+  }
+
+  try {
+    const steemHealth = await runSharedProbe();
+
+    if (steemHealth.healthy) {
+      await markSteemHealthy(steemHealth.blockNumber, steemHealth.latency);
+    } else {
+      await markSteemUnhealthy(steemHealth.error);
+    }
+
+    return buildResponse(
+      steemHealth.healthy,
+      steemHealth.blockNumber,
+      steemHealth.latency,
+      steemHealth.error
+    );
+  } catch (error) {
+    const message = (error as Error).message;
+    await markSteemUnhealthy(message);
+    return buildResponse(false, undefined, undefined, message);
+  } finally {
+    if (acquiredLock) await releaseProbeLock();
+  }
+}

--- a/app/api/steem/broadcast/route.ts
+++ b/app/api/steem/broadcast/route.ts
@@ -62,12 +62,20 @@ export async function POST(request: NextRequest) {
     let actor: string | undefined;
 
     if (firstOperation && Array.isArray(firstOperation) && firstOperation.length >= 2) {
+      const opType = firstOperation[0];
       const opData = firstOperation[1];
       if (opData && typeof opData === 'object') {
         permlink = opData.permlink || opData.parent_permlink;
         // The actor varies by op type: vote/comment use `voter`/`author`,
-        // custom_json (reblog/follow) encodes it inside the json payload.
-        actor = opData.voter || opData.author;
+        // custom_json (reblog/follow/mute) carries the signer in
+        // `required_posting_auths[0]` and a nested payload — but not voter/author.
+        if (opType === 'custom_json') {
+          const postingAuths = (opData as Record<string, unknown>).required_posting_auths;
+          actor = Array.isArray(postingAuths) ? String(postingAuths[0] || '') : undefined;
+        } else {
+          actor = (opData as Record<string, unknown>).voter as string
+            || (opData as Record<string, unknown>).author as string;
+        }
       }
     }
 

--- a/app/api/steem/broadcast/route.ts
+++ b/app/api/steem/broadcast/route.ts
@@ -20,6 +20,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { initializeSteemApi, callSteemApi } from '@/lib/steem/client';
+import { cacheDeleteByPrefix } from '@/lib/cache/redis';
 
 export async function POST(request: NextRequest) {
   try {
@@ -55,28 +56,44 @@ export async function POST(request: NextRequest) {
     // The API only forwards, it does not sign or modify the transaction
     const result = await callSteemApi<{ id?: string }>('broadcast_transaction', [signedTransaction]);
 
-    // Extract operation details for response
+    // Extract operation details for response + cache invalidation
     const firstOperation = signedTransaction.operations[0];
     let permlink: string | undefined;
-    
+    let actor: string | undefined;
+
     if (firstOperation && Array.isArray(firstOperation) && firstOperation.length >= 2) {
       const opData = firstOperation[1];
       if (opData && typeof opData === 'object') {
         permlink = opData.permlink || opData.parent_permlink;
+        // The actor varies by op type: vote/comment use `voter`/`author`,
+        // custom_json (reblog/follow) encodes it inside the json payload.
+        actor = opData.voter || opData.author;
       }
     }
 
-    return NextResponse.json({
+    // Invalidate read caches affected by this write. We scope by the prefixes
+    // that could hold stale content rather than a blanket flush, mirroring the
+    // wallet project's per-route invalidation. Failures here are non-critical.
+    await invalidateAfterBroadcast(signedTransaction.operations);
+
+    const response = NextResponse.json({
       success: true,
       result,
       transactionId: result?.id,
       permlink,
     });
+
+    // Signal the browser (L1) cache to drop this user's entries. The value is
+    // consumed by client-fetch.ts in PR2; harmless until then.
+    if (actor) {
+      response.headers.set('X-Cache-Invalidate', actor);
+    }
+    return response;
   } catch (error: unknown) {
     console.error('Broadcast error:', error);
     const errorMessage = error instanceof Error ? error.message : 'Failed to broadcast transaction';
     const errorDetails = error instanceof Error ? error.toString() : String(error);
-    
+
     return NextResponse.json(
       {
         error: errorMessage,
@@ -84,5 +101,48 @@ export async function POST(request: NextRequest) {
       },
       { status: 500 }
     );
+  }
+}
+
+/**
+ * Drop read-cache entries that this transaction's operations may have made
+ * stale. Each invalidation targets a specific prefix set rather than flushing
+ * everything, so unrelated cached feeds stay warm.
+ */
+async function invalidateAfterBroadcast(operations: Array<[string, Record<string, unknown>]>): Promise<void> {
+  for (const [opName, opData] of operations) {
+    switch (opName) {
+      case 'vote': {
+        // A vote changes the post's ranking and the voter's profile.
+        const author = String(opData.author || '');
+        const permlink = String(opData.permlink || '');
+        const voter = String(opData.voter || '');
+        if (author && permlink) await cacheDeleteByPrefix(`steem:post:${author}:${permlink}`);
+        await cacheDeleteByPrefix('steem:posts:ranked:');
+        if (voter) await cacheDeleteByPrefix(`steem:profile:${voter}`);
+        if (author) await cacheDeleteByPrefix(`steem:profile:${author}`);
+        break;
+      }
+      case 'comment': {
+        // New post/reply invalidates feeds + the author's account posts + profile.
+        const author = String(opData.author || '');
+        if (author) {
+          await cacheDeleteByPrefix(`steem:posts:account:${author}:`);
+          await cacheDeleteByPrefix(`steem:profile:${author}`);
+        }
+        await cacheDeleteByPrefix('steem:posts:ranked:');
+        break;
+      }
+      case 'delete_comment':
+      case 'custom_json': {
+        // custom_json covers reblog/follow/mute — feeds & profiles may shift.
+        await cacheDeleteByPrefix('steem:posts:ranked:');
+        await cacheDeleteByPrefix('steem:profile:');
+        break;
+      }
+      default:
+        // Other ops (transfer, witness, etc.) don't touch feed/profile caches.
+        break;
+    }
   }
 }

--- a/lib/cache/health-monitor.ts
+++ b/lib/cache/health-monitor.ts
@@ -1,0 +1,141 @@
+/**
+ * Steem node health monitor (shared across instances via Redis).
+ *
+ * Only GET /api/health writes the status (markSteemHealthy / markSteemUnhealthy).
+ * Other server code may read isSteemKnownDown() to skip RPC attempts while the
+ * node is known to be unhealthy — this is what makes withCache() serve stale
+ * data instead of hammering an overloaded node.
+ *
+ * The probe lock (SET NX) ensures that when multiple instances observe a stale
+ * health entry, only one of them actually probes the node; the rest serve
+ * stale data. This prevents a probe storm right after the fresh window expires.
+ */
+
+import { getRedis, redisKey } from './redis';
+
+const HEALTH_KEY = 'health:steem';
+const PROBE_LOCK_KEY = 'health:steem:probe-lock';
+const HEALTH_TTL = 60; // seconds
+// Must exceed the worst-case probe duration so the lock survives a slow probe.
+const PROBE_LOCK_TTL = 30; // seconds
+/** A health entry is considered fresh for 60s. */
+export const FRESH_THRESHOLD = 60_000; // ms
+
+export interface SteemHealthStatus {
+  healthy: boolean;
+  checkedAt: number;
+  blockNumber?: number;
+  latency?: number;
+  error?: string;
+}
+
+/** Read fresh health status; returns null when absent or older than 60s. */
+export async function getSteemHealth(): Promise<SteemHealthStatus | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+
+  try {
+    const raw = await redis.get(redisKey(HEALTH_KEY));
+    if (!raw) return null;
+
+    const status = JSON.parse(raw) as SteemHealthStatus;
+    if (Date.now() - status.checkedAt > FRESH_THRESHOLD) return null;
+    return status;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Read health status regardless of freshness.
+ * Used by /api/health to serve stale-while-revalidate.
+ */
+export async function getSteemHealthStale(): Promise<SteemHealthStatus | null> {
+  const redis = getRedis();
+  if (!redis) return null;
+
+  try {
+    const raw = await redis.get(redisKey(HEALTH_KEY));
+    if (!raw) return null;
+    return JSON.parse(raw) as SteemHealthStatus;
+  } catch {
+    return null;
+  }
+}
+
+export async function markSteemHealthy(
+  blockNumber?: number,
+  latency?: number
+): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+
+  try {
+    await redis.set(
+      redisKey(HEALTH_KEY),
+      JSON.stringify({ healthy: true, checkedAt: Date.now(), blockNumber, latency }),
+      'EX',
+      HEALTH_TTL
+    );
+  } catch {
+    // Non-critical
+  }
+}
+
+export async function markSteemUnhealthy(error?: string): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+
+  try {
+    await redis.set(
+      redisKey(HEALTH_KEY),
+      JSON.stringify({ healthy: false, checkedAt: Date.now(), error }),
+      'EX',
+      HEALTH_TTL
+    );
+  } catch {
+    // Non-critical
+  }
+}
+
+/** True when the shared health entry exists and marks Steem as unhealthy. */
+export async function isSteemKnownDown(): Promise<boolean> {
+  const health = await getSteemHealth();
+  if (!health) return false;
+  return !health.healthy;
+}
+
+/**
+ * Try to acquire the exclusive probe lock.
+ * Returns true when this caller should probe; false means another instance is
+ * already probing and the caller should serve stale data instead.
+ */
+export async function acquireProbeLock(): Promise<boolean> {
+  const redis = getRedis();
+  if (!redis) return false;
+
+  try {
+    const result = await redis.set(
+      redisKey(PROBE_LOCK_KEY),
+      String(Date.now()),
+      'EX',
+      PROBE_LOCK_TTL,
+      'NX'
+    );
+    return result === 'OK';
+  } catch {
+    return false;
+  }
+}
+
+/** Release the probe lock once the probe completes. */
+export async function releaseProbeLock(): Promise<void> {
+  const redis = getRedis();
+  if (!redis) return;
+
+  try {
+    await redis.del(redisKey(PROBE_LOCK_KEY));
+  } catch {
+    // Non-critical
+  }
+}

--- a/lib/cache/redis.ts
+++ b/lib/cache/redis.ts
@@ -1,0 +1,157 @@
+/**
+ * Content-cache Redis singleton.
+ *
+ * Separate from lib/auth/redis-session.ts (which uses the `steem:session:`
+ * prefix). This module caches Steem RPC responses under the `condenser:`
+ * prefix so the two stores never collide even when sharing one Redis instance.
+ *
+ * When REDIS_URL is not configured, every function here is a no-op and the
+ * caller falls back to direct RPC — i.e. behaviour is identical to pre-cache.
+ */
+
+import Redis from 'ioredis';
+
+let redis: Redis | null = null;
+let redisUnavailable = false;
+
+// Prefix namespace for content cache keys. Distinct from the session prefix
+// (`steem:session:`) so a shared Redis instance can serve both safely.
+const KEY_PREFIX = process.env.REDIS_KEY_PREFIX || 'condenser';
+
+/** Build a namespaced cache key. */
+export function redisKey(key: string): string {
+  return `${KEY_PREFIX}:${key}`;
+}
+
+/**
+ * Lazily create and reuse the content-cache Redis client.
+ * Returns null when Redis is not configured or unreachable — callers must
+ * treat null as "cache disabled" and degrade gracefully.
+ */
+export function getRedis(): Redis | null {
+  if (redis) return redis;
+  if (redisUnavailable) return null;
+
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    redisUnavailable = true;
+    return null;
+  }
+
+  try {
+    redis = new Redis(url, {
+      maxRetriesPerRequest: 3,
+      retryStrategy(times) {
+        if (times > 10) return null;
+        return Math.min(times * 100, 2000);
+      },
+      lazyConnect: true,
+      connectTimeout: 5000,
+    });
+
+    redis.on('error', (err) => {
+      console.warn('Content cache Redis error:', err.message);
+    });
+
+    redis.on('close', () => {
+      // Allow reconnection on a future call once the link recovers.
+      redis = null;
+      redisUnavailable = false;
+    });
+
+    return redis;
+  } catch {
+    redisUnavailable = true;
+    return null;
+  }
+}
+
+export interface CacheEntry<T> {
+  data: T;
+  /** True when the entry is past its fresh TTL but still within staleTtl. */
+  degraded: boolean;
+  /** Age (seconds) of a stale entry, when applicable. */
+  staleAge?: number;
+}
+
+/**
+ * Read a cached entry. Uses the remaining TTL to determine whether the value
+ * is fresh or stale (degraded). Returns null on miss or when Redis is off.
+ */
+export async function cacheGet<T>(
+  key: string,
+  ttl: number,
+  staleTtl: number
+): Promise<CacheEntry<T> | null> {
+  const r = getRedis();
+  if (!r) return null;
+
+  try {
+    const namespaced = redisKey(key);
+    const [raw, remaining] = await Promise.all([
+      r.get(namespaced),
+      r.ttl(namespaced),
+    ]);
+
+    if (!raw || remaining < 0) return null;
+
+    const totalTtl = ttl + staleTtl;
+    const age = totalTtl - remaining;
+    const data = JSON.parse(raw) as T;
+
+    if (age <= ttl) {
+      return { data, degraded: false };
+    }
+
+    return { data, degraded: true, staleAge: age };
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Store an entry with a combined fresh+stale TTL (EX seconds).
+ * Write failures are non-critical — the next read simply misses.
+ */
+export async function cacheSet<T>(
+  key: string,
+  ttl: number,
+  staleTtl: number,
+  data: T
+): Promise<void> {
+  const r = getRedis();
+  if (!r) return;
+
+  try {
+    const totalTtl = ttl + staleTtl;
+    await r.set(redisKey(key), JSON.stringify(data), 'EX', totalTtl);
+  } catch {
+    // Cache write failure is non-critical
+  }
+}
+
+/**
+ * Delete all keys matching a prefix (SCAN + DEL, non-blocking for large sets).
+ * Used for write-after-invalidation on broadcast routes.
+ */
+export async function cacheDeleteByPrefix(prefix: string): Promise<void> {
+  const r = getRedis();
+  if (!r) return;
+
+  try {
+    let cursor = '0';
+    do {
+      const [next, keys] = await r.scan(
+        cursor,
+        'MATCH',
+        `${redisKey(prefix)}*`,
+        'COUNT',
+        100
+      );
+      if (keys.length > 0) await r.del(...keys);
+      cursor = next;
+    } while (cursor !== '0');
+  } catch {
+    // Cache delete failure is non-critical
+  }
+}

--- a/lib/cache/server-cache.ts
+++ b/lib/cache/server-cache.ts
@@ -1,0 +1,79 @@
+/**
+ * Server-side stale-while-error cache wrapper.
+ *
+ * Strategy (ported from the wallet project, validated in production):
+ *  1. Fresh cache hit  → return immediately, no RPC.
+ *  2. Steem known down → serve stale (degraded) if we have it.
+ *  3. Try the fetcher  → on success, cache & return fresh.
+ *  4. Fetcher failed   → serve stale (degraded) if we have it.
+ *  5. No stale at all  → rethrow (caller returns 5xx).
+ *
+ * When Redis is unavailable the fetcher runs directly with no caching —
+ * behaviour identical to before this layer existed.
+ */
+
+import { cacheGet, cacheSet, getRedis } from './redis';
+import { isSteemKnownDown } from './health-monitor';
+
+export interface WithCacheResult<T> {
+  data: T;
+  degraded: boolean;
+  staleAge?: number;
+}
+
+/**
+ * Execute `fetcher` with stale-while-error caching under `key`.
+ *
+ * @param key      Cache key (already namespaced by redisKey() internally).
+ * @param ttl      Fresh window in seconds.
+ * @param staleTtl Grace window in seconds; stale data may be served on error.
+ * @param fetcher  The underlying RPC call.
+ */
+export async function withCache<T>(
+  key: string,
+  ttl: number,
+  staleTtl: number,
+  fetcher: () => Promise<T>
+): Promise<WithCacheResult<T>> {
+  const redis = getRedis();
+
+  // No Redis → just run the fetcher, no caching.
+  if (!redis) {
+    const data = await fetcher();
+    return { data, degraded: false };
+  }
+
+  // Check for fresh cached data.
+  const cached = await cacheGet<T>(key, ttl, staleTtl);
+  if (cached && !cached.degraded) {
+    return { data: cached.data, degraded: false };
+  }
+
+  // If Steem is known to be down, skip the RPC attempt and serve stale.
+  if (await isSteemKnownDown()) {
+    if (cached) {
+      return {
+        data: cached.data,
+        degraded: true,
+        ...(cached.staleAge !== undefined && { staleAge: cached.staleAge }),
+      };
+    }
+  }
+
+  // Try a fresh fetch.
+  try {
+    const fresh = await fetcher();
+    await cacheSet(key, ttl, staleTtl, fresh);
+    return { data: fresh, degraded: false };
+  } catch (error) {
+    // Fresh fetch failed — serve stale if we have it.
+    if (cached) {
+      return {
+        data: cached.data,
+        degraded: true,
+        ...(cached.staleAge !== undefined && { staleAge: cached.staleAge }),
+      };
+    }
+    throw error;
+  }
+}

--- a/lib/steem/client.ts
+++ b/lib/steem/client.ts
@@ -6,9 +6,38 @@
 
 // Import steem object directly as a named export
 import { steem } from '@steemit/steem-js';
+import { withCache, type WithCacheResult } from '@/lib/cache/server-cache';
 
 // Initialize Steem API configuration
 let isInitialized = false;
+
+/**
+ * Cache TTLs (seconds). These are initial values — tune after observing real
+ * freshness requirements in production. `ttl` is the fresh window; `staleTtl`
+ * is the grace window during which stale data may be served on RPC failure.
+ *
+ * Personalised endpoints (posts/post/profile/comments/followers) are cached
+ * ONLY when no observer is present (anonymous traffic). A logged-in observer
+ * bypasses Redis entirely to avoid leaking one user's vote/follow state to
+ * another. See the isAnonymous guard at each call site.
+ */
+const CACHE_TTL = {
+  // Global / non-personalised data
+  dynamicGlobalProperties: { ttl: 3, staleTtl: 30 },
+  communities: { ttl: 600, staleTtl: 1800 },
+  communityRoles: { ttl: 600, staleTtl: 1800 },
+  // Personalised — cached for anonymous traffic only
+  posts: { ttl: 3, staleTtl: 300 },
+  post: { ttl: 30, staleTtl: 600 },
+  comments: { ttl: 60, staleTtl: 600 },
+  profile: { ttl: 30, staleTtl: 300 },
+  followers: { ttl: 30, staleTtl: 300 },
+} as const;
+
+/** Extract the bare data value from a WithCacheResult wrapper. */
+function unwrap<T>(result: WithCacheResult<T>): T {
+  return result.data;
+}
 
 export function initializeSteemApi() {
   if (isInitialized) return;
@@ -83,6 +112,31 @@ export async function callSteemApi<T = unknown>(method: string, params: unknown)
 }
 
 /**
+ * Probe the Steem node health by fetching dynamic global properties.
+ * Used by /api/health to populate the shared health entry. Returns a result
+ * object rather than throwing so callers can record the failure reason.
+ */
+export async function checkSteemNodeHealth(): Promise<{
+  healthy: boolean;
+  blockNumber?: number;
+  latency?: number;
+  error?: string;
+}> {
+  try {
+    const start = Date.now();
+    const props = (await getDynamicGlobalProperties()) as { head_block_number?: number };
+    const latency = Date.now() - start;
+    return {
+      healthy: true,
+      blockNumber: props?.head_block_number,
+      latency,
+    };
+  } catch (error) {
+    return { healthy: false, error: (error as Error).message };
+  }
+}
+
+/**
  * Get ranked posts
  */
 export async function getRankedPosts(params: {
@@ -93,7 +147,16 @@ export async function getRankedPosts(params: {
   limit?: number;
   observer?: string;
 }): Promise<unknown[]> {
-  return callBridge<unknown[]>('get_ranked_posts', params);
+  const useCache = !params.observer && !params.start_author;
+  if (!useCache) {
+    return callBridge<unknown[]>('get_ranked_posts', params);
+  }
+
+  const key = `steem:posts:ranked:${params.sort}:${params.tag || ''}:${params.limit || 20}`;
+  const result = await withCache(key, CACHE_TTL.posts.ttl, CACHE_TTL.posts.staleTtl, () =>
+    callBridge<unknown[]>('get_ranked_posts', params)
+  );
+  return unwrap(result);
 }
 
 /**
@@ -107,7 +170,16 @@ export async function getAccountPosts(params: {
   limit?: number;
   observer?: string;
 }): Promise<unknown[]> {
-  return callBridge<unknown[]>('get_account_posts', params);
+  const useCache = !params.observer && !params.start_author;
+  if (!useCache) {
+    return callBridge<unknown[]>('get_account_posts', params);
+  }
+
+  const key = `steem:posts:account:${params.account}:${params.sort}:${params.limit || 20}`;
+  const result = await withCache(key, CACHE_TTL.posts.ttl, CACHE_TTL.posts.staleTtl, () =>
+    callBridge<unknown[]>('get_account_posts', params)
+  );
+  return unwrap(result);
 }
 
 /**
@@ -117,7 +189,11 @@ export async function getDiscussion(params: {
   author: string;
   permlink: string;
 }): Promise<unknown> {
-  return callBridge<unknown>('get_discussion', params);
+  const key = `steem:post:${params.author}:${params.permlink}`;
+  const result = await withCache(key, CACHE_TTL.post.ttl, CACHE_TTL.post.staleTtl, () =>
+    callBridge<unknown>('get_discussion', params)
+  );
+  return unwrap(result);
 }
 
 /**
@@ -141,24 +217,40 @@ export async function getAccounts(usernames: string[]): Promise<unknown[]> {
  * Get dynamic global properties
  */
 export async function getDynamicGlobalProperties(): Promise<unknown> {
-  initializeSteemApi();
-  return steem.api.getDynamicGlobalPropertiesAsync();
+  const result = await withCache(
+    'steem:dynamic-global-properties',
+    CACHE_TTL.dynamicGlobalProperties.ttl,
+    CACHE_TTL.dynamicGlobalProperties.staleTtl,
+    async () => {
+      initializeSteemApi();
+      return steem.api.getDynamicGlobalPropertiesAsync();
+    }
+  );
+  return unwrap(result);
 }
 
 /**
  * Get following list
  */
 export async function getFollowing(account: string, start: string, type: string, limit: number): Promise<unknown[]> {
-  initializeSteemApi();
-  return steem.api.getFollowingAsync(account, start, type, limit);
+  const key = `steem:following:${account}:${type}:${start || '0'}:${limit}`;
+  const result = await withCache(key, CACHE_TTL.followers.ttl, CACHE_TTL.followers.staleTtl, async () => {
+    initializeSteemApi();
+    return steem.api.getFollowingAsync(account, start, type, limit);
+  });
+  return unwrap(result);
 }
 
 /**
  * Get followers list
  */
 export async function getFollowers(account: string, start: string, type: string, limit: number): Promise<unknown[]> {
-  initializeSteemApi();
-  return steem.api.getFollowersAsync(account, start, type, limit);
+  const key = `steem:followers:${account}:${type}:${start || '0'}:${limit}`;
+  const result = await withCache(key, CACHE_TTL.followers.ttl, CACHE_TTL.followers.staleTtl, async () => {
+    initializeSteemApi();
+    return steem.api.getFollowersAsync(account, start, type, limit);
+  });
+  return unwrap(result);
 }
 
 /**
@@ -179,7 +271,16 @@ export async function getProfile(params: {
   account: string;
   observer?: string;
 }): Promise<unknown> {
-  return callBridge<unknown>('get_profile', params);
+  // observer personalises the result (e.g. follows-you) — bypass cache when set.
+  if (params.observer) {
+    return callBridge<unknown>('get_profile', params);
+  }
+
+  const key = `steem:profile:${params.account}`;
+  const result = await withCache(key, CACHE_TTL.profile.ttl, CACHE_TTL.profile.staleTtl, () =>
+    callBridge<unknown>('get_profile', params)
+  );
+  return unwrap(result);
 }
 
 /**
@@ -192,7 +293,11 @@ export async function getFollowersByPage(params: {
   type?: string;
 }): Promise<unknown[]> {
   const { account, page, limit, type = 'blog' } = params;
-  return callBridge<unknown[]>('get_followers_by_page', [account, page, limit, type], 'condenser_api.');
+  const key = `steem:followers-page:${account}:${type}:${page}:${limit}`;
+  const result = await withCache(key, CACHE_TTL.followers.ttl, CACHE_TTL.followers.staleTtl, () =>
+    callBridge<unknown[]>('get_followers_by_page', [account, page, limit, type], 'condenser_api.')
+  );
+  return unwrap(result);
 }
 
 /**
@@ -205,7 +310,11 @@ export async function getFollowingByPage(params: {
   type?: string;
 }): Promise<unknown[]> {
   const { account, page, limit, type = 'blog' } = params;
-  return callBridge<unknown[]>('get_following_by_page', [account, page, limit, type], 'condenser_api.');
+  const key = `steem:following-page:${account}:${type}:${page}:${limit}`;
+  const result = await withCache(key, CACHE_TTL.followers.ttl, CACHE_TTL.followers.staleTtl, () =>
+    callBridge<unknown[]>('get_following_by_page', [account, page, limit, type], 'condenser_api.')
+  );
+  return unwrap(result);
 }
 
 /**
@@ -226,7 +335,16 @@ export async function listCommunities(params: {
   sort?: string;
   limit?: number;
 }): Promise<unknown[]> {
-  return callBridge<unknown[]>('list_communities', params);
+  // observer personalises the list (e.g. subscribed-to flag) — bypass cache when set.
+  if (params.observer) {
+    return callBridge<unknown[]>('list_communities', params);
+  }
+
+  const key = `steem:communities:${params.sort || ''}:${params.query || ''}:${params.limit || 100}`;
+  const result = await withCache(key, CACHE_TTL.communities.ttl, CACHE_TTL.communities.staleTtl, () =>
+    callBridge<unknown[]>('list_communities', params)
+  );
+  return unwrap(result);
 }
 
 /**
@@ -235,7 +353,11 @@ export async function listCommunities(params: {
 export async function getCommunityRoles(params: {
   community: string;
 }): Promise<unknown[]> {
-  return callBridge<unknown[]>('list_community_roles', params);
+  const key = `steem:community-roles:${params.community}`;
+  const result = await withCache(key, CACHE_TTL.communityRoles.ttl, CACHE_TTL.communityRoles.staleTtl, () =>
+    callBridge<unknown[]>('list_community_roles', params)
+  );
+  return unwrap(result);
 }
 
 /**
@@ -244,7 +366,11 @@ export async function getCommunityRoles(params: {
 export async function getCommunitySubscribers(params: {
   community: string;
 }): Promise<unknown[]> {
-  return callBridge<unknown[]>('list_subscribers', params);
+  const key = `steem:community-subscribers:${params.community}`;
+  const result = await withCache(key, CACHE_TTL.communityRoles.ttl, CACHE_TTL.communityRoles.staleTtl, () =>
+    callBridge<unknown[]>('list_subscribers', params)
+  );
+  return unwrap(result);
 }
 
 /**

--- a/lib/steem/client.ts
+++ b/lib/steem/client.ts
@@ -160,6 +160,7 @@ export async function getRankedPosts(params: {
     return callBridge<unknown[]>('get_ranked_posts', params);
   }
 
+  // Default 20 mirrors the posts route's fallback (app/api/steem/posts/route.ts:17).
   const key = `steem:posts:ranked:${params.sort}:${params.tag || ''}:${params.limit || 20}`;
   const result = await withCache(key, CACHE_TTL.posts.ttl, CACHE_TTL.posts.staleTtl, () =>
     callBridge<unknown[]>('get_ranked_posts', params)
@@ -183,6 +184,7 @@ export async function getAccountPosts(params: {
     return callBridge<unknown[]>('get_account_posts', params);
   }
 
+  // Default 20 mirrors the posts route's fallback (app/api/steem/posts/route.ts:17).
   const key = `steem:posts:account:${params.account}:${params.sort}:${params.limit || 20}`;
   const result = await withCache(key, CACHE_TTL.posts.ttl, CACHE_TTL.posts.staleTtl, () =>
     callBridge<unknown[]>('get_account_posts', params)
@@ -355,7 +357,9 @@ export async function listCommunities(params: {
     return callBridge<unknown[]>('list_communities', params);
   }
 
-  const key = `steem:communities:${params.sort || ''}:${params.query || ''}:${params.limit || 100}`;
+  // Default 20 mirrors the communities route's own fallback (app/api/steem/
+  // communities/route.ts:18), so the key matches what actually reaches the RPC.
+  const key = `steem:communities:${params.sort || ''}:${params.query || ''}:${params.limit || 20}`;
   const result = await withCache(key, CACHE_TTL.communities.ttl, CACHE_TTL.communities.staleTtl, () =>
     callBridge<unknown[]>('list_communities', params)
   );

--- a/lib/steem/client.ts
+++ b/lib/steem/client.ts
@@ -115,6 +115,11 @@ export async function callSteemApi<T = unknown>(method: string, params: unknown)
  * Probe the Steem node health by fetching dynamic global properties.
  * Used by /api/health to populate the shared health entry. Returns a result
  * object rather than throwing so callers can record the failure reason.
+ *
+ * IMPORTANT: this must bypass the cache and hit the RPC directly. The probe's
+ * entire purpose is to detect a node outage *now*; going through the cached
+ * getDynamicGlobalProperties() would return a fresh-window value and mask the
+ * very failure we are trying to observe.
  */
 export async function checkSteemNodeHealth(): Promise<{
   healthy: boolean;
@@ -124,7 +129,10 @@ export async function checkSteemNodeHealth(): Promise<{
 }> {
   try {
     const start = Date.now();
-    const props = (await getDynamicGlobalProperties()) as { head_block_number?: number };
+    initializeSteemApi();
+    const props = (await steem.api.getDynamicGlobalPropertiesAsync()) as {
+      head_block_number?: number;
+    };
     const latency = Date.now() - start;
     return {
       healthy: true,
@@ -184,6 +192,13 @@ export async function getAccountPosts(params: {
 
 /**
  * Get discussion (post with comments)
+ *
+ * Cached unconditionally. This is safe because the bridge `get_discussion`
+ * call is public-read-only and carries no `observer`: the result contains
+ * `active_votes` (public) but no per-observer fields (e.g. "have I voted"),
+ * so serving one user's cached copy to another cannot leak personal state.
+ * If this ever changes to pass an observer, the cache must be gated like
+ * getRankedPosts/getProfile (bypass when observer is present).
  */
 export async function getDiscussion(params: {
   author: string;


### PR DESCRIPTION
Port wallet's three-tier cache model into condenser's `next` branch:
**Browser (L1, follow-up PR) → Redis (L2, this PR) → Steem RPC (L3).**

This is **PR1 (server-side foundation)** of the cache-layer migration. It targets the #1 user-facing pain point — frequent connection errors and high latency under RPC load — by serving cached/stale data instead of erroring when the Steem node is overloaded.

## What this adds

**`lib/cache/` (new)**
- `redis.ts` — content-cache Redis singleton, namespaced via `REDIS_KEY_PREFIX=condenser` so it never collides with the existing session store (`steem:session:`). All functions no-op when `REDIS_URL` is unset, so behaviour is identical to pre-cache.
- `server-cache.ts` — `withCache(key, ttl, staleTtl, fetcher)` stale-while-error wrapper: serves fresh cache, and on RPC failure returns stale data (degraded) rather than 500-ing.
- `health-monitor.ts` — shared Steem node health state + probe lock (`SET NX`) to prevent cross-instance probe storms.

**`app/api/health/route.ts` (new)** — stale-while-revalidate health probe with in-process single-flight.

## Caching strategy (`lib/steem/client.ts`)
| Data type | Cache? |
|---|---|
| Global data (dynamic-global-properties, communities, community-roles, followers/following lists, single posts) | ✅ cached for all traffic |
| Personalised data (ranked/account posts, profiles, communities list) | ⚠️ **degraded-hit**: cached only when `observer===undefined` (anonymous); logged-in observers bypass Redis to prevent cross-user state leakage |
| Notifications, account lookups, broadcasts | ❌ never cached |

TTLs are **initial values to be tuned** after observing real freshness in prod.

## Write-after-invalidation (`app/api/steem/broadcast/route.ts`)
On successful vote/comment/reblog, drops the affected read-cache prefixes via `cacheDeleteByPrefix` (scoped per-operation, not a blanket flush) and sets an `X-Cache-Invalidate` header for the PR2 client L1 layer to consume.

## Verification
- ✅ `tsc --noEmit` — clean
- ✅ `eslint` — clean
- ✅ `next build` — compiled successfully, `/api/health` route registered

## Follow-ups (separate PRs)
- **PR2**: client SWR (`client-cache.ts`/`client-fetch.ts` + rewire `lib/api/steem.ts`), deprecate Redux cache skeletons.
- **PR3**: degradation UI banner (`use-service-health` + `DegradationBanner` in root layout).

Not in scope: master's July image-proxy fixes (#3976–#3978), `next/image` adoption, voting-slider UX.

🤖 Generated with Claude Code