### PR TITLE
feat(cache): degradation UI banner + no-Redis health throttle (PR3)

### DIFF
--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -8,12 +8,16 @@
  *   probe storm.
  * - No cache / lock acquired: run a single shared in-flight probe, write the
  *   result to Redis, and return it.
+ * - No Redis: cache/lock layers are no-ops; an in-process minimum interval
+ *   (5s) replays the last probe result to avoid amplifying the 60s client
+ *   poll into per-request node probes.
  *
  * Returns 200 when healthy, 503 when degraded.
  */
 
 import { NextResponse } from 'next/server';
 import { checkSteemNodeHealth } from '@/lib/steem/client';
+import { getRedis } from '@/lib/cache/redis';
 import {
   getSteemHealthStale,
   markSteemHealthy,
@@ -26,11 +30,41 @@ import {
 // In-process single-flight: concurrent requests share one probe within an instance.
 let inFlightProbe: Promise<Awaited<ReturnType<typeof checkSteemNodeHealth>>> | null = null;
 
+// No-Redis throttle: without Redis, the three cache/lock layers are all no-ops
+// and every request would probe the node directly. With use-service-health
+// polling every 60s across N instances that is an amplification risk. This
+// in-process minimum interval caps the no-Redis path so a probe runs at most
+// once per NO_REDIS_MIN_INTERVAL within each instance. (Redis path is already
+// throttled by cache + probe lock and ignores this.)
+const NO_REDIS_MIN_INTERVAL = 5_000; // ms
+let lastProbeAt = 0;
+
+// In-process last probe result, used only on the no-Redis path to answer
+// requests within the throttle window without re-probing the node.
+interface InMemoryHealth {
+  healthy: boolean;
+  blockNumber?: number;
+  latency?: number;
+  error?: string;
+}
+let lastInMemoryHealth: InMemoryHealth | null = null;
+
 function runSharedProbe() {
   if (!inFlightProbe) {
-    inFlightProbe = checkSteemNodeHealth().finally(() => {
-      inFlightProbe = null;
-    });
+    inFlightProbe = checkSteemNodeHealth()
+      .then((result) => {
+        lastInMemoryHealth = {
+          healthy: result.healthy,
+          ...(result.blockNumber !== undefined && { blockNumber: result.blockNumber }),
+          ...(result.latency !== undefined && { latency: result.latency }),
+          ...(result.error !== undefined && { error: result.error }),
+        };
+        return result;
+      })
+      .finally(() => {
+        inFlightProbe = null;
+        lastProbeAt = Date.now();
+      });
   }
   return inFlightProbe;
 }
@@ -80,6 +114,21 @@ export async function GET() {
       cached.blockNumber,
       cached.latency,
       cached.error
+    );
+  }
+
+  // No-Redis throttle: when Redis is unavailable the cache/lock layers are all
+  // no-ops. Without this guard, every request (including the 60s client poll
+  // from use-service-health across instances) would hit the node directly. We
+  // self-limit: within NO_REDIS_MIN_INTERVAL of the last probe, replay the
+  // in-memory result instead of re-probing.
+  const noRedis = !getRedis();
+  if (noRedis && lastInMemoryHealth && Date.now() - lastProbeAt < NO_REDIS_MIN_INTERVAL) {
+    return buildResponse(
+      lastInMemoryHealth.healthy,
+      lastInMemoryHealth.blockNumber,
+      lastInMemoryHealth.latency,
+      lastInMemoryHealth.error
     );
   }
 

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { Header } from "@/components/layout/Header";
+import { DegradationBanner } from "@/components/layout/DegradationBanner";
 import { GlobalModals } from "@/components/modules/GlobalModals";
 import { ThemeSync } from "@/components/layout/ThemeSync";
 
@@ -19,6 +20,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     <div className="flex min-h-screen flex-col bg-background text-foreground">
       <ThemeSync />
       <Header />
+      <DegradationBanner />
       <GlobalModals />
       <main className="flex flex-1 flex-col px-0 pb-8 pt-4 md:pb-0">
         {children}

--- a/components/layout/DegradationBanner.tsx
+++ b/components/layout/DegradationBanner.tsx
@@ -1,0 +1,44 @@
+'use client';
+
+import {
+  useServiceHealth,
+  type ServiceHealthStatus,
+} from '@/hooks/use-service-health';
+
+/**
+ * Top banner shown when the Steem node is unreachable or serving stale data.
+ * Hidden entirely while healthy or before the first health check resolves.
+ *
+ * - degraded: the node is serving stale cache (RPC failing but data still
+ *   available). Reads still work, but may be slightly out of date.
+ * - outage:   /api/health itself is unreachable. Writes may fail.
+ */
+const bannerStyles: Record<ServiceHealthStatus, string> = {
+  healthy: '',
+  degraded:
+    'bg-amber-100 dark:bg-amber-900/30 border-b border-amber-300 dark:border-amber-700 text-amber-800 dark:text-amber-200',
+  outage:
+    'bg-red-100 dark:bg-red-900/30 border-b border-red-300 dark:border-red-700 text-red-800 dark:text-red-200',
+  unknown: '',
+};
+
+export function DegradationBanner() {
+  const status = useServiceHealth();
+
+  if (status === 'healthy' || status === 'unknown') return null;
+
+  const message =
+    status === 'outage'
+      ? 'Connection to the Steem network is unstable. Some actions may fail.'
+      : 'Showing cached content — the Steem network is slow to respond.';
+
+  return (
+    <div
+      role="status"
+      aria-live="polite"
+      className={`px-4 py-2 text-center text-sm ${bannerStyles[status]}`}
+    >
+      {message}
+    </div>
+  );
+}

--- a/hooks/use-service-health.ts
+++ b/hooks/use-service-health.ts
@@ -1,0 +1,75 @@
+'use client';
+
+import { useEffect, useState, useCallback, useRef } from 'react';
+
+export type ServiceHealthStatus = 'healthy' | 'degraded' | 'outage' | 'unknown';
+
+const POLL_INTERVAL = 60_000; // 60s, matching the server health TTL
+
+/**
+ * Poll /api/health and surface the Steem node's service status.
+ * - Polls every 60s while the tab is visible.
+ * - Re-checks immediately on focus (visibilitychange → visible).
+ * - Pauses polling when the tab is hidden to avoid needless load.
+ *
+ * 'unknown' is the initial state (before the first poll resolves) and is
+ * treated as "no banner" by DegradationBanner.
+ */
+export function useServiceHealth(): ServiceHealthStatus {
+  const [status, setStatus] = useState<ServiceHealthStatus>('unknown');
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const resolveStatus = useCallback(async (): Promise<ServiceHealthStatus> => {
+    try {
+      const res = await fetch('/api/health', { cache: 'no-store' });
+      // Derive status from the body, not res.ok: the route returns 503 for the
+      // 'degraded' case (node slow, serving stale cache) as well as for full
+      // outages. Keying only on res.ok would collapse both into 'outage' and
+      // the amber "showing cached content" banner would never appear.
+      const data = (await res.json()) as { status?: string };
+      if (data.status === 'healthy') return 'healthy';
+      if (data.status === 'degraded') return 'degraded';
+      return 'outage';
+    } catch {
+      // Network failure reaching our own /api/health (or unparseable body) →
+      // we cannot determine node health, so treat as an outage.
+      return 'outage';
+    }
+  }, []);
+
+  useEffect(() => {
+    let active = true;
+
+    const poll = async () => {
+      const next = await resolveStatus();
+      if (active) setStatus(next);
+    };
+
+    void poll();
+    intervalRef.current = setInterval(() => {
+      void poll();
+    }, POLL_INTERVAL);
+
+    const handleVisibility = () => {
+      if (document.visibilityState === 'visible') {
+        void poll();
+        if (!intervalRef.current) {
+          intervalRef.current = setInterval(poll, POLL_INTERVAL);
+        }
+      } else if (intervalRef.current) {
+        clearInterval(intervalRef.current);
+        intervalRef.current = null;
+      }
+    };
+
+    document.addEventListener('visibilitychange', handleVisibility);
+
+    return () => {
+      active = false;
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      document.removeEventListener('visibilitychange', handleVisibility);
+    };
+  }, [resolveStatus]);
+
+  return status;
+}


### PR DESCRIPTION
Completes the three-tier cache migration with the user-facing degraded signal and a no-Redis safety net for `/api/health`. This is **PR3** of the cache migration (PR1 #3984 server-side Redis, PR2 #3985 client SWR).

## Degradation UI
- **`hooks/use-service-health.ts`** — polls `/api/health` every 60s, re-checks immediately on tab focus, and pauses polling while the tab is hidden to avoid needless load. Guards `setState` with an `active` flag so async resolves after unmount are dropped (satisfies `react-hooks/set-state-in-effect`).
- **`components/layout/DegradationBanner.tsx`** — amber banner when the node is serving stale cache ("Showing cached content — the Steem network is slow to respond."), red banner on outage. Hidden while healthy or before the first poll resolves.
- **`AppShell.tsx`** — banner mounted just below the header, above main content.

## No-Redis health throttle (carry-over from #3984)
Without Redis, the cache/probe-lock layers in `/api/health` are no-ops, so every request would probe the node directly. PR2's client poll (60s × N instances) turns that into an amplification risk. Added an in-process minimum interval (**5s**) that replays the last probe result within the window, capping the no-Redis path to one probe per instance per interval. The Redis path is unaffected (already throttled by cache + probe lock).

### Trade-off worth noting
On the no-Redis path, if a probe *fails* (throw), the in-memory result isn't updated, so requests within the next 5s replay the previous *successful* probe result. This is acceptable — it's the stale-while-error spirit (briefly show last-known-good rather than re-probing per request), only affects the no-Redis degraded path, and the failing request itself still returns the correct outage signal.

## Verification
- tsc --noEmit — clean
- eslint — clean (fixed set-state-in-effect via active guard)
- next build — Compiled successfully

## Migration status
This closes the cache-layer migration:
| PR | Layer | Status |
|---|---|---|
| #3984 | Redis L2 (server) | merged |
| #3985 | Browser L1 (client) | merged |
| this PR | Degraded UI + no-Redis throttle | review |