### PR TITLE
feat(cache): client-side stale-while-revalidate layer (PR2)

### DIFF
--- a/components/cards/NotificationsList.tsx
+++ b/components/cards/NotificationsList.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import { receiveNotifications, receiveUnreadNotifications, notificationsLoading } from '@/store/slices/globalSlice';
+import { cachedFetch } from '@/lib/cache/client-fetch';
 import LoadingIndicator from '@/components/elements/LoadingIndicator';
 import Link from 'next/link';
 
@@ -55,14 +56,14 @@ export default function NotificationsList({ username }: NotificationsListProps) 
       });
       if (startId) searchParams.set('last_id', startId.toString());
 
-      const response = await fetch(`/api/steem/notifications?${searchParams.toString()}`);
-      if (!response.ok) {
-        throw new Error(`Failed to fetch notifications: ${response.statusText}`);
-      }
-
-      const notifications = await response.json();
+      // Initial load is cacheable (SWR); pagination cursors bypass the cache
+      // to avoid stitching a stale page onto a shifted feed.
+      const { data: notifications } = await cachedFetch<Notification[]>(
+        `/api/steem/notifications?${searchParams.toString()}`,
+        { staleMs: 10_000, maxAgeMs: 30_000, noStore: Boolean(startId) }
+      );
       const isLastPage = notifications.length < 100;
-      
+
       dispatch(
         receiveNotifications({
           name: accountName,

--- a/lib/api/steem.ts
+++ b/lib/api/steem.ts
@@ -2,7 +2,32 @@
  * Steem API client
  * This module provides functions to interact with the Steem blockchain API
  * Replaces the old FetchDataSaga functionality
+ *
+ * All read functions go through the browser-side stale-while-revalidate cache
+ * (lib/cache/client-fetch). Public signatures are unchanged so existing call
+ * sites keep working; the SWR behaviour is transparent. Writes/mutations are
+ * never cached.
  */
+
+import { cachedFetch, HttpError } from '@/lib/cache/client-fetch';
+
+/**
+ * Client-side staleMs / maxAgeMs per data type.
+ *   staleMs  — fresh window; within it, no network request is made.
+ *   maxAgeMs — hard expiry; beyond it a fetch blocks rather than serving stale.
+ * These mirror (loosely) the server-side Redis TTLs but are tuned for the
+ * browser (shorter, since users expect fresh content on explicit navigation).
+ */
+const SWR = {
+  posts: { staleMs: 10_000, maxAgeMs: 60_000 }, // 10s fresh / 1m max
+  post: { staleMs: 15_000, maxAgeMs: 120_000 }, // 15s fresh / 2m max
+  comments: { staleMs: 15_000, maxAgeMs: 120_000 },
+  profile: { staleMs: 15_000, maxAgeMs: 60_000 },
+  followers: { staleMs: 15_000, maxAgeMs: 120_000 },
+  communities: { staleMs: 30_000, maxAgeMs: 300_000 },
+  communityRoles: { staleMs: 30_000, maxAgeMs: 300_000 },
+  notifications: { staleMs: 10_000, maxAgeMs: 30_000 },
+} as const;
 
 export interface Post {
   author: string;
@@ -72,23 +97,25 @@ export async function fetchRankedPosts(params: FetchPostsParams): Promise<Post[]
     observer,
   } = params;
 
+  const searchParams = new URLSearchParams({
+    sort: order,
+    tag: category,
+    limit: limit.toString(),
+  });
+  if (start_author) searchParams.set('start_author', start_author);
+  if (start_permlink) searchParams.set('start_permlink', start_permlink);
+  if (observer) searchParams.set('observer', observer);
+
+  // Pagination cursors change the result set — bypass cache to avoid
+  // stitching a stale "load more" page onto a shifted feed.
+  const noStore = Boolean(start_author || start_permlink);
+
   try {
-    const searchParams = new URLSearchParams({
-      sort: order,
-      tag: category,
-      limit: limit.toString(),
+    const { data } = await cachedFetch<Post[]>(`/api/steem/posts?${searchParams.toString()}`, {
+      ...SWR.posts,
+      noStore,
     });
-    if (start_author) searchParams.set('start_author', start_author);
-    if (start_permlink) searchParams.set('start_permlink', start_permlink);
-    if (observer) searchParams.set('observer', observer);
-
-    const response = await fetch(`/api/steem/posts?${searchParams.toString()}`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch posts: ${response.statusText}`);
-    }
-
-    const posts = await response.json();
-    return posts as Post[];
+    return data;
   } catch (error) {
     console.error('Error fetching ranked posts:', error);
     return [];
@@ -110,23 +137,23 @@ export async function fetchAccountPosts(
     observer,
   } = params;
 
+  const searchParams = new URLSearchParams({
+    sort: order,
+    account,
+    limit: limit.toString(),
+  });
+  if (start_author) searchParams.set('start_author', start_author);
+  if (start_permlink) searchParams.set('start_permlink', start_permlink);
+  if (observer) searchParams.set('observer', observer);
+
+  const noStore = Boolean(start_author || start_permlink);
+
   try {
-    const searchParams = new URLSearchParams({
-      sort: order,
-      account,
-      limit: limit.toString(),
+    const { data } = await cachedFetch<Post[]>(`/api/steem/posts?${searchParams.toString()}`, {
+      ...SWR.posts,
+      noStore,
     });
-    if (start_author) searchParams.set('start_author', start_author);
-    if (start_permlink) searchParams.set('start_permlink', start_permlink);
-    if (observer) searchParams.set('observer', observer);
-
-    const response = await fetch(`/api/steem/posts?${searchParams.toString()}`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch account posts: ${response.statusText}`);
-    }
-
-    const posts = await response.json();
-    return posts as Post[];
+    return data;
   } catch (error) {
     console.error('Error fetching account posts:', error);
     return [];
@@ -141,23 +168,14 @@ export async function fetchPostByPermlink(
   author: string,
   permlink: string
 ): Promise<Post | null> {
+  const searchParams = new URLSearchParams({ author, permlink });
   try {
-    const searchParams = new URLSearchParams({
-      author,
-      permlink,
+    const { data } = await cachedFetch<Post>(`/api/steem/post?${searchParams.toString()}`, {
+      ...SWR.post,
     });
-
-    const response = await fetch(`/api/steem/post?${searchParams.toString()}`);
-    if (!response.ok) {
-      if (response.status === 404) {
-        return null;
-      }
-      throw new Error(`Failed to fetch post: ${response.statusText}`);
-    }
-
-    const post = await response.json();
-    return post as Post;
+    return data;
   } catch (error) {
+    if (error instanceof HttpError && error.status === 404) return null;
     console.error('Error fetching post:', error);
     return null;
   }
@@ -170,19 +188,12 @@ export async function fetchCommentsByPermlink(
   author: string,
   permlink: string
 ): Promise<Post[]> {
+  const searchParams = new URLSearchParams({ author, permlink });
   try {
-    const searchParams = new URLSearchParams({
-      author,
-      permlink,
+    const { data } = await cachedFetch<Post[]>(`/api/steem/comments?${searchParams.toString()}`, {
+      ...SWR.comments,
     });
-
-    const response = await fetch(`/api/steem/comments?${searchParams.toString()}`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch comments: ${response.statusText}`);
-    }
-
-    const comments = await response.json();
-    return comments as Post[];
+    return data;
   } catch (error) {
     console.error('Error fetching comments:', error);
     return [];
@@ -227,23 +238,15 @@ export async function fetchUserProfile(
   account: string,
   observer?: string
 ): Promise<UserProfile | null> {
+  const searchParams = new URLSearchParams({ account });
+  if (observer) searchParams.set('observer', observer);
   try {
-    const searchParams = new URLSearchParams({
-      account,
+    const { data } = await cachedFetch<UserProfile>(`/api/steem/profile?${searchParams.toString()}`, {
+      ...SWR.profile,
     });
-    if (observer) searchParams.set('observer', observer);
-
-    const response = await fetch(`/api/steem/profile?${searchParams.toString()}`);
-    if (!response.ok) {
-      if (response.status === 404) {
-        return null;
-      }
-      throw new Error(`Failed to fetch profile: ${response.statusText}`);
-    }
-
-    const profile = await response.json();
-    return profile as UserProfile;
+    return data;
   } catch (error) {
+    if (error instanceof HttpError && error.status === 404) return null;
     console.error('Error fetching user profile:', error);
     return null;
   }
@@ -266,21 +269,17 @@ export async function fetchFollowers(
   page: number = 1,
   limit: number = 20
 ): Promise<FollowItem[]> {
+  const searchParams = new URLSearchParams({
+    account,
+    type: 'followers',
+    page: page.toString(),
+    limit: limit.toString(),
+  });
   try {
-    const searchParams = new URLSearchParams({
-      account,
-      type: 'followers',
-      page: page.toString(),
-      limit: limit.toString(),
+    const { data } = await cachedFetch<FollowItem[]>(`/api/steem/followers?${searchParams.toString()}`, {
+      ...SWR.followers,
     });
-
-    const response = await fetch(`/api/steem/followers?${searchParams.toString()}`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch followers: ${response.statusText}`);
-    }
-
-    const followers = await response.json();
-    return followers as FollowItem[];
+    return data;
   } catch (error) {
     console.error('Error fetching followers:', error);
     return [];
@@ -295,21 +294,17 @@ export async function fetchFollowing(
   page: number = 1,
   limit: number = 20
 ): Promise<FollowItem[]> {
+  const searchParams = new URLSearchParams({
+    account,
+    type: 'following',
+    page: page.toString(),
+    limit: limit.toString(),
+  });
   try {
-    const searchParams = new URLSearchParams({
-      account,
-      type: 'following',
-      page: page.toString(),
-      limit: limit.toString(),
+    const { data } = await cachedFetch<FollowItem[]>(`/api/steem/followers?${searchParams.toString()}`, {
+      ...SWR.followers,
     });
-
-    const response = await fetch(`/api/steem/followers?${searchParams.toString()}`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch following: ${response.statusText}`);
-    }
-
-    const following = await response.json();
-    return following as FollowItem[];
+    return data;
   } catch (error) {
     console.error('Error fetching following:', error);
     return [];
@@ -332,16 +327,13 @@ export interface UnreadNotificationsResponse {
 export async function fetchUnreadNotificationsCount(
   account: string
 ): Promise<UnreadNotificationsResponse> {
+  const searchParams = new URLSearchParams({ account });
   try {
-    const searchParams = new URLSearchParams({ account });
-    const response = await fetch(`/api/steem/unread-notifications?${searchParams.toString()}`);
-    
-    if (!response.ok) {
-      throw new Error(`Failed to fetch unread notifications: ${response.statusText}`);
-    }
-
-    const result = await response.json();
-    return result as UnreadNotificationsResponse;
+    const { data } = await cachedFetch<UnreadNotificationsResponse>(
+      `/api/steem/unread-notifications?${searchParams.toString()}`,
+      { ...SWR.notifications }
+    );
+    return data;
   } catch (error) {
     console.error('Error fetching unread notifications count:', error);
     return {
@@ -385,19 +377,13 @@ export interface CommunitySubscription {
 export async function fetchUserSubscriptions(
   account: string
 ): Promise<CommunitySubscription[]> {
+  const searchParams = new URLSearchParams({ account, type: 'subscriptions' });
   try {
-    const searchParams = new URLSearchParams({
-      account,
-      type: 'subscriptions',
-    });
-
-    const response = await fetch(`/api/steem/communities?${searchParams.toString()}`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch subscriptions: ${response.statusText}`);
-    }
-
-    const subscriptions = await response.json();
-    return subscriptions as CommunitySubscription[];
+    const { data } = await cachedFetch<CommunitySubscription[]>(
+      `/api/steem/communities?${searchParams.toString()}`,
+      { ...SWR.communities }
+    );
+    return data;
   } catch (error) {
     console.error('Error fetching user subscriptions:', error);
     return [];
@@ -413,20 +399,17 @@ export async function fetchCommunities(params: {
   sort?: string;
   limit?: number;
 } = {}): Promise<CommunitySubscription[]> {
+  const searchParams = new URLSearchParams();
+  if (params.observer) searchParams.set('observer', params.observer);
+  if (params.query) searchParams.set('query', params.query);
+  if (params.sort) searchParams.set('sort', params.sort);
+  if (params.limit) searchParams.set('limit', params.limit.toString());
   try {
-    const searchParams = new URLSearchParams();
-    if (params.observer) searchParams.set('observer', params.observer);
-    if (params.query) searchParams.set('query', params.query);
-    if (params.sort) searchParams.set('sort', params.sort);
-    if (params.limit) searchParams.set('limit', params.limit.toString());
-
-    const response = await fetch(`/api/steem/communities?${searchParams.toString()}`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch communities: ${response.statusText}`);
-    }
-
-    const communities = await response.json();
-    return communities as CommunitySubscription[];
+    const { data } = await cachedFetch<CommunitySubscription[]>(
+      `/api/steem/communities?${searchParams.toString()}`,
+      { ...SWR.communities }
+    );
+    return data;
   } catch (error) {
     console.error('Error fetching communities:', error);
     return [];
@@ -460,19 +443,13 @@ export interface CommunitySubscriber {
 export async function fetchCommunityRoles(
   community: string
 ): Promise<CommunityRole[]> {
+  const searchParams = new URLSearchParams({ community, type: 'roles' });
   try {
-    const searchParams = new URLSearchParams({
-      community,
-      type: 'roles',
-    });
-
-    const response = await fetch(`/api/steem/community-roles?${searchParams.toString()}`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch community roles: ${response.statusText}`);
-    }
-
-    const roles = await response.json();
-    return roles as CommunityRole[];
+    const { data } = await cachedFetch<CommunityRole[]>(
+      `/api/steem/community-roles?${searchParams.toString()}`,
+      { ...SWR.communityRoles }
+    );
+    return data;
   } catch (error) {
     console.error('Error fetching community roles:', error);
     return [];
@@ -485,19 +462,13 @@ export async function fetchCommunityRoles(
 export async function fetchCommunitySubscribers(
   community: string
 ): Promise<CommunitySubscriber[]> {
+  const searchParams = new URLSearchParams({ community, type: 'subscribers' });
   try {
-    const searchParams = new URLSearchParams({
-      community,
-      type: 'subscribers',
-    });
-
-    const response = await fetch(`/api/steem/community-roles?${searchParams.toString()}`);
-    if (!response.ok) {
-      throw new Error(`Failed to fetch community subscribers: ${response.statusText}`);
-    }
-
-    const subscribers = await response.json();
-    return subscribers as CommunitySubscriber[];
+    const { data } = await cachedFetch<CommunitySubscriber[]>(
+      `/api/steem/community-roles?${searchParams.toString()}`,
+      { ...SWR.communityRoles }
+    );
+    return data;
   } catch (error) {
     console.error('Error fetching community subscribers:', error);
     return [];

--- a/lib/cache/client-cache.ts
+++ b/lib/cache/client-cache.ts
@@ -1,0 +1,101 @@
+/**
+ * Browser-side LRU cache with stale-while-revalidate support.
+ *
+ * Module-level singleton shared across all imports within a single browser tab.
+ * This is the L1 layer of the three-tier cache (Browser L1 → Redis L2 → RPC).
+ *
+ * Each entry carries two timestamps:
+ *   - staleAt   : until this time data is "fresh"; after it, data is returned
+ *                 immediately but a background refresh is triggered.
+ *   - expiresAt : after this time data is discarded and a fresh fetch blocks.
+ */
+
+const MAX_ENTRIES = 50;
+
+interface CacheEntry<T> {
+  data: T;
+  staleAt: number;
+  expiresAt: number;
+}
+
+export interface CacheRead<T> {
+  data: T;
+  /** True when past staleAt but before expiresAt. */
+  stale: boolean;
+}
+
+class ClientCache {
+  private store = new Map<string, CacheEntry<unknown>>();
+  private insertionOrder: string[] = [];
+
+  get<T>(key: string): CacheRead<T> | null {
+    const entry = this.store.get(key);
+    if (!entry) return null;
+
+    const now = Date.now();
+    if (now > entry.expiresAt) {
+      this.store.delete(key);
+      this.removeFromOrder(key);
+      return null;
+    }
+
+    return { data: entry.data as T, stale: now > entry.staleAt };
+  }
+
+  set<T>(key: string, data: T, staleMs: number, maxAgeMs: number): void {
+    const existed = this.store.has(key);
+
+    // Evict the oldest entry once at capacity (LRU by insertion order). Only
+    // evict when inserting a brand-new key — refreshing an existing one must
+    // not evict anything.
+    if (!existed && this.store.size >= MAX_ENTRIES) {
+      const oldest = this.insertionOrder.shift();
+      if (oldest) this.store.delete(oldest);
+    }
+
+    const now = Date.now();
+    this.store.set(key, {
+      data,
+      staleAt: now + staleMs,
+      expiresAt: now + maxAgeMs,
+    });
+
+    // True LRU: a refresh (existing key) moves it to the back of the queue as
+    // most-recently-used, so hot keys are never evicted in favour of cold ones.
+    if (existed) {
+      this.removeFromOrder(key);
+    }
+    this.insertionOrder.push(key);
+  }
+
+  /**
+   * Drop all entries whose key contains `prefix`.
+   * Driven by the `X-Cache-Invalidate` response header set on writes.
+   *
+   * Collects matching keys first, then deletes: deleting during Map iteration
+   * can skip not-yet-visited keys (per ES spec), which would leave stale write
+   * victims behind.
+   */
+  invalidate(prefix: string): void {
+    const toDelete: string[] = [];
+    for (const key of this.store.keys()) {
+      if (key.includes(prefix)) toDelete.push(key);
+    }
+    for (const key of toDelete) {
+      this.store.delete(key);
+      this.removeFromOrder(key);
+    }
+  }
+
+  clear(): void {
+    this.store.clear();
+    this.insertionOrder = [];
+  }
+
+  private removeFromOrder(key: string): void {
+    const idx = this.insertionOrder.indexOf(key);
+    if (idx !== -1) this.insertionOrder.splice(idx, 1);
+  }
+}
+
+export const clientCache = new ClientCache();

--- a/lib/cache/client-fetch.ts
+++ b/lib/cache/client-fetch.ts
@@ -1,0 +1,109 @@
+/**
+ * Browser-side stale-while-revalidate fetch wrapper (L1 cache).
+ *
+ * - Fresh cache   → return immediately, no network.
+ * - Stale cache   → return immediately + fire-and-forget background refresh.
+ * - No cache      → fetch (blocking), cache, return.
+ *
+ * Error handling: a non-OK response ALWAYS throws HttpError — error bodies are
+ * never cached and never returned as if they were data. Callers catch the
+ * error and apply their own fallback (e.g. return []).
+ *
+ * The `X-Cache-Invalidate` response header (set by the broadcast route after a
+ * write) lets a successful write evict related entries from L1 immediately.
+ *
+ * Note: degradation-state from the wallet project is intentionally NOT ported
+ * — it was dead code (written, never read). PR3's use-service-health hook
+ * owns the degraded-UI signal via /api/health polling.
+ */
+
+import { clientCache } from './client-cache';
+
+export interface CachedFetchOptions {
+  /** Milliseconds until data becomes stale (eligible for background refresh). */
+  staleMs: number;
+  /** Milliseconds until data must be discarded entirely. */
+  maxAgeMs: number;
+  /** Skip cache and always fetch fresh. */
+  noStore?: boolean;
+}
+
+export interface CachedFetchResult<T> {
+  data: T;
+  /** True if data was served from cache past its stale time. */
+  stale: boolean;
+}
+
+/**
+ * Fetch `url` with browser-side stale-while-revalidate caching.
+ * Returns `{ data, stale }`; callers decide how to surface staleness.
+ *
+ * Throws HttpError on any non-OK HTTP response — the caller is expected to
+ * catch and fall back (e.g. return an empty list). Error bodies are never
+ * cached, so a transient 5xx never poisons the cache for maxAgeMs.
+ */
+export async function cachedFetch<T>(
+  url: string,
+  opts: CachedFetchOptions
+): Promise<CachedFetchResult<T>> {
+  if (opts.noStore) {
+    const res = await fetch(url, { cache: 'no-store' });
+    if (!res.ok) throw new HttpError(res.status, res.statusText);
+    return { data: (await res.json()) as T, stale: false };
+  }
+
+  const cached = clientCache.get<T>(url);
+  if (cached && !cached.stale) {
+    return { data: cached.data, stale: false };
+  }
+
+  // Stale but usable → return old data + refresh in the background.
+  if (cached) {
+    backgroundRefresh(url, opts);
+    return { data: cached.data, stale: true };
+  }
+
+  // No cache at all → must wait for fetch.
+  const res = await fetch(url);
+  if (!res.ok) throw new HttpError(res.status, res.statusText);
+  const data = (await res.json()) as T;
+  handleCacheInvalidation(res);
+  clientCache.set(url, data, opts.staleMs, opts.maxAgeMs);
+  return { data, stale: false };
+}
+
+/**
+ * Error carrying the HTTP status, so callers can branch on 404 vs 5xx.
+ * Thrown on any non-OK response (never caches the error body).
+ */
+export class HttpError extends Error {
+  readonly status: number;
+  readonly statusText: string;
+  constructor(status: number, statusText: string) {
+    super(`Request failed: ${status} ${statusText}`);
+    this.name = 'HttpError';
+    this.status = status;
+    this.statusText = statusText;
+  }
+}
+
+function backgroundRefresh(url: string, opts: CachedFetchOptions): void {
+  fetch(url)
+    .then(async (res) => {
+      // A background refresh hitting an error must NOT overwrite the cached
+      // entry with an error body — leave the stale (but valid) data in place.
+      if (!res.ok) return;
+      const data = await res.json();
+      handleCacheInvalidation(res);
+      clientCache.set(url, data, opts.staleMs, opts.maxAgeMs);
+    })
+    .catch(() => {
+      // Background refresh failure is non-critical; stale data stays.
+    });
+}
+
+/** Honour the server's per-write invalidation directive (X-Cache-Invalidate). */
+function handleCacheInvalidation(res: Response): void {
+  const prefix = res.headers.get('X-Cache-Invalidate');
+  if (prefix) clientCache.invalidate(prefix);
+}

--- a/store/slices/communitySlice.ts
+++ b/store/slices/communitySlice.ts
@@ -24,6 +24,11 @@ const communitySlice = createSlice({
   name: 'community',
   initialState,
   reducers: {
+    // @deprecated: these reducers were ported from legacy expecting a
+    // redux-saga that no longer exists in the Next.js app, and have no
+    // dispatchers. The browser SWR layer (lib/cache/client-fetch) is now the
+    // single source of truth for cached community data. Kept only to avoid
+    // breaking imports.
     // Saga watcher - no state change
     getCommunitySubscribers: (state, action: PayloadAction<{ community: string }>) => {
       // Saga handles this

--- a/store/slices/globalSlice.ts
+++ b/store/slices/globalSlice.ts
@@ -89,6 +89,13 @@ const globalSlice = createSlice({
   name: 'global',
   initialState,
   reducers: {
+    // NOTE on client-side data caching:
+    // The following reducers were ported from legacy as a cache skeleton but
+    // have NO dispatchers in the Next.js app: receiveContent, receiveAccount,
+    // receiveAccounts, receivePostHeader, receiveCommunities, receiveCommunity.
+    // They are @deprecated — the browser SWR layer (lib/cache/client-fetch) is
+    // now the single source of truth for cached read data. Do not add new
+    // dispatchers for them; leave them in place only to avoid breaking imports.
     setCollapsed: (state, action: PayloadAction<{ post: string; collapsed: boolean }>) => {
       const { post, collapsed } = action.payload;
       if (!state.content[post]) {

--- a/store/slices/userProfilesSlice.ts
+++ b/store/slices/userProfilesSlice.ts
@@ -17,6 +17,9 @@ const userProfilesSlice = createSlice({
   name: 'userProfiles',
   initialState,
   reducers: {
+    // @deprecated: this reducer has no dispatchers in the Next.js app. The
+    // browser SWR layer (lib/cache/client-fetch) is now the single source of
+    // truth for cached profile data. Kept only to avoid breaking imports.
     addProfile: (state, action: PayloadAction<{
       username: string;
       account: any;


### PR DESCRIPTION
Completes the three-tier cache (**Browser L1 → Redis L2 → Steem RPC**) by adding the browser-level SWR layer. This is **PR2** of the cache migration; PR1 (#3984) landed the server-side Redis tier.

## New (`lib/cache/`)
- **`client-cache.ts`** — browser LRU (50 entries) with dual TTL (`staleAt`/`expiresAt`), module-level singleton per tab. `invalidate(prefix)` driven by the `X-Cache-Invalidate` header set on writes.
- **`client-fetch.ts`** — `cachedFetch(url, {staleMs, maxAgeMs})`: fresh → return; stale → return + fire-and-forget background refresh; miss → block + cache.

### Error handling (audited before opening this PR)
A non-OK response **always throws `HttpError`** — error bodies are **never cached**, so a transient 5xx never poisons the cache for `maxAgeMs`. The background refresh hits the same guard (`!res.ok` → skip, leave valid stale data in place). Callers catch and apply their own fallback (`[]` / `null`).

## Rewire read paths (13 call sites)
`lib/api/steem.ts` (12 read fns) + `NotificationsList.tsx` direct fetch now go through `cachedFetch`. **Public signatures unchanged** — existing call sites work transparently.
- Per-data-type `staleMs`/`maxAgeMs` tuned for the browser (shorter than server TTLs).
- Pagination cursors (`start_author`/`start_permlink`, notifications `last_id`) bypass the cache via `noStore` — prevents stitching a stale "load more" page onto a shifted feed.
- 404 → `null` preserved for `fetchPostByPermlink`/`fetchUserProfile` via `HttpError.status`.
- Writes (`broadcast.ts`) untouched — never cached.

## Deprecate dead Redux cache skeletons
`globalSlice` (`receiveContent`/`receiveAccount`/`receiveAccounts`/`receivePostHeader`/`receiveCommunities`/`receiveCommunity`), `userProfilesSlice` (`addProfile`), and `communitySlice` reducers were ported from legacy as empty skeletons with **no dispatchers**. Marked `@deprecated`; SWR is now the single client cache source of truth. Verified each has zero dispatchers; `receiveNotifications` is actively used and deliberately left alone.

## Not ported
`degradation-state.ts` from wallet — confirmed dead code (written, never read). PR3's `use-service-health` hook owns the degraded-UI signal via `/api/health` polling.

## Verification
- ✅ `tsc --noEmit` — clean
- ✅ `next build` — Compiled successfully
- ✅ No new lint violations (pre-existing `no-explicit-any` in untouched interfaces unchanged)

## Follow-up
**PR3**: degradation UI (`use-service-health` + `DegradationBanner` in root layout), plus the no-Redis health-throttle carry-over noted on #3984.

🤖 Generated with Claude Code