### PR TITLE
feat(ui): 1:1 legacy UI parity pass (header/feed/post/comments/profile/misc)

### DIFF
--- a/app/(main)/[sort]/[tag]/page.tsx
+++ b/app/(main)/[sort]/[tag]/page.tsx
@@ -108,11 +108,16 @@ export default function SortTagPage() {
   }, [isValidSort, loading, hasMore, posts, sortString, tagString]);
 
   const isHiveCommunity = tagString.startsWith("hive-");
+  // Legacy shows the community title (from bridge data) instead of the
+  // hive- id once posts have loaded.
+  const communityTitle = isHiveCommunity
+    ? posts.find((p) => p.community_title)?.community_title
+    : undefined;
   const feedTitle =
     tagString.toLowerCase() === "my"
       ? "My communities"
       : isHiveCommunity
-        ? tagString
+        ? (communityTitle ?? tagString)
         : `#${tagString}`;
 
   if (showNotFound) {
@@ -131,11 +136,6 @@ export default function SortTagPage() {
           tagString.toLowerCase() !== "my"
         }
       />
-      {isHiveCommunity ? (
-        <p className="-mt-2 mb-4 text-sm text-muted-foreground">
-          Showing posts from the {tagString} community
-        </p>
-      ) : null}
       <PostsList
         posts={posts}
         loading={loading}

--- a/app/(main)/communities/page.tsx
+++ b/app/(main)/communities/page.tsx
@@ -1,31 +1,175 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useState, useCallback } from "react";
+import Link from "next/link";
+import { SearchIcon } from "lucide-react";
 
 import { FeedLayout } from "@/components/layout/FeedLayout";
-import { useAppDispatch } from "@/store/hooks";
+import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { setPathname } from "@/store/slices/globalSlice";
+import {
+  fetchCommunities,
+  type CommunitySubscription,
+} from "@/lib/api/steem";
+import { getSteemitWalletBaseUrl } from "@/lib/steemitWallet";
+import SubscribeButton from "@/components/elements/SubscribeButton";
+import LoadingIndicator from "@/components/elements/LoadingIndicator";
+
+const SORT_OPTIONS = [
+  { value: "rank", label: "Rank" },
+  { value: "subs", label: "Subscribers" },
+  { value: "new", label: "New" },
+];
 
 /**
- * Communities index — stub until full communities UI is ported from legacy.
+ * Communities explore page — legacy CommunitiesIndex: search + sort + table
+ * of communities with a subscribe button per row.
  */
 export default function CommunitiesPage() {
   const dispatch = useAppDispatch();
+  const username = useAppSelector((s) => s.user.current?.username);
+  const walletBase = getSteemitWalletBaseUrl();
+
+  const [communities, setCommunities] = useState<CommunitySubscription[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [query, setQuery] = useState("");
+  const [sort, setSort] = useState("rank");
 
   useEffect(() => {
     dispatch(setPathname("/communities"));
   }, [dispatch]);
 
+  const performSearch = useCallback(
+    async (q: string, order: string) => {
+      setLoading(true);
+      try {
+        const data = await fetchCommunities({
+          observer: username,
+          query: q || undefined,
+          sort: order,
+          limit: 100,
+        });
+        setCommunities(data);
+      } catch (error) {
+        console.error("Error fetching communities:", error);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [username]
+  );
+
+  useEffect(() => {
+    void performSearch("", sort);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [username]);
+
   return (
     <FeedLayout>
-      <header className="mb-6">
-        <h1 className="font-sans text-2xl font-bold text-foreground md:text-3xl">
-          Communities
-        </h1>
-        <p className="mt-2 text-muted-foreground">
-          Community discovery and management will appear here.
-        </p>
-      </header>
+      <div className="CommunitiesIndex c-sidebar__module">
+        {username && (
+          <div className="float-right">
+            <a
+              href={`${walletBase}/@${username}/communities`}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent-foreground"
+            >
+              Create a community
+            </a>
+          </div>
+        )}
+
+        <h4 className="mb-2 font-bold text-foreground">
+          Communities: Find your people
+        </h4>
+
+        <div className="articles__header flex items-center gap-4">
+          <form
+            className="relative flex-1"
+            onSubmit={(e) => {
+              e.preventDefault();
+              void performSearch(query, sort);
+            }}
+          >
+            <input
+              type="search"
+              value={query}
+              onChange={(e) => setQuery(e.target.value)}
+              placeholder="Search"
+              aria-label="Search communities"
+              className="h-[42px] w-full border-none bg-transparent pr-10 text-[16px] text-foreground outline-none placeholder:text-muted-foreground"
+            />
+            <button
+              type="submit"
+              aria-label="Submit search"
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-foreground"
+            >
+              <SearchIcon className="size-5" strokeWidth={1.2} />
+            </button>
+          </form>
+          <select
+            value={sort}
+            onChange={(e) => {
+              setSort(e.target.value);
+              void performSearch(query, e.target.value);
+            }}
+            aria-label="Sort communities"
+            className="h-10 max-w-[300px] cursor-pointer border border-input bg-card px-2 text-sm text-foreground"
+          >
+            {SORT_OPTIONS.map((o) => (
+              <option key={o.value} value={o.value}>
+                {o.label}
+              </option>
+            ))}
+          </select>
+        </div>
+        <hr className="my-4 border-border" />
+
+        {loading ? (
+          <div className="flex justify-center py-12">
+            <LoadingIndicator type="circle" />
+          </div>
+        ) : communities.length === 0 ? (
+          <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
+            Nothing was found.
+          </div>
+        ) : (
+          <table className="mt-4 w-full">
+            <tbody>
+              {communities.map((comm) => (
+                <tr key={comm.name} className="border-b border-border">
+                  <th className="w-[600px] py-2 pr-[6%] text-left font-normal">
+                    <Link
+                      className="text-[1.3em] font-normal text-foreground hover:text-accent-foreground"
+                      href={`/trending/${comm.name}`}
+                    >
+                      {comm.title}
+                    </Link>
+                    {comm.context?.role && comm.context.role !== "guest" && (
+                      <span className="user_role mx-1 text-[0.8em] uppercase text-gray-500">
+                        {comm.context.role}
+                      </span>
+                    )}
+                    <br />
+                    <span className="text-foreground">{comm.about}</span>
+                    <small className="block text-[#999]">
+                      {comm.subscribers} subscribers &bull; {comm.num_authors}{" "}
+                      posters &bull; {comm.num_pending} posts
+                    </small>
+                  </th>
+                  <td className="w-[40px] py-2 text-center align-middle">
+                    <SubscribeButton
+                      community={comm.name}
+                      subscribed={Boolean(comm.context?.subscribed)}
+                    />
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        )}
+      </div>
     </FeedLayout>
   );
 }

--- a/app/(main)/search/SearchContent.tsx
+++ b/app/(main)/search/SearchContent.tsx
@@ -14,8 +14,8 @@ import {
 import PostsList from "@/components/cards/PostsList";
 import { Post } from "@/lib/api/steem";
 import { FeedLayout } from "@/components/layout/FeedLayout";
-import { Button } from "@/components/ui/button";
-import { Input } from "@/components/ui/input";
+import { SearchIcon } from "lucide-react";
+import Userpic from "@/components/elements/Userpic";
 import { cn } from "@/lib/utils";
 
 /** Elasticsearch hit shape (minimal fields used for Post mapping). */
@@ -188,97 +188,95 @@ export default function SearchContent() {
 
   return (
     <FeedLayout centerClassName="md:max-w-4xl lg:max-w-6xl">
-      <h1 className="mb-6 font-sans text-2xl font-bold text-foreground md:text-3xl">
-        Search
-      </h1>
-
-      <div className="mb-6">
+      {/* legacy: the in-page search box only shows ≤765px (desktop uses the
+          header search) */}
+      <div className="mb-6 min-[766px]:hidden">
         <form
           onSubmit={(e) => {
             e.preventDefault();
             handleSearch(localQuery);
           }}
-          className="flex flex-col gap-2 sm:flex-row"
+          className="relative"
         >
-          <Input
-            type="text"
+          <input
+            type="search"
             value={localQuery}
             onChange={(e) => setLocalQuery(e.target.value)}
-            placeholder="Search posts, comments, and accounts..."
-            className="min-h-10 flex-1"
+            placeholder="Search"
+            aria-label="Search"
+            className="h-[42px] w-full border-none bg-transparent pr-10 text-[16px] text-foreground outline-none placeholder:text-muted-foreground"
           />
-          <Button type="submit" className="shrink-0">
-            Search
-          </Button>
+          <button
+            type="submit"
+            aria-label="Submit search"
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-foreground"
+          >
+            <SearchIcon className="size-5" strokeWidth={1.2} />
+          </button>
         </form>
       </div>
 
       {query.trim() ? (
         <>
-          <div className="mb-4 flex flex-col flex-wrap gap-4 border-b border-border pb-4 md:flex-row md:items-center">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center">
-              <span className="text-sm text-muted-foreground">Search in:</span>
-              <div className="flex flex-wrap gap-1">
-                {[
-                  { value: 0, label: "Posts" },
-                  { value: 1, label: "Comments" },
-                  { value: 2, label: "Accounts" },
-                ].map((tab) => (
-                  <Button
-                    key={tab.value}
-                    type="button"
-                    size="sm"
-                    variant={depth === tab.value ? "default" : "outline"}
-                    onClick={() => handleDepthChange(tab.value)}
-                  >
-                    {tab.label}
-                  </Button>
-                ))}
+          {/* legacy SearchTabs: module-bg bar, wide gaps, #00FFC8 active */}
+          <div className="mb-4 flex flex-wrap items-center gap-y-2 border-b border-border pb-2">
+            <div className="flex items-center">
+              {[
+                { value: 0, label: "Posts" },
+                { value: 1, label: "Comments" },
+                { value: 2, label: "Accounts" },
+              ].map((tab) => (
+                <button
+                  key={tab.value}
+                  type="button"
+                  onClick={() => handleDepthChange(tab.value)}
+                  className={cn(
+                    "mr-[1rem] border-b-4 px-1 py-1 text-sm transition-colors min-[457px]:mr-[2.8rem]",
+                    depth === tab.value
+                      ? "border-[#00FFC8] text-[#00FFC8]"
+                      : "border-transparent text-foreground hover:text-accent-foreground"
+                  )}
+                >
+                  {tab.label}
+                </button>
+              ))}
+            </div>
+
+            {/* legacy: sort only Newest / Highest Payout, hidden for Accounts */}
+            {depth !== 2 && (
+              <div className="ml-auto flex items-center gap-2">
+                <label
+                  htmlFor="search-sort"
+                  className="text-sm text-muted-foreground"
+                >
+                  Sort by:
+                </label>
+                <select
+                  id="search-sort"
+                  value={sort === "payout" ? "payout" : "created_at"}
+                  onChange={(e) => handleSortChange(e.target.value)}
+                  className={cn(
+                    "h-9 border border-input bg-background px-3 text-sm text-foreground outline-none",
+                    "focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50"
+                  )}
+                >
+                  <option value="created_at">Newest</option>
+                  <option value="payout">Highest Payout</option>
+                </select>
               </div>
-            </div>
-
-            <div className="flex flex-col gap-2 sm:ml-auto sm:flex-row sm:items-center">
-              <label
-                htmlFor="search-sort"
-                className="text-sm text-muted-foreground"
-              >
-                Sort by:
-              </label>
-              <select
-                id="search-sort"
-                value={sort}
-                onChange={(e) => handleSortChange(e.target.value)}
-                className={cn(
-                  "h-9 rounded-md border border-input bg-background px-3 text-sm text-foreground shadow-xs outline-none",
-                  "focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50"
-                )}
-              >
-                <option value="created_at">Newest</option>
-                <option value="trending">Trending</option>
-                <option value="votes">Most Votes</option>
-                <option value="payout">Highest Payout</option>
-              </select>
-            </div>
+            )}
           </div>
-
-          {searchState.total_result > 0 ? (
-            <p className="mb-4 text-sm text-muted-foreground">
-              Found {searchState.total_result.toLocaleString()} results
-            </p>
-          ) : null}
 
           {searchState.pending && posts.length === 0 ? (
             <div className="flex flex-col items-center justify-center gap-2 py-12">
               <p className="text-muted-foreground">Searching...</p>
             </div>
           ) : posts.length === 0 ? (
-            <div className="rounded-lg border border-border bg-muted/40 p-8 text-center">
-              <p className="text-muted-foreground">
-                {query.trim()
-                  ? "No results found."
-                  : "Enter a search query to get started."}
-              </p>
+            <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
+              Nothing was found.
             </div>
+          ) : depth === 2 ? (
+            <SearchUserList hits={searchState.result} />
           ) : (
             <PostsList
               posts={posts}
@@ -290,13 +288,45 @@ export default function SearchContent() {
           )}
         </>
       ) : (
-        <div className="rounded-lg border border-border bg-muted/40 p-8 text-center">
-          <p className="text-muted-foreground">
-            Enter a search query above to find posts, comments, and accounts.
-          </p>
+        <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
+          Enter a search query above to find posts, comments, and accounts.
         </div>
       )}
     </FeedLayout>
+  );
+}
+
+/** Legacy SearchUserList: one row per account (avatar + name + about). */
+function SearchUserList({ hits }: { hits: SearchHitSource[] }) {
+  return (
+    <ul>
+      {hits.map((hit, i) => {
+        const account = (hit as { name?: string }).name || hit.author || "";
+        if (!account) return null;
+        const about = (hit as { about?: string }).about;
+        return (
+          <li
+            key={`${account}-${i}`}
+            className="flex items-center gap-3 border-b border-border py-2"
+          >
+            <a href={`/@${account}`} className="shrink-0">
+              <Userpic account={account} className="!size-10" />
+            </a>
+            <div className="min-w-0">
+              <a
+                href={`/@${account}`}
+                className="font-bold text-foreground hover:text-accent-foreground"
+              >
+                @{account}
+              </a>
+              {about && (
+                <p className="truncate text-sm text-muted-foreground">{about}</p>
+              )}
+            </div>
+          </li>
+        );
+      })}
+    </ul>
   );
 }
 

--- a/app/(main)/submit/page.tsx
+++ b/app/(main)/submit/page.tsx
@@ -51,9 +51,6 @@ export default function SubmitPostPage() {
 
   return (
     <FeedLayout centerClassName="md:max-w-4xl">
-      <h1 className="mb-6 font-sans text-2xl font-bold text-foreground md:text-3xl">
-        Create Post
-      </h1>
       <PostEditor type="submit_story" onSuccess={handleSuccess} />
     </FeedLayout>
   );

--- a/app/(main)/user/[username]/[section]/page.tsx
+++ b/app/(main)/user/[username]/[section]/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
+import Link from 'next/link';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setPathname } from '@/store/slices/globalSlice';
 import {
@@ -130,6 +131,20 @@ export default function UserProfileSectionPage() {
 
   const isMyAccount = username === accountname;
 
+  const profileHeader = (
+    <UserProfileHeader
+      accountname={accountname}
+      profile={profile?.metadata?.profile || null}
+      currentUser={username}
+      stats={profile?.stats}
+      reputation={profile?.reputation}
+      postCount={profile?.post_count}
+      created={profile?.created}
+      active={profile?.active}
+      blacklists={profile?.blacklists}
+    />
+  );
+
   // Show loading state if profile is still loading
   if (profileLoading) {
     return (
@@ -167,15 +182,7 @@ export default function UserProfileSectionPage() {
 
     return (
       <FeedLayout centerClassName="md:max-w-4xl">
-        <UserProfileHeader
-          accountname={accountname}
-          profile={profile?.metadata?.profile || null}
-          currentUser={username}
-          stats={profile?.stats}
-          reputation={profile?.reputation}
-          postCount={profile?.post_count}
-          created={profile?.created}
-        />
+        {profileHeader}
         <div className="mt-8">
           <UserSettings 
             accountname={accountname} 
@@ -202,19 +209,19 @@ export default function UserProfileSectionPage() {
     const followType = section === 'followers' ? 'followers' : 'following';
     return (
       <FeedLayout centerClassName="md:max-w-4xl">
-        <UserProfileHeader
-          accountname={accountname}
-          profile={profile?.metadata?.profile || null}
-          currentUser={username}
-          stats={profile?.stats}
-          reputation={profile?.reputation}
-          postCount={profile?.post_count}
-          created={profile?.created}
-        />
-        <h2 className="mt-6 mb-6 text-2xl font-bold text-foreground">
+        {profileHeader}
+        <h3 className="mt-6 mb-4 text-lg font-bold text-foreground">
           {section === 'followers' ? 'Followers' : 'Following'}
-        </h2>
-        <FollowList accountname={accountname} type={followType} />
+        </h3>
+        <FollowList
+          accountname={accountname}
+          type={followType}
+          total={
+            section === 'followers'
+              ? profile?.stats?.followers
+              : profile?.stats?.following
+          }
+        />
       </FeedLayout>
     );
   }
@@ -222,15 +229,7 @@ export default function UserProfileSectionPage() {
   if (section === 'notifications') {
     return (
       <FeedLayout centerClassName="md:max-w-4xl lg:max-w-6xl">
-        <UserProfileHeader
-          accountname={accountname}
-          profile={profile?.metadata?.profile || null}
-          currentUser={username}
-          stats={profile?.stats}
-          reputation={profile?.reputation}
-          postCount={profile?.post_count}
-          created={profile?.created}
-        />
+        {profileHeader}
         <NotificationsList username={accountname} />
       </FeedLayout>
     );
@@ -239,18 +238,7 @@ export default function UserProfileSectionPage() {
   if (section === 'communities') {
     return (
       <FeedLayout centerClassName="md:max-w-4xl lg:max-w-6xl">
-        <UserProfileHeader
-          accountname={accountname}
-          profile={profile?.metadata?.profile || null}
-          currentUser={username}
-          stats={profile?.stats}
-          reputation={profile?.reputation}
-          postCount={profile?.post_count}
-          created={profile?.created}
-        />
-        <h2 className="mt-6 mb-6 text-2xl font-bold text-foreground">
-          Communities
-        </h2>
+        {profileHeader}
         <CommunitiesList accountname={accountname} />
       </FeedLayout>
     );
@@ -258,45 +246,15 @@ export default function UserProfileSectionPage() {
 
   return (
     <FeedLayout>
-      <UserProfileHeader
-        accountname={accountname}
-        profile={profile?.metadata?.profile || null}
-        currentUser={username}
-        stats={profile?.stats}
-        reputation={profile?.reputation}
-        postCount={profile?.post_count}
-        created={profile?.created}
-      />
-
-      <div className="mb-6 border-b border-border">
-        <nav className="flex flex-wrap gap-6">
-          {['blog', 'posts', 'comments', 'replies', 'payout'].map((tab) => (
-            <a
-              key={tab}
-              href={`/@${accountname}/${tab}`}
-              className={`border-b-2 px-1 py-4 text-sm font-medium transition-colors ${
-                section === tab
-                  ? "border-ring text-accent-foreground"
-                  : "border-transparent text-muted-foreground hover:border-border hover:text-foreground"
-              }`}
-            >
-              {tab.charAt(0).toUpperCase() + tab.slice(1)}
-            </a>
-          ))}
-        </nav>
-      </div>
+      {profileHeader}
 
       {loading && posts.length === 0 ? (
         <div className="flex flex-col items-center justify-center gap-2 py-12">
           <p className="text-muted-foreground">Loading posts...</p>
         </div>
       ) : posts.length === 0 ? (
-        <div className="rounded-lg border border-border bg-muted/40 p-8 text-center">
-          <p className="text-muted-foreground">
-            {isMyAccount
-              ? "You haven't posted anything yet."
-              : `@${accountname} hasn't posted anything yet.`}
-          </p>
+        <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
+          {emptySectionText(section, accountname, isMyAccount)}
         </div>
       ) : (
         <PostsList
@@ -309,5 +267,52 @@ export default function UserProfileSectionPage() {
       )}
     </FeedLayout>
   );
+}
+
+/** Legacy UserProfile empty-state copy per section (UserProfile.jsx:23-69). */
+function emptySectionText(
+  section: string,
+  accountname: string,
+  isMyAccount: boolean
+): React.ReactNode {
+  switch (section) {
+    case 'replies':
+      return `@${accountname} hasn't had any replies yet.`;
+    case 'payout':
+      return 'No pending payouts.';
+    case 'comments':
+      return `@${accountname} hasn't made any comments yet.`;
+    case 'posts':
+      return `@${accountname} hasn't made any posts yet.`;
+    default:
+      break;
+  }
+  if (isMyAccount) {
+    return (
+      <span className="flex flex-col items-center gap-2">
+        <span>You haven&apos;t posted anything yet.</span>
+        <span className="flex flex-wrap justify-center gap-3">
+          <Link href="/communities" className="text-accent-foreground underline">
+            Explore Communities
+          </Link>
+          <Link href="/submit" className="text-accent-foreground underline">
+            Create a post
+          </Link>
+          <Link href="/trending" className="text-accent-foreground underline">
+            Trending Articles
+          </Link>
+          <a
+            href="https://steemit.com/welcome"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent-foreground underline"
+          >
+            Welcome Guide
+          </a>
+        </span>
+      </span>
+    );
+  }
+  return `@${accountname} hasn't posted anything yet.`;
 }
 

--- a/app/globals.css
+++ b/app/globals.css
@@ -355,3 +355,16 @@
   height: 48px;
   flex-shrink: 0;
 }
+
+/* Header logo hover: fill flips to near-black (light) / white (dark),
+   matching legacy SteemLogo styles. */
+@media (hover: hover) {
+  .Header__logotype .logo:hover svg path,
+  .Header__logotype .logo:active svg path {
+    fill: #171f24;
+  }
+  .dark .Header__logotype .logo:hover svg path,
+  .dark .Header__logotype .logo:active svg path {
+    fill: #ffffff;
+  }
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -342,3 +342,16 @@
 .phishy {
   color: crimson;
 }
+
+/* Account avatar (legacy Userpic.scss). Size overrides are applied inline
+   or via utility classes at the usage site (24px feed, 48px post/comment). */
+.Userpic {
+  display: inline-block;
+  background-size: cover;
+  background-repeat: no-repeat;
+  background-position: 50% 50%;
+  border-radius: 50%;
+  width: 48px;
+  height: 48px;
+  flex-shrink: 0;
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -83,6 +83,9 @@
   --sidebar-accent-foreground: #06d6a9;
   --sidebar-border: #eeeeee;
   --sidebar-ring: #06d6a9;
+  /* Legacy text links (_themes.scss light: textColorAccent/Hover) */
+  --link: #004eff;
+  --link-hover: #1a5099;
 }
 
 /* Dark theme — aligned with _themes.scss (dark) */
@@ -118,6 +121,9 @@
   --sidebar-accent-foreground: #06d6a9;
   --sidebar-border: #2b3a45;
   --sidebar-ring: #06d6a9;
+  /* Legacy text links (_themes.scss dark: textColorAccent/Hover) */
+  --link: #06d6a9;
+  --link-hover: #06d6a9;
 }
 
 @layer base {
@@ -138,11 +144,137 @@
   overflow: hidden;
 }
 
+/* Full typography port of legacy assets/stylesheets/markdown.scss */
 .Markdown {
+  font-family: 'Source Serif Pro', serif;
+  font-size: 120%;
+  line-height: 150%;
   overflow-wrap: break-word;
   word-wrap: break-word;
   word-break: break-word;
   hyphens: none;
+}
+
+.Markdown h1,
+.Markdown h2,
+.Markdown h3,
+.Markdown h4,
+.Markdown h5,
+.Markdown h6 {
+  font-family: var(--font-sans);
+  font-weight: 600;
+}
+
+.Markdown h1 { margin: 2.5rem 0 0.3rem; font-size: 160%; }
+.Markdown h2 { margin: 2.5rem 0 0.3rem; font-size: 140%; }
+.Markdown h3 { margin: 2rem 0 0.3rem; font-size: 120%; }
+.Markdown h4 { margin: 1.5rem 0 0.2rem; font-size: 110%; }
+.Markdown h5 { margin: 1rem 0 0.2rem; font-size: 100%; }
+.Markdown h6 { margin: 1rem 0 0.2rem; font-size: 90%; }
+
+.Markdown code {
+  padding: 0.2rem;
+  font-size: 85%;
+  border-radius: 3px;
+  border: none;
+  background-color: #f4f4f4;
+  font-weight: inherit;
+  overflow: scroll;
+}
+
+.dark .Markdown code {
+  background-color: #212c33;
+}
+
+.Markdown pre > code {
+  display: block;
+}
+
+.Markdown strong {
+  font-weight: 600;
+}
+
+.Markdown ol,
+.Markdown ul {
+  margin-left: 2rem;
+}
+
+.Markdown table td {
+  word-break: normal;
+}
+
+.Markdown table thead th {
+  word-break: normal;
+}
+
+.Markdown p {
+  font-size: 100%;
+  line-height: 150%;
+  margin: 0 0 1.5rem 0;
+}
+
+/* legacy .link--accent (light: blue #004EFF, dark: teal) */
+.Markdown a {
+  color: var(--link);
+  text-decoration: none;
+  transition: 0.2s all ease-in-out;
+}
+
+.Markdown a:visited,
+.Markdown a:active {
+  color: var(--link);
+}
+
+.Markdown a:hover,
+.Markdown a:focus {
+  color: var(--link-hover);
+}
+
+.Markdown img {
+  width: 100%;
+  max-width: 100%;
+  height: auto;
+  max-height: none;
+}
+
+@media only screen and (min-width: 768px) {
+  .Markdown img {
+    width: auto;
+  }
+}
+
+.Markdown iframe {
+  max-width: 100%;
+  max-height: 75vw;
+}
+
+.Markdown div.pull-right {
+  float: right;
+  padding-left: 1rem;
+  max-width: 50%;
+}
+
+.Markdown div.pull-left {
+  float: left;
+  padding-right: 1rem;
+  max-width: 50%;
+}
+
+.Markdown div.text-justify { text-align: justify; }
+.Markdown div.text-right { text-align: right; }
+.Markdown div.text-center { text-align: center; }
+.Markdown div.text-rtl { direction: rtl; }
+
+.Markdown blockquote {
+  border-left: 1px solid #788187;
+}
+
+.dark .Markdown blockquote {
+  border-left: 1px solid #a6b2ba;
+}
+
+.Markdown blockquote > p {
+  color: var(--muted-foreground);
 }
 
 .Markdown div.videoWrapper {
@@ -161,6 +293,11 @@
 }
 
 /* used for comments */
+.Markdown.MarkdownViewer--small {
+  font-family: inherit;
+  font-size: 110%;
+}
+
 .Markdown.MarkdownViewer--small img {
   max-width: 400px;
   max-height: 400px;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -28,6 +28,20 @@ export default function RootLayout({
       <body
         className={`${sourceSans.variable} ${geistMono.variable} font-sans antialiased`}
       >
+        {/* Post-body serif font, same source as legacy (server-html.jsx).
+            Loaded via Google Fonts CDN because next/font/google does not
+            ship Source Serif Pro. */}
+        <link rel="preconnect" href="https://fonts.googleapis.com" />
+        <link
+          rel="preconnect"
+          href="https://fonts.gstatic.com"
+          crossOrigin="anonymous"
+        />
+        {/* eslint-disable-next-line @next/next/no-page-custom-font */}
+        <link
+          rel="stylesheet"
+          href="https://fonts.googleapis.com/css?family=Source+Serif+Pro:400,600&display=swap"
+        />
         <ReduxProvider>{children}</ReduxProvider>
       </body>
     </html>

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,36 +1,18 @@
 "use client";
 
-import { Suspense, useEffect } from "react";
-import { useRouter, useSearchParams } from "next/navigation";
-
-import { useAppDispatch } from "@/store/hooks";
-import { showLogin } from "@/store/slices/userSlice";
+import { FeedLayout } from "@/components/layout/FeedLayout";
+import LoginForm from "@/components/modules/LoginForm";
 
 /**
- * /login opens the login modal (Redux) and returns to app chrome.
- * Deep links and bookmarks stay valid without a standalone login screen.
+ * /login renders the login form itself (legacy pages/Login.jsx), rather
+ * than opening the modal and redirecting away.
  */
-function LoginOpenRedirect() {
-  const router = useRouter();
-  const searchParams = useSearchParams();
-  const dispatch = useAppDispatch();
-
-  useEffect(() => {
-    dispatch(showLogin({}));
-    const next =
-      searchParams.get("redirect") ??
-      searchParams.get("return") ??
-      "/trending";
-    router.replace(next.startsWith("/") ? next : "/trending");
-  }, [dispatch, router, searchParams]);
-
-  return null;
-}
-
 export default function LoginPage() {
   return (
-    <Suspense fallback={null}>
-      <LoginOpenRedirect />
-    </Suspense>
+    <FeedLayout centerClassName="md:max-w-4xl">
+      <div className="py-8">
+        <LoginForm />
+      </div>
+    </FeedLayout>
   );
 }

--- a/components/NotFoundView.tsx
+++ b/components/NotFoundView.tsx
@@ -1,69 +1,62 @@
 "use client";
 
 import Link from "next/link";
-import { useRouter } from "next/navigation";
 
-import { Button } from "@/components/ui/button";
+/** Legacy steem round icon (from SteemLogo), shown at 4x on the 404 page. */
+function SteemIcon() {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 40 40"
+      className="mx-auto mb-4 size-[4em] [&_path]:fill-[#06D6A9]"
+      aria-hidden
+    >
+      <path d="M32.7004951,11.3807248 C31.1310771,9.81140963 29.3043776,8.66313021 27.3619013,7.92312792 C28.4939405,4.59311764 32.5075339,3.38104493 32.5075339,3.38104493 C32.5075339,3.38104493 23.1424826,-1.48000457 12.7997611,0.459311764 C9.35218721,1.00793415 6.0461183,3.12587173 3.62767097,5.92001831 C-1.62087426,11.9803819 -0.926213868,21.1028239 5.18422484,26.3083572 C6.1233028,27.1121528 8.22014805,28.3625014 8.2587403,28.4262947 C6.8822836,31.9221676 2.48276772,32.8790671 2.48276772,32.8790671 C2.48276772,32.8790671 8.29733255,36.5152853 16.10583,37.4594261 C18.1769471,37.7145993 20.3767051,37.7783926 22.6536475,37.5359781 C26.2684544,37.2425289 29.8703972,35.3287299 32.6104465,32.6366526 C38.5407881,26.7931863 38.5922444,17.2752258 32.7004951,11.3807248 Z M30.0247661,30.3145765 C27.8121441,32.4835487 24.5060752,33.861484 21.9589871,34.0528639 C20.1580157,34.2314851 18.2284034,34.2570024 16.3759757,34.0273465 C13.6487905,33.6956214 11.680586,32.9428604 9.75097374,32.2156168 C10.7286439,31.271476 11.7063141,29.9700926 12.1051006,28.8473305 C12.3623823,28.1838802 12.3366541,27.4438779 12.0279162,26.7931863 C9.95679906,22.5317938 10.8572848,17.4283297 14.2662664,14.1110781 C16.73617,11.6996913 20.1322875,10.5641706 23.5798614,10.9852064 C26.1140854,11.2914142 28.416756,12.4014176 30.2177274,14.2003887 C34.5915151,18.5893678 34.4371461,26.014908 30.0247661,30.3145765 Z" />
+    </svg>
+  );
+}
+
+const MENU = [
+  { href: "/created", label: "new posts" },
+  { href: "/hot", label: "hot posts" },
+  { href: "/trending", label: "trending posts" },
+  { href: "/promoted", label: "promoted posts" },
+  { href: "/payout", label: "active posts" },
+];
 
 /**
- * Shared 404 body: typography and actions aligned with Legacy / shadcn tokens.
- * Wrap with FeedLayout (and optionally AppShell for root not-found).
+ * Legacy NotFound page: steem icon + "Sorry! This page doesn't exist." +
+ * pipe-separated feed links (pages/NotFound.jsx, app.scss .NotFound).
  */
 export function NotFoundView() {
-  const router = useRouter();
-
   return (
-    <div className="flex flex-col items-center py-8 text-center">
-      <h1 className="mb-4 font-sans text-8xl font-bold text-muted-foreground/40 md:text-9xl">
-        404
-      </h1>
-      <h2 className="mb-4 font-sans text-2xl font-bold text-foreground md:text-3xl">
-        Page Not Found
-      </h2>
-      <p className="mb-8 max-w-md text-lg text-muted-foreground">
-        The page you are looking for does not exist or has been moved.
+    <div className="NotFound mx-auto mt-[2em] w-[340px] text-center min-[640px]:w-[640px]">
+      <SteemIcon />
+      <h4 className="mb-4 text-lg font-bold text-foreground">
+        Sorry! This page doesn&apos;t exist.
+      </h4>
+      <p className="mb-4 text-foreground">
+        Not to worry. You can head back to{" "}
+        <Link href="/" className="font-bold text-accent-foreground">
+          our homepage
+        </Link>
+        , or check out some great posts below.
       </p>
-
-      <div className="flex flex-col gap-4 sm:flex-row sm:justify-center">
-        <Button nativeButton={false} render={<Link href="/trending" />}>
-          Go to Trending
-        </Button>
-        <Button variant="outline" type="button" onClick={() => router.back()}>
-          Go Back
-        </Button>
-      </div>
-
-      <div className="mt-10 w-full border-t border-border pt-8">
-        <p className="mb-4 text-sm text-muted-foreground">
-          You might be looking for:
-        </p>
-        <div className="flex flex-wrap justify-center gap-2">
-          <Button
-            variant="secondary"
-            size="sm"
-            nativeButton={false}
-            render={<Link href="/trending" />}
-          >
-            Trending
-          </Button>
-          <Button
-            variant="secondary"
-            size="sm"
-            nativeButton={false}
-            render={<Link href="/search" />}
-          >
-            Search
-          </Button>
-          <Button
-            variant="secondary"
-            size="sm"
-            nativeButton={false}
-            render={<Link href="/login" />}
-          >
-            Login
-          </Button>
-        </div>
-      </div>
+      <ul className="NotFound__menu mt-[1em]">
+        {MENU.map((item, i) => (
+          <li key={item.href} className="mr-[1%] inline-block list-none">
+            <Link
+              href={item.href}
+              className="text-accent-foreground hover:underline"
+            >
+              {item.label}
+            </Link>
+            {i < MENU.length - 1 && (
+              <span className="text-muted-foreground">&nbsp;|</span>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/components/cards/Comment.tsx
+++ b/components/cards/Comment.tsx
@@ -1,16 +1,23 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import Link from 'next/link';
 import { useAppSelector } from '@/store/hooks';
 import MarkdownViewer from '@/components/elements/MarkdownViewer';
 import Voting from '@/components/elements/Voting';
 import PostEditor from '@/components/elements/PostEditor';
+import Userpic from '@/components/elements/Userpic';
+import TimeAgo from '@/components/elements/TimeAgo';
+import Reputation from '@/components/elements/Reputation';
+import { reputation } from '@/lib/extract-content';
 import { Post } from '@/lib/api/steem';
+import { cn } from '@/lib/utils';
 
 export interface Comment extends Post {
   depth?: number;
   replies?: string[]; // Array of comment keys (author/permlink)
+  /** Nested child comments (built by CommentsList). */
+  repliesData?: Comment[];
   parent_author?: string;
   parent_permlink?: string;
   children?: number;
@@ -20,23 +27,23 @@ interface CommentProps {
   comment: Comment;
   depth?: number;
   sortOrder?: 'votes' | 'new' | 'trending';
-  showNegativeComments?: boolean;
   onReply?: (parentAuthor: string, parentPermlink: string, body: string) => void;
   onEdit?: (author: string, permlink: string, body: string) => void;
   onDelete?: (author: string, permlink: string) => void;
   replies?: Comment[];
 }
 
+const MAX_DEPTH = 7;
+
 /**
- * Comment component
- * Displays a comment with nested replies support
- * Migrated from legacy/src/app/components/cards/Comment.jsx
+ * Comment — legacy three-part card (cards/Comment.jsx + Comment.scss):
+ * 48px avatar column, bordered header/body/footer blocks with a 62px
+ * indent, dotted reply tree lines, collapse [+]/[-], gray-comment reveal.
  */
 export default function Comment({
   comment,
   depth = 1,
   sortOrder = 'trending',
-  showNegativeComments = false,
   onReply,
   onEdit,
   onDelete,
@@ -45,23 +52,18 @@ export default function Comment({
   const [collapsed, setCollapsed] = useState(false);
   const [showReply, setShowReply] = useState(false);
   const [showEdit, setShowEdit] = useState(false);
-  const [hideBody, setHideBody] = useState(false);
+  // legacy: gray comments render with the body hidden behind a reveal link
+  const [revealGray, setRevealGray] = useState(false);
   const username = useAppSelector((state) => state.user.current?.username);
 
   const isMyComment = username === comment.author;
-  const canReply = depth < 255;
-  const canEdit = isMyComment;
-  const canDelete = isMyComment;
-  const maxDepth = 7;
+  const gray = Boolean(comment.stats?.gray) && !isMyComment;
+  const hideBody = gray && !revealGray;
 
-  // Check if comment should be hidden (negative reputation)
-  useEffect(() => {
-    const gray = comment.stats?.gray || false;
-    const notOwn = username !== comment.author;
-    if (notOwn && gray) {
-      setHideBody(true);
-    }
-  }, [comment, username]);
+  const rep = reputation(comment.author_reputation);
+  const edited = comment.last_update && comment.last_update !== comment.created;
+
+  const commentUrl = `/${comment.category}/@${comment.author}/${comment.permlink}`;
 
   const handleReplySubmit = (body: string) => {
     if (onReply) {
@@ -83,9 +85,6 @@ export default function Comment({
     }
   };
 
-  const commentUrl = `/${comment.category}/@${comment.author}/${comment.permlink}`;
-  const createdDate = new Date(comment.created);
-
   // Sort replies
   const sortedReplies = [...replies].sort((a, b) => {
     if (sortOrder === 'new') {
@@ -94,168 +93,194 @@ export default function Comment({
       const aVotes = a.active_votes?.filter((v) => v.weight > 0).length || 0;
       const bVotes = b.active_votes?.filter((v) => v.weight > 0).length || 0;
       return bVotes - aVotes;
-    } else {
-      // trending: sort by payout or net_rshares
-      const aPayout = parseFloat(a.pending_payout_value || '0');
-      const bPayout = parseFloat(b.pending_payout_value || '0');
-      if (aPayout !== bPayout) return bPayout - aPayout;
-      const aRshares = parseFloat(a.net_rshares || '0');
-      const bRshares = parseFloat(b.net_rshares || '0');
-      return bRshares - aRshares;
     }
+    const aPayout = parseFloat(a.pending_payout_value || '0');
+    const bPayout = parseFloat(b.pending_payout_value || '0');
+    if (aPayout !== bPayout) return bPayout - aPayout;
+    const aRshares = parseFloat(a.net_rshares || '0');
+    const bRshares = parseFloat(b.net_rshares || '0');
+    return bRshares - aRshares;
   });
 
-  if (!showNegativeComments && comment.stats?.gray && !isMyComment) {
-    return null;
-  }
+  // Gray comments sink to the bottom (legacy behavior).
+  sortedReplies.sort((a, b) => Number(Boolean(a.stats?.gray)) - Number(Boolean(b.stats?.gray)));
 
   return (
     <div
-      className={`comment ${depth === 1 ? 'root' : 'reply'} ${
-        collapsed ? 'collapsed' : ''
-      } ${hideBody ? 'downvoted' : ''}`}
+      className={cn('Comment mb-5', depth === 1 ? 'root' : 'reply')}
       id={`@${comment.author}/${comment.permlink}`}
     >
-      <div className="comment__block border-l-2 border-gray-200 pl-4 py-2">
-        {/* Comment header */}
-        <div className="comment__header flex items-center gap-2 text-sm text-gray-600 mb-2">
-          <button
-            onClick={() => setCollapsed(!collapsed)}
-            className="text-gray-400 hover:text-gray-600"
-            title={collapsed ? 'Expand' : 'Collapse'}
-          >
-            {collapsed ? '[+]' : '[-]'}
-          </button>
+      <div className="Comment__block">
+        {/* avatar column (48px desktop / 16px mobile) */}
+        <Link href={`/@${comment.author}`} className="float-left">
+          <Userpic
+            account={comment.author}
+            className="!size-4 min-[640px]:!size-12"
+          />
+        </Link>
 
-          <Link
-            href={`/@${comment.author}`}
-            className="font-medium text-blue-600 hover:underline"
-          >
-            @{comment.author}
-          </Link>
-
-          <span>•</span>
-
-          <Link href={commentUrl} className="text-gray-500 hover:text-gray-700">
-            <time dateTime={comment.created}>
-              {createdDate.toLocaleDateString()} {createdDate.toLocaleTimeString()}
-            </time>
-          </Link>
+        <div className="ml-[26px] min-[640px]:ml-[62px]">
+          {/* header */}
+          <div className="Comment__header rounded-t-[6px] border border-border bg-card px-[5px] py-[3px] text-[90%]">
+            <button
+              type="button"
+              onClick={() => setCollapsed(!collapsed)}
+              className="float-right tracking-[0.1rem] text-muted-foreground hover:text-foreground"
+              title={collapsed ? 'Expand' : 'Collapse'}
+            >
+              {collapsed ? '[+]' : '[-]'}
+            </button>
+            <Link
+              href={`/@${comment.author}`}
+              className="font-bold text-foreground hover:text-accent-foreground"
+            >
+              {comment.author}
+            </Link>{' '}
+            {rep !== null && <Reputation value={rep} />}{' '}
+            <Link
+              href={commentUrl}
+              className="text-muted-foreground hover:text-accent-foreground"
+            >
+              <TimeAgo date={comment.created} />
+            </Link>
+            {edited && (
+              <span
+                className="ml-1 text-muted-foreground"
+                title={`Last updated ${new Date(
+                  (comment.last_update || '') + 'Z'
+                ).toLocaleString()}`}
+              >
+                (edited)
+              </span>
+            )}
+            {gray && hideBody && (
+              <button
+                type="button"
+                onClick={() => setRevealGray(true)}
+                className="ml-2 text-accent-foreground hover:underline"
+              >
+                reveal comment
+              </button>
+            )}
+            {collapsed && (comment.children ?? sortedReplies.length) > 0 && (
+              <span className="ml-2 text-muted-foreground">
+                ({comment.children ?? sortedReplies.length}{' '}
+                {(comment.children ?? sortedReplies.length) === 1
+                  ? 'reply'
+                  : 'replies'}
+                )
+              </span>
+            )}
+          </div>
 
           {!collapsed && (
-            <div className="ml-auto flex items-center gap-2">
-              <Voting post={comment} />
-            </div>
-          )}
-        </div>
-
-        {/* Comment body */}
-        {!collapsed && (
-          <>
-            {hideBody ? (
-              <div className="bg-yellow-50 border border-yellow-200 rounded p-3 mb-2">
-                <p className="text-yellow-800 text-sm mb-2">
-                  This comment has been hidden due to low ratings.
-                </p>
-                <button
-                  onClick={() => setHideBody(false)}
-                  className="text-sm text-yellow-700 hover:text-yellow-900 underline"
-                >
-                  Show anyway
-                </button>
+            <>
+              {/* body */}
+              <div className="Comment__body border-x border-border bg-card px-[5px] py-1 text-[90%]">
+                {hideBody ? (
+                  <pre className="whitespace-pre-wrap font-sans opacity-50">
+                    {comment.body}
+                  </pre>
+                ) : (
+                  <MarkdownViewer text={comment.body || ''} />
+                )}
+                {gray && (
+                  <p className="text-[85%] text-muted-foreground">
+                    This comment will be hidden due to low ratings.
+                  </p>
+                )}
               </div>
-            ) : (
-              <div className="comment__body mb-3">
-                <MarkdownViewer text={comment.body || ''} />
-              </div>
-            )}
 
-            {/* Comment actions */}
-            <div className="comment__actions flex items-center gap-4 text-sm mb-3">
-              {canReply && (
+              {/* footer */}
+              <div className="Comment__footer flex flex-wrap items-center gap-x-3 gap-y-1 rounded-b-[6px] border border-border bg-card px-[10px] pb-[5px] pt-[3px] text-[90%]">
+                <Voting post={comment} isComment />
                 <button
+                  type="button"
                   onClick={() => {
                     setShowReply(!showReply);
                     setShowEdit(false);
                   }}
-                  className="text-blue-600 hover:text-blue-700"
+                  className="text-foreground hover:text-accent-foreground"
                 >
                   Reply
                 </button>
-              )}
-              {canEdit && (
-                <button
-                  onClick={() => {
-                    setShowEdit(!showEdit);
-                    setShowReply(false);
-                  }}
-                  className="text-blue-600 hover:text-blue-700"
-                >
-                  Edit
-                </button>
-              )}
-              {canDelete && (
-                <button
-                  onClick={handleDelete}
-                  className="text-red-600 hover:text-red-700"
-                >
-                  Delete
-                </button>
-              )}
-            </div>
-
-            {/* Reply/Edit editor */}
-            {(showReply || showEdit) && (
-              <div className="comment__editor mb-4">
-                <PostEditor
-                  type={showReply ? 'submit_comment' : 'edit'}
-                  body={showEdit ? comment.body : undefined}
-                  onSuccess={(category, body) => {
-                    if (showReply && body) {
-                      handleReplySubmit(body);
-                    } else if (showEdit && body) {
-                      handleEditSubmit(body);
-                    }
-                  }}
-                  onCancel={() => {
-                    setShowReply(false);
-                    setShowEdit(false);
-                  }}
-                />
-              </div>
-            )}
-
-            {/* Nested replies */}
-            {sortedReplies.length > 0 && (
-              <div className="comment__replies ml-6 mt-4 space-y-2">
-                {depth >= maxDepth ? (
-                  <Link
-                    href={commentUrl}
-                    className="text-blue-600 hover:underline text-sm"
-                  >
-                    Show {comment.children || sortedReplies.length} more{' '}
-                    {comment.children === 1 ? 'reply' : 'replies'}
-                  </Link>
-                ) : (
-                  sortedReplies.map((reply) => (
-                    <Comment
-                      key={`${reply.author}/${reply.permlink}`}
-                      comment={reply}
-                      depth={depth + 1}
-                      sortOrder={sortOrder}
-                      showNegativeComments={showNegativeComments}
-                      onReply={onReply}
-                      onEdit={onEdit}
-                      onDelete={onDelete}
-                    />
-                  ))
+                {isMyComment && (
+                  <>
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setShowEdit(!showEdit);
+                        setShowReply(false);
+                      }}
+                      className="text-foreground hover:text-accent-foreground"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={handleDelete}
+                      className="text-foreground hover:text-accent-foreground"
+                    >
+                      Delete
+                    </button>
+                  </>
                 )}
               </div>
+
+              {/* reply/edit editor */}
+              {(showReply || showEdit) && (
+                <div className="comment__editor my-4">
+                  <PostEditor
+                    type={showReply ? 'submit_comment' : 'edit'}
+                    body={showEdit ? comment.body : undefined}
+                    onSuccess={(category, body) => {
+                      if (showReply && body) {
+                        handleReplySubmit(body);
+                      } else if (showEdit && body) {
+                        handleEditSubmit(body);
+                      }
+                    }}
+                    onCancel={() => {
+                      setShowReply(false);
+                      setShowEdit(false);
+                    }}
+                  />
+                </div>
+              )}
+            </>
+          )}
+        </div>
+
+        {/* nested replies — dotted tree line, recursive */}
+        {sortedReplies.length > 0 && (
+          <div className="Comment__replies ml-[10px] mt-[1.4rem] border-l border-dotted border-[#788187] pl-2 min-[640px]:ml-[62px]">
+            {depth >= MAX_DEPTH ? (
+              <Link
+                href={commentUrl}
+                className="text-accent-foreground hover:underline"
+              >
+                Show {comment.children || sortedReplies.length} more{' '}
+                {(comment.children || sortedReplies.length) === 1
+                  ? 'reply'
+                  : 'replies'}
+              </Link>
+            ) : (
+              sortedReplies.map((reply) => (
+                <Comment
+                  key={`${reply.author}/${reply.permlink}`}
+                  comment={reply}
+                  depth={depth + 1}
+                  sortOrder={sortOrder}
+                  onReply={onReply}
+                  onEdit={onEdit}
+                  onDelete={onDelete}
+                  replies={reply.repliesData ?? []}
+                />
+              ))
             )}
-          </>
+          </div>
         )}
       </div>
     </div>
   );
 }
-

--- a/components/cards/CommentsList.tsx
+++ b/components/cards/CommentsList.tsx
@@ -1,8 +1,10 @@
 'use client';
 
 import { useState } from 'react';
+import { useAppSelector } from '@/store/hooks';
 import Comment, { Comment as CommentType } from './Comment';
 import PostEditor from '@/components/elements/PostEditor';
+import { ChevronDown } from 'lucide-react';
 
 interface CommentsListProps {
   comments: CommentType[];
@@ -15,157 +17,146 @@ interface CommentsListProps {
   onDelete?: (author: string, permlink: string) => void;
 }
 
+const PAGE_SIZE = 10;
+
+/** Legacy comment ordering (trending = payout desc, then rshares; gray sinks). */
+function sortComments(list: CommentType[], order: 'votes' | 'new' | 'trending') {
+  const sorted = [...list].sort((a, b) => {
+    if (order === 'new') {
+      return new Date(b.created).getTime() - new Date(a.created).getTime();
+    } else if (order === 'votes') {
+      const aVotes = a.active_votes?.filter((v) => v.weight > 0).length || 0;
+      const bVotes = b.active_votes?.filter((v) => v.weight > 0).length || 0;
+      return bVotes - aVotes;
+    }
+    const aPayout = parseFloat(a.pending_payout_value || '0');
+    const bPayout = parseFloat(b.pending_payout_value || '0');
+    if (aPayout !== bPayout) return bPayout - aPayout;
+    const aRshares = parseFloat(a.net_rshares || '0');
+    const bRshares = parseFloat(b.net_rshares || '0');
+    return bRshares - aRshares;
+  });
+  // Gray comments sink to the bottom (legacy behavior).
+  return sorted.sort(
+    (a, b) => Number(Boolean(a.stats?.gray)) - Number(Boolean(b.stats?.gray))
+  );
+}
+
+/** Build the nested comment tree (repliesData on every level). */
+function buildCommentTree(allComments: CommentType[]): CommentType[] {
+  const map = new Map<string, CommentType>();
+  const roots: CommentType[] = [];
+
+  allComments.forEach((c) => {
+    map.set(`${c.author}/${c.permlink}`, { ...c, repliesData: [] });
+  });
+
+  allComments.forEach((c) => {
+    const node = map.get(`${c.author}/${c.permlink}`)!;
+    if (c.parent_author && c.parent_permlink) {
+      const parent = map.get(`${c.parent_author}/${c.parent_permlink}`);
+      if (parent) {
+        parent.repliesData!.push(node);
+        return;
+      }
+    }
+    roots.push(node);
+  });
+
+  return roots;
+}
+
 /**
- * CommentsList component
- * Displays a list of comments with sorting and reply functionality
+ * CommentsList — legacy Post comments section: sort dropdown at top-right,
+ * first 10 comments with a green "LOAD MORE COMMENTS" button, reply editor
+ * at the top when logged in.
  */
 export default function CommentsList({
   comments,
   postAuthor,
   postPermlink,
-  postCategory,
   sortOrder = 'trending',
   onReply,
   onEdit,
   onDelete,
 }: CommentsListProps) {
-  const [showNewComment, setShowNewComment] = useState(false);
+  const username = useAppSelector((s) => s.user.current?.username);
   const [currentSortOrder, setCurrentSortOrder] = useState(sortOrder);
+  const [visibleCount, setVisibleCount] = useState(PAGE_SIZE);
 
-  // Build reply tree structure
-  const buildCommentTree = (allComments: CommentType[]): CommentType[] => {
-    const commentMap = new Map<string, CommentType>();
-    const rootComments: CommentType[] = [];
-
-    // First pass: create map of all comments
-    allComments.forEach((comment) => {
-      commentMap.set(`${comment.author}/${comment.permlink}`, {
-        ...comment,
-        replies: [],
-      });
-    });
-
-    // Second pass: build tree structure
-    allComments.forEach((comment) => {
-      const commentKey = `${comment.author}/${comment.permlink}`;
-      const commentWithReplies = commentMap.get(commentKey)!;
-
-      if (comment.parent_author && comment.parent_permlink) {
-        const parentKey = `${comment.parent_author}/${comment.parent_permlink}`;
-        const parent = commentMap.get(parentKey);
-        if (parent) {
-          if (!parent.replies) parent.replies = [];
-          parent.replies.push(commentKey);
-        }
-      } else {
-        // Root comment
-        rootComments.push(commentWithReplies);
-      }
-    });
-
-    return rootComments;
-  };
-
-  const rootComments = buildCommentTree(comments);
-
-  // Sort root comments
-  const sortedRootComments = [...rootComments].sort((a, b) => {
-    if (currentSortOrder === 'new') {
-      return new Date(b.created).getTime() - new Date(a.created).getTime();
-    } else if (currentSortOrder === 'votes') {
-      const aVotes = a.active_votes?.filter((v) => v.weight > 0).length || 0;
-      const bVotes = b.active_votes?.filter((v) => v.weight > 0).length || 0;
-      return bVotes - aVotes;
-    } else {
-      // trending
-      const aPayout = parseFloat(a.pending_payout_value || '0');
-      const bPayout = parseFloat(b.pending_payout_value || '0');
-      if (aPayout !== bPayout) return bPayout - aPayout;
-      const aRshares = parseFloat(a.net_rshares || '0');
-      const bRshares = parseFloat(b.net_rshares || '0');
-      return bRshares - aRshares;
-    }
-  });
-
-  const getRepliesForComment = (comment: CommentType): CommentType[] => {
-    if (!comment.replies || comment.replies.length === 0) return [];
-    return comments.filter((c) =>
-      comment.replies!.includes(`${c.author}/${c.permlink}`)
-    );
-  };
+  const rootComments = sortComments(buildCommentTree(comments), currentSortOrder);
+  const visibleRoots = rootComments.slice(0, visibleCount);
 
   const handleNewComment = (category?: string, body?: string) => {
     if (onReply && body) {
       onReply(postAuthor, postPermlink, body);
-      setShowNewComment(false);
     }
   };
 
   return (
-    <div className="comments-list mt-8 pt-8 border-t border-gray-200">
-      <div className="flex items-center justify-between mb-6">
-        <h2 className="text-2xl font-bold">
-          Comments ({comments.length})
-        </h2>
-
-        <div className="flex items-center gap-4">
-          <div className="flex items-center gap-2">
-            <label className="text-sm text-gray-600">Sort by:</label>
-            <select
-              value={currentSortOrder}
-              onChange={(e) =>
-                setCurrentSortOrder(e.target.value as 'votes' | 'new' | 'trending')
-              }
-              className="px-3 py-1 border border-gray-300 rounded-lg text-sm"
-            >
-              <option value="trending">Trending</option>
-              <option value="votes">Votes</option>
-              <option value="new">New</option>
-            </select>
-          </div>
-
-          <button
-            onClick={() => setShowNewComment(!showNewComment)}
-            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+    <div
+      className="Post_comments__content mx-auto mb-14 mt-8 max-w-[54rem] text-[92%]"
+      id="comments"
+    >
+      {/* sort control (legacy: top-right, "Sort by: <bold>") */}
+      <div className="Post__comments_sort_order mb-2 flex items-center justify-end gap-1 text-[94%]">
+        <span className="text-muted-foreground">Sort by:</span>
+        <span className="relative inline-flex items-center">
+          <select
+            value={currentSortOrder}
+            onChange={(e) =>
+              setCurrentSortOrder(e.target.value as 'votes' | 'new' | 'trending')
+            }
+            aria-label="Comment sort order"
+            className="cursor-pointer appearance-none bg-transparent pr-4 font-bold text-foreground outline-none"
           >
-            {showNewComment ? 'Cancel' : 'Add Comment'}
-          </button>
-        </div>
+            <option value="trending">Trending</option>
+            <option value="votes">Votes</option>
+            <option value="new">New</option>
+          </select>
+          <ChevronDown className="pointer-events-none absolute right-0 size-3.5" aria-hidden />
+        </span>
       </div>
 
-      {/* New comment editor */}
-      {showNewComment && (
+      {/* top-level reply editor (legacy shows it when logged in) */}
+      {username && (
         <div className="mb-6">
-          <PostEditor
-            type="submit_comment"
-            onSuccess={handleNewComment}
-            onCancel={() => setShowNewComment(false)}
-          />
+          <PostEditor type="submit_comment" onSuccess={handleNewComment} />
         </div>
       )}
 
-      {/* Comments list */}
-      {sortedRootComments.length === 0 ? (
-        <div className="text-center py-12 text-gray-500">
+      {visibleRoots.length === 0 ? (
+        <div className="py-12 text-center text-muted-foreground">
           <p>No comments yet. Be the first to comment!</p>
         </div>
       ) : (
-        <div className="space-y-4">
-          {sortedRootComments.map((comment) => (
+        <>
+          {visibleRoots.map((comment) => (
             <Comment
               key={`${comment.author}/${comment.permlink}`}
               comment={comment}
               depth={1}
               sortOrder={currentSortOrder}
-              replies={getRepliesForComment(comment)}
+              replies={comment.repliesData ?? []}
               onReply={onReply}
               onEdit={onEdit}
               onDelete={onDelete}
             />
           ))}
-        </div>
+
+          {rootComments.length > visibleCount && (
+            <div className="mt-6 text-center">
+              <button
+                type="button"
+                onClick={() => setVisibleCount((c) => c + PAGE_SIZE)}
+                className="comment-button rounded-[10px] bg-[#06d6a9] px-8 py-[15px] font-bold text-white"
+              >
+                LOAD MORE COMMENTS
+              </button>
+            </div>
+          )}
+        </>
       )}
     </div>
   );
 }
-

--- a/components/cards/CommunitiesList.tsx
+++ b/components/cards/CommunitiesList.tsx
@@ -3,21 +3,21 @@
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
 import { fetchUserSubscriptions, CommunitySubscription } from '@/lib/api/steem';
+import LoadingIndicator from '@/components/elements/LoadingIndicator';
 
 interface CommunitiesListProps {
   accountname: string;
 }
 
 /**
- * CommunitiesList component
- * Displays user's subscribed communities
- * Migrated from legacy/src/app/components/modules/CommunitySubscriberList.jsx
+ * CommunitiesList — a user's community subscriptions, as a simple list
+ * (legacy cards/SubscriptionsList.jsx): h4 + one row per community with
+ * role/affiliation text labels.
  */
 export default function CommunitiesList({ accountname }: CommunitiesListProps) {
   const [communities, setCommunities] = useState<CommunitySubscription[]>([]);
   const [loading, setLoading] = useState(true);
 
-  // Load communities data
   useEffect(() => {
     const loadCommunities = async () => {
       setLoading(true);
@@ -36,117 +36,38 @@ export default function CommunitiesList({ accountname }: CommunitiesListProps) {
 
   if (loading) {
     return (
-      <div className="flex justify-center items-center py-12">
-        <p className="text-gray-500">Loading communities...</p>
-      </div>
-    );
-  }
-
-  if (communities.length === 0) {
-    return (
-      <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
-        <p className="text-gray-600">
-          @{accountname} hasn't joined any communities yet.
-        </p>
+      <div className="flex items-center justify-center py-12">
+        <LoadingIndicator type="circle" />
       </div>
     );
   }
 
   return (
-    <div className="space-y-4">
-      <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-        {communities.map((community) => (
-          <div
-            key={community.name}
-            className="bg-white border border-gray-200 rounded-lg p-4 hover:shadow-md transition-shadow"
-          >
-            {/* Community header */}
-            <div className="flex items-start space-x-3 mb-3">
-              {community.avatar_url ? (
-                <img
-                  src={community.avatar_url}
-                  alt={community.title}
-                  className="w-12 h-12 rounded-full object-cover"
-                />
-              ) : (
-                <div className="w-12 h-12 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center text-white font-bold text-lg">
-                  {community.title?.charAt(0)?.toUpperCase() || 'C'}
-                </div>
-              )}
-              <div className="flex-1 min-w-0">
-                <Link
-                  href={`/trending/${community.name}`}
-                  className="font-semibold text-gray-900 hover:text-blue-600 block truncate"
-                >
-                  {community.title}
-                </Link>
-                <p className="text-sm text-gray-500 truncate">
-                  {community.name}
-                </p>
-              </div>
-            </div>
-
-            {/* Community description */}
-            {community.about && (
-              <p className="text-sm text-gray-600 mb-3 line-clamp-2">
-                {community.about}
-              </p>
-            )}
-
-            {/* Community stats */}
-            <div className="flex items-center justify-between text-xs text-gray-500">
-              <div className="flex space-x-4">
-                {community.subscribers !== undefined && (
-                  <span>
-                    {community.subscribers.toLocaleString()} subscribers
-                  </span>
-                )}
-                {community.num_authors !== undefined && (
-                  <span>
-                    {community.num_authors.toLocaleString()} authors
-                  </span>
-                )}
-              </div>
-              
-              {/* User role in community */}
-              {community.context?.role && (
-                <span className={`px-2 py-1 rounded-full text-xs font-medium ${
-                  community.context.role === 'admin' 
-                    ? 'bg-red-100 text-red-800'
-                    : community.context.role === 'mod'
-                    ? 'bg-yellow-100 text-yellow-800'
-                    : 'bg-blue-100 text-blue-800'
-                }`}>
+    <div className="SubscriptionsList mt-4">
+      <h4 className="mb-2 font-bold text-foreground">Subscriptions</h4>
+      {communities.length === 0 ? (
+        <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
+          @{accountname} hasn&apos;t joined any communities yet.
+        </div>
+      ) : (
+        <ul>
+          {communities.map((community) => (
+            <li key={community.name} className="border-b border-border py-2">
+              <Link
+                href={`/trending/${community.name}`}
+                className="font-semibold text-foreground hover:text-accent-foreground"
+              >
+                {community.title}
+              </Link>
+              {community.context?.role && community.context.role !== 'guest' && (
+                <span className="user_role mx-1 text-[0.8em] uppercase text-gray-500">
                   {community.context.role}
                 </span>
               )}
-            </div>
-
-            {/* Action buttons */}
-            <div className="mt-3 pt-3 border-t border-gray-100">
-              <div className="flex space-x-2">
-                <Link
-                  href={`/trending/${community.name}`}
-                  className="flex-1 px-3 py-1 text-sm bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors text-center"
-                >
-                  View Posts
-                </Link>
-                <Link
-                  href={`/roles/${community.name}`}
-                  className="px-3 py-1 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors"
-                >
-                  Roles
-                </Link>
-              </div>
-            </div>
-          </div>
-        ))}
-      </div>
-
-      {/* Total count */}
-      <div className="text-center text-sm text-gray-500 pt-4">
-        Member of {communities.length} communit{communities.length !== 1 ? 'ies' : 'y'}
-      </div>
+            </li>
+          ))}
+        </ul>
+      )}
     </div>
   );
 }

--- a/components/cards/FollowList.tsx
+++ b/components/cards/FollowList.tsx
@@ -1,157 +1,156 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
+
 import { fetchFollowers, fetchFollowing, FollowItem } from '@/lib/api/steem';
+import Follow from '@/components/elements/Follow';
+import LoadingIndicator from '@/components/elements/LoadingIndicator';
+import { useAppSelector } from '@/store/hooks';
 
 interface FollowListProps {
   accountname: string;
   type: 'followers' | 'following';
+  /** Total count from profile stats (for page-number pagination). */
+  total?: number;
 }
 
+const PAGE_SIZE = 20;
+
 /**
- * FollowList component
- * Displays followers or following list for a user
- * Migrated from legacy/src/app/components/elements/FollowList.jsx
+ * FollowList — legacy UserList table rows (@username + Follow button column)
+ * with page-number pagination (ReactPaginate style).
  */
-export default function FollowList({ accountname, type }: FollowListProps) {
+export default function FollowList({ accountname, type, total }: FollowListProps) {
+  const currentUser = useAppSelector((s) => s.user.current?.username);
   const [items, setItems] = useState<FollowItem[]>([]);
   const [loading, setLoading] = useState(true);
   const [page, setPage] = useState(1);
-  const [hasMore, setHasMore] = useState(true);
-  const [loadingMore, setLoadingMore] = useState(false);
 
-  // Load initial data
-  useEffect(() => {
-    const loadData = async () => {
+  const loadPage = useCallback(
+    async (p: number) => {
       setLoading(true);
       try {
-        const fetchFunction = type === 'followers' ? fetchFollowers : fetchFollowing;
-        const data = await fetchFunction(accountname, 1, 20);
+        const fetchFunction =
+          type === 'followers' ? fetchFollowers : fetchFollowing;
+        const data = await fetchFunction(accountname, p, PAGE_SIZE);
         setItems(data);
-        setHasMore(data.length >= 20);
-        setPage(1);
+        setPage(p);
       } catch (error) {
         console.error(`Error fetching ${type}:`, error);
       } finally {
         setLoading(false);
       }
-    };
+    },
+    [accountname, type]
+  );
 
-    loadData();
-  }, [accountname, type]);
+  useEffect(() => {
+    void loadPage(1);
+  }, [loadPage]);
 
-  // Load more data
-  const handleLoadMore = async () => {
-    if (loadingMore || !hasMore) return;
+  const totalPages =
+    typeof total === 'number' && total > 0
+      ? Math.ceil(total / PAGE_SIZE)
+      : items.length >= PAGE_SIZE
+        ? page + 1 // unknown total; at least one more page
+        : page;
 
-    setLoadingMore(true);
-    try {
-      const nextPage = page + 1;
-      const fetchFunction = type === 'followers' ? fetchFollowers : fetchFollowing;
-      const data = await fetchFunction(accountname, nextPage, 20);
-      
-      if (data.length > 0) {
-        setItems(prev => [...prev, ...data]);
-        setPage(nextPage);
-        setHasMore(data.length >= 20);
-      } else {
-        setHasMore(false);
-      }
-    } catch (error) {
-      console.error(`Error loading more ${type}:`, error);
-    } finally {
-      setLoadingMore(false);
-    }
-  };
-
-  if (loading) {
+  if (loading && items.length === 0) {
     return (
-      <div className="flex justify-center items-center py-12">
-        <p className="text-gray-500">Loading {type}...</p>
+      <div className="flex items-center justify-center py-12">
+        <LoadingIndicator type="circle" />
       </div>
     );
   }
 
   if (items.length === 0) {
     return (
-      <div className="bg-gray-50 border border-gray-200 rounded-lg p-8 text-center">
-        <p className="text-gray-600">
-          {type === 'followers' 
-            ? `@${accountname} has no followers yet.`
-            : `@${accountname} is not following anyone yet.`
-          }
-        </p>
+      <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
+        {type === 'followers'
+          ? `@${accountname} has no followers yet.`
+          : `@${accountname} is not following anyone yet.`}
       </div>
     );
   }
 
+  // Page number window (ReactPaginate-like: prev/next + numbered pages).
+  const pageNumbers: number[] = [];
+  const start = Math.max(1, Math.min(page - 2, totalPages - 4));
+  for (let p = start; p <= Math.min(totalPages, start + 4); p++) {
+    pageNumbers.push(p);
+  }
+
   return (
-    <div className="space-y-4">
-      <div className="grid gap-4">
-        {items.map((item, index) => {
-          const username = type === 'followers' ? item.follower : item.following;
-          return (
-            <div
-              key={`${username}-${index}`}
-              className="flex items-center justify-between p-4 bg-white border border-gray-200 rounded-lg hover:shadow-md transition-shadow"
-            >
-              <div className="flex items-center space-x-3">
-                <div className="w-10 h-10 rounded-full bg-gray-200 flex items-center justify-center text-lg font-bold text-gray-400">
-                  {username.charAt(0).toUpperCase()}
-                </div>
-                <div>
+    <div>
+      <table className="w-full">
+        <tbody>
+          {items.map((item, index) => {
+            const username =
+              type === 'followers' ? item.follower : item.following;
+            return (
+              <tr key={`${username}-${index}`} className="border-b border-border">
+                <td className="py-2 pr-4">
                   <Link
                     href={`/@${username}`}
-                    className="font-medium text-gray-900 hover:text-blue-600"
+                    className="font-bold text-foreground hover:text-accent-foreground"
                   >
                     @{username}
                   </Link>
-                  <div className="text-sm text-gray-500">
-                    {item.what.includes('blog') && (
-                      <span className="inline-block px-2 py-1 bg-blue-100 text-blue-800 rounded-full text-xs mr-1">
-                        Blog
-                      </span>
-                    )}
-                    {item.what.includes('ignore') && (
-                      <span className="inline-block px-2 py-1 bg-red-100 text-red-800 rounded-full text-xs">
-                        Muted
-                      </span>
-                    )}
-                  </div>
-                </div>
-              </div>
-              
-              <div className="flex space-x-2">
-                <Link
-                  href={`/@${username}`}
-                  className="px-3 py-1 text-sm bg-gray-100 text-gray-700 rounded-lg hover:bg-gray-200 transition-colors"
-                >
-                  View Profile
-                </Link>
-              </div>
-            </div>
-          );
-        })}
-      </div>
+                </td>
+                {currentUser && (
+                  <td className="w-[250px] py-2 text-right">
+                    <Follow following={username} showMute={false} />
+                  </td>
+                )}
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
 
-      {/* Load more button */}
-      {hasMore && (
-        <div className="text-center pt-6">
+      {totalPages > 1 && (
+        <nav
+          aria-label="Pagination"
+          className="mt-6 flex items-center justify-center gap-1 text-sm"
+        >
           <button
-            onClick={handleLoadMore}
-            disabled={loadingMore}
-            className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+            type="button"
+            disabled={page <= 1 || loading}
+            onClick={() => void loadPage(page - 1)}
+            className="rounded px-2 py-1 text-foreground hover:bg-accent disabled:opacity-40"
           >
-            {loadingMore ? 'Loading...' : 'Load More'}
+            previous
           </button>
-        </div>
+          {start > 1 && <span className="px-1 text-muted-foreground">…</span>}
+          {pageNumbers.map((p) => (
+            <button
+              key={p}
+              type="button"
+              disabled={loading}
+              onClick={() => void loadPage(p)}
+              className={`rounded px-2 py-1 ${
+                p === page
+                  ? 'bg-accent font-bold text-accent-foreground'
+                  : 'text-foreground hover:bg-accent'
+              } disabled:opacity-40`}
+            >
+              {p}
+            </button>
+          ))}
+          {pageNumbers[pageNumbers.length - 1] < totalPages && (
+            <span className="px-1 text-muted-foreground">…</span>
+          )}
+          <button
+            type="button"
+            disabled={page >= totalPages || loading}
+            onClick={() => void loadPage(page + 1)}
+            className="rounded px-2 py-1 text-foreground hover:bg-accent disabled:opacity-40"
+          >
+            next
+          </button>
+        </nav>
       )}
-
-      {/* Total count */}
-      <div className="text-center text-sm text-gray-500 pt-4">
-        Showing {items.length} {type}
-      </div>
     </div>
   );
 }

--- a/components/cards/NotificationsList.tsx
+++ b/components/cards/NotificationsList.tsx
@@ -5,7 +5,17 @@ import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import { receiveNotifications, receiveUnreadNotifications, notificationsLoading } from '@/store/slices/globalSlice';
 import { cachedFetch } from '@/lib/cache/client-fetch';
 import LoadingIndicator from '@/components/elements/LoadingIndicator';
+import Userpic from '@/components/elements/Userpic';
+import TimeAgo from '@/components/elements/TimeAgo';
 import Link from 'next/link';
+import {
+  AtSign,
+  Bell,
+  ChevronUp,
+  MessageCircle,
+  Repeat,
+  UserPlus,
+} from 'lucide-react';
 
 interface Notification {
   id: number;
@@ -14,37 +24,78 @@ interface Notification {
   date: string;
   msg: string;
   url?: string;
-  [key: string]: any;
+  [key: string]: unknown;
 }
 
 interface NotificationsListProps {
   username: string;
 }
 
+const FILTERS = [
+  { key: 'all', label: 'All' },
+  { key: 'replies', label: 'Replies' },
+  { key: 'mentions', label: 'Mentions' },
+  { key: 'follows', label: 'Follows' },
+  { key: 'upvotes', label: 'Upvotes' },
+  { key: 'resteems', label: 'Resteems' },
+] as const;
+
+type FilterKey = (typeof FILTERS)[number]['key'];
+
+const TYPE_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  reply: MessageCircle,
+  reply_post: MessageCircle,
+  reply_comment: MessageCircle,
+  follow: UserPlus,
+  vote: ChevronUp,
+  reblog: Repeat,
+  mention: AtSign,
+};
+
+/** First @account mentioned in a notification message (for the avatar). */
+function firstAccount(msg: string): string | null {
+  const m = msg.match(/@([a-z][a-z0-9.-]*)/);
+  return m ? m[1] : null;
+}
+
+/** Render the message with the first @mention bolded (legacy behavior). */
+function renderMsg(msg: string): React.ReactNode {
+  const m = msg.match(/@([a-z][a-z0-9.-]*)/);
+  if (!m || m.index === undefined) return msg;
+  return (
+    <>
+      {msg.slice(0, m.index)}
+      <strong>@{m[1]}</strong>
+      {msg.slice(m.index + m[0].length)}
+    </>
+  );
+}
+
 /**
- * NotificationsList component
- * Displays user notifications with filtering and pagination
- * Migrated from legacy/src/app/components/cards/NotificationsList.jsx
+ * NotificationsList — legacy layout: pipe-separated text filters, avatar +
+ * linked message + icon/time row, unread accent dot, score-tinted rows.
  */
 export default function NotificationsList({ username }: NotificationsListProps) {
   const dispatch = useAppDispatch();
-  const notificationsState = useAppSelector((state) => 
+  const notificationsState = useAppSelector((state) =>
     state.global.notifications?.[username]
   );
   const loading = useAppSelector((state) => state.global.notifications?.loading);
 
-  const [filter, setFilter] = useState<'all' | 'replies' | 'follows' | 'upvotes' | 'resteems' | 'mentions'>('all');
-  const [lastId, setLastId] = useState<number | null>(null);
+  const [filter, setFilter] = useState<FilterKey>('all');
 
   const notifications: Notification[] = notificationsState?.notifications || [];
   const isLastPage = notificationsState?.isLastPage || false;
-  const unreadCount = Object.keys(notificationsState?.unreadNotifications || {}).length;
+  const unreadMap: Record<string, unknown> =
+    notificationsState?.unreadNotifications || {};
+  const unreadCount = Object.keys(unreadMap).length;
 
   // Load notifications on mount
   useEffect(() => {
     if (username) {
       loadNotifications(username);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [username]);
 
   const loadNotifications = async (accountName: string, startId?: number) => {
@@ -86,13 +137,9 @@ export default function NotificationsList({ username }: NotificationsListProps) 
   };
 
   const handleMarkAsRead = async () => {
-    const timeNow = new Date().toISOString().slice(0, 19);
     try {
       // TODO: Implement actual API call to mark notifications as read
       // This requires broadcasting a custom_json operation
-      // For now, just update the local state
-      
-      // Update unread notifications state
       dispatch(
         receiveUnreadNotifications({
           name: username,
@@ -104,43 +151,11 @@ export default function NotificationsList({ username }: NotificationsListProps) 
     }
   };
 
-  const getNotificationIcon = (type: string) => {
-    const iconMap: Record<string, string> = {
-      reply: '💬',
-      reply_post: '💬',
-      reply_comment: '💬',
-      follow: '👥',
-      set_label: '✏️',
-      set_role: '✏️',
-      vote: '⬆️',
-      error: '⚙️',
-      reblog: '🔄',
-      mention: '💭',
-    };
-    return iconMap[type] || '🔔';
-  };
-
-  const getNotificationTypeLabel = (type: string) => {
-    const labelMap: Record<string, string> = {
-      reply: 'Reply',
-      reply_post: 'Reply',
-      reply_comment: 'Reply',
-      follow: 'Follow',
-      set_label: 'Label',
-      set_role: 'Role',
-      vote: 'Upvote',
-      error: 'Error',
-      reblog: 'Reblog',
-      mention: 'Mention',
-    };
-    return labelMap[type] || type;
-  };
-
   const filterNotifications = (notifs: Notification[]) => {
     if (filter === 'all') return notifs;
 
     const filterMap: Record<string, string[]> = {
-      replies: ['reply_comment', 'reply'],
+      replies: ['reply_comment', 'reply', 'reply_post'],
       follows: ['follow'],
       upvotes: ['vote'],
       resteems: ['reblog'],
@@ -153,105 +168,107 @@ export default function NotificationsList({ username }: NotificationsListProps) 
 
   const filteredNotifications = filterNotifications(notifications);
 
-  const formatDate = (dateString: string) => {
-    const date = new Date(dateString);
-    const now = new Date();
-    const diffMs = now.getTime() - date.getTime();
-    const diffMins = Math.floor(diffMs / 60000);
-    const diffHours = Math.floor(diffMs / 3600000);
-    const diffDays = Math.floor(diffMs / 86400000);
-
-    if (diffMins < 1) return 'Just now';
-    if (diffMins < 60) return `${diffMins}m ago`;
-    if (diffHours < 24) return `${diffHours}h ago`;
-    if (diffDays < 7) return `${diffDays}d ago`;
-    return date.toLocaleDateString();
-  };
-
   return (
-    <div className="notifications-list">
-      <div className="mb-6">
-        <div className="flex items-center justify-between mb-4">
-          <h1 className="text-3xl font-bold">Notifications</h1>
-          {unreadCount > 0 && (
+    <div className="notifications-list mt-4">
+      {/* Filter links (legacy: centered, pipe-separated, selected = bold) */}
+      <div className="mb-4 text-center">
+        {FILTERS.map((f, i) => (
+          <span key={f.key}>
             <button
-              onClick={handleMarkAsRead}
-              className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 text-sm"
+              type="button"
+              onClick={() => setFilter(f.key)}
+              className={`px-[5px] text-foreground hover:text-accent-foreground ${
+                filter === f.key ? 'font-bold' : ''
+              } ${i > 0 ? 'border-l border-[#ababab]' : ''}`}
             >
-              Mark all as read ({unreadCount})
+              {f.label}
             </button>
-          )}
-        </div>
-
-        {/* Filter tabs */}
-        <div className="flex gap-2 border-b border-gray-200 mb-4">
-          {(['all', 'replies', 'follows', 'upvotes', 'resteems', 'mentions'] as const).map((filterType) => (
-            <button
-              key={filterType}
-              onClick={() => setFilter(filterType)}
-              className={`px-4 py-2 -mb-px border-b-2 transition-colors ${
-                filter === filterType
-                  ? 'border-blue-500 text-blue-600 font-medium'
-                  : 'border-transparent text-gray-500 hover:text-gray-700 hover:border-gray-300'
-              }`}
-            >
-              {filterType.charAt(0).toUpperCase() + filterType.slice(1)}
-            </button>
-          ))}
-        </div>
+          </span>
+        ))}
       </div>
 
-      {/* Notifications list */}
+      {unreadCount > 0 && (
+        <div className="mb-4 text-center">
+          <button
+            type="button"
+            onClick={handleMarkAsRead}
+            className="font-bold text-foreground hover:text-accent-foreground"
+          >
+            Mark all as read
+          </button>
+        </div>
+      )}
+
       {loading && notifications.length === 0 ? (
-        <div className="flex justify-center items-center py-12">
+        <div className="flex items-center justify-center py-12">
           <LoadingIndicator type="circle" />
         </div>
       ) : filteredNotifications.length === 0 ? (
-        <div className="text-center py-12 text-gray-500">
-          <p>No notifications found.</p>
+        <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
+          Welcome! You don&apos;t have any notifications yet.
         </div>
       ) : (
-        <div className="space-y-2">
-          {filteredNotifications.map((notification) => (
-            <div
-              key={notification.id}
-              className={`notification-item p-4 border rounded-lg hover:bg-gray-50 transition-colors ${
-                notification.type ? `notification-${notification.type}` : ''
-              }`}
-            >
-              <div className="flex items-start gap-3">
-                <span className="text-2xl mt-1">{getNotificationIcon(notification.type)}</span>
-                <div className="flex-1">
-                  <div className="flex items-center gap-2 mb-1">
-                    <span className="text-xs text-gray-500">
-                      {getNotificationTypeLabel(notification.type)}
-                    </span>
-                    <span className="text-xs text-gray-400">
-                      {formatDate(notification.date)}
-                    </span>
-                  </div>
-                  {notification.url ? (
-                    <Link
-                      href={notification.url}
-                      className="text-gray-800 hover:text-blue-600"
-                    >
-                      {notification.msg}
+        <div>
+          {filteredNotifications.map((notification) => {
+            const account = firstAccount(notification.msg || '');
+            const TypeIcon = TYPE_ICONS[notification.type] || Bell;
+            const isUnread = Boolean(unreadMap[notification.id]);
+            const score = notification.score ?? 0;
+            return (
+              <div
+                key={notification.id}
+                className="relative border-b border-border px-4 py-2"
+                style={{
+                  background:
+                    score > 0
+                      ? `rgba(225,255,225,${Math.min(score, 100) / 100})`
+                      : undefined,
+                }}
+              >
+                {isUnread && (
+                  <span
+                    className="absolute right-4 top-3 text-[2em] leading-none text-accent-foreground"
+                    title="Unread"
+                  >
+                    •
+                  </span>
+                )}
+                <div className="flex items-start gap-3">
+                  {account && (
+                    <Link href={`/@${account}`} className="mt-0.5 shrink-0">
+                      <Userpic account={account} className="!size-10" />
                     </Link>
-                  ) : (
-                    <p className="text-gray-800">{notification.msg}</p>
                   )}
+                  <div className="min-w-0 flex-1">
+                    {notification.url ? (
+                      <Link
+                        href={notification.url}
+                        className="text-foreground hover:text-accent-foreground"
+                      >
+                        {renderMsg(notification.msg || '')}
+                      </Link>
+                    ) : (
+                      <p className="text-foreground">
+                        {renderMsg(notification.msg || '')}
+                      </p>
+                    )}
+                    <div className="mt-1 flex items-center gap-1 text-sm text-muted-foreground">
+                      <TypeIcon className="size-4" aria-hidden />
+                      <TimeAgo date={notification.date} />
+                    </div>
+                  </div>
                 </div>
               </div>
-            </div>
-          ))}
+            );
+          })}
 
-          {/* Load more button */}
           {!isLastPage && (
-            <div className="text-center py-4">
+            <div className="py-4 text-center">
               <button
+                type="button"
                 onClick={handleLoadMore}
                 disabled={loading}
-                className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                className="font-bold text-foreground hover:text-accent-foreground disabled:opacity-50"
               >
                 {loading ? 'Loading...' : 'Load more'}
               </button>
@@ -262,4 +279,3 @@ export default function NotificationsList({ username }: NotificationsListProps) 
     </div>
   );
 }
-

--- a/components/cards/PostFull.tsx
+++ b/components/cards/PostFull.tsx
@@ -2,21 +2,28 @@
 
 import { useEffect } from 'react';
 import Link from 'next/link';
+import { Clock, Link2, MessageSquare } from 'lucide-react';
+
 import { Post } from '@/lib/api/steem';
+import { reputation } from '@/lib/extract-content';
 import MarkdownViewer from '@/components/elements/MarkdownViewer';
 import Voting from '@/components/elements/Voting';
 import Reblog from '@/components/elements/Reblog';
 import ShareMenu from '@/components/elements/ShareMenu';
 import TagList from '@/components/elements/TagList';
+import Userpic from '@/components/elements/Userpic';
+import TimeAgo from '@/components/elements/TimeAgo';
+import Reputation from '@/components/elements/Reputation';
 
 interface PostFullProps {
   post: Post;
 }
 
 /**
- * PostFull component
- * Displays a full post with title, body, metadata, and actions
- * Migrated from legacy/src/app/components/cards/PostFull.jsx
+ * PostFull — legacy full post card (cards/PostFull.jsx + PostFull.scss):
+ * bordered card, 40rem centered header/body, 48px avatar author row,
+ * tags below the body, legacy footer (Voting | Reblog | Reply | responses
+ * | share icons | link).
  */
 export default function PostFull({ post }: PostFullProps) {
   // Set document title
@@ -44,10 +51,9 @@ export default function PostFull({ post }: PostFullProps) {
 
   const tags = post.json_metadata?.tags || [];
   const postUrl = `/${post.category}/@${post.author}/${post.permlink}`;
-  const createdDate = new Date(post.created);
-
-  // Legacy parity (PostFull.jsx): high_quality_post = payout > 10.0;
-  // noImage = post.stats.gray (low-rated posts hide images behind a banner).
+  const rep = reputation(post.author_reputation);
+  const edited = post.last_update && post.last_update !== post.created;
+  const powerUp100 = post.percent_steem_dollars === 0;
   const payout =
     typeof post.payout === 'number'
       ? post.payout
@@ -55,53 +61,77 @@ export default function PostFull({ post }: PostFullProps) {
   const highQualityPost = payout > 10.0;
   const noImage = Boolean(post.stats?.gray);
 
+  const copyLink = () => {
+    if (typeof window === 'undefined') return;
+    const full = `${window.location.origin}${postUrl}`;
+    void navigator.clipboard?.writeText(full);
+  };
+
   return (
-    <article className="post-full">
-      <header className="post-full__header mb-6">
-        <h1 className="text-3xl font-bold mb-4">{post.title || 'Untitled'}</h1>
-        
-        <div className="post-full__meta text-sm text-gray-600 mb-4 space-y-2">
-          <div className="flex items-center gap-2 flex-wrap">
-            <span className="post-full__author">
-              by{' '}
-              <Link
-                href={`/@${post.author}`}
-                className="text-blue-600 hover:underline font-medium"
-              >
-                @{post.author}
-              </Link>
+    <article
+      className="PostFull relative rounded-[6px] border border-border bg-card px-4 pb-4 pt-8"
+      itemScope
+      itemType="http://schema.org/Article"
+    >
+      <div className="PostFull__header mx-auto max-w-[40rem] border-b border-border">
+        <h1
+          className="font-sans font-extrabold leading-[1.1] [overflow-wrap:break-word] text-[240%]"
+          itemProp="headline"
+        >
+          {post.title || 'Untitled'}
+          {powerUp100 && (
+            <span title="100% Steem Power payout" className="ml-2 align-middle text-[50%]">
+              ⚡
             </span>
-            <span>•</span>
-            <span className="post-full__category">
+          )}
+        </h1>
+
+        {/* TimeAuthorCategoryLarge: 48px avatar + author/time rows */}
+        <div className="PostFull__time_author_category_large my-4 flex items-center text-[120%] text-muted-foreground">
+          <Link href={`/@${post.author}`} className="shrink-0">
+            <Userpic account={post.author} />
+          </Link>
+          <span className="right-side ml-3 leading-[1.2]">
+            <span className="block">
+              <Clock className="mr-1 inline size-4 align-[-2px]" aria-hidden />
               in{' '}
               <Link
                 href={`/trending/${post.category}`}
-                className="text-blue-600 hover:underline"
+                className="text-muted-foreground hover:text-accent-foreground"
               >
-                #{post.category}
-              </Link>
+                #{post.community_title && post.category?.startsWith('hive-')
+                  ? post.community_title
+                  : post.category}
+              </Link>{' '}
+              •{' '}
+              <TimeAgo date={post.created} />
+              {edited && (
+                <span
+                  className="ml-1"
+                  title={`Last updated ${new Date(
+                    (post.last_update || '') + 'Z'
+                  ).toLocaleString()}`}
+                >
+                  (edited)
+                </span>
+              )}
             </span>
-            <span>•</span>
-            <span className="post-full__date">
-              <time dateTime={post.created}>
-                {createdDate.toLocaleDateString('en-US', {
-                  year: 'numeric',
-                  month: 'long',
-                  day: 'numeric',
-                })}
-              </time>
+            <span className="block">
+              by{' '}
+              <Link
+                href={`/@${post.author}`}
+                className="font-bold text-foreground hover:text-accent-foreground"
+                itemProp="author"
+              >
+                {post.author}
+              </Link>{' '}
+              {rep !== null && <Reputation value={rep} />}
             </span>
-          </div>
-
-          {tags.length > 0 && (
-            <div className="mt-2">
-              <TagList tags={tags} category={post.category} />
-            </div>
-          )}
+          </span>
         </div>
-      </header>
+      </div>
 
-      <div className="post-full__body prose max-w-none mb-8">
+      <div className="PostFull__body mx-auto max-w-[40rem] py-4" itemProp="articleBody">
         <MarkdownViewer
           text={post.body || ''}
           large
@@ -110,26 +140,46 @@ export default function PostFull({ post }: PostFullProps) {
         />
       </div>
 
-      <footer className="post-full__footer mt-8 pt-6 border-t border-gray-200">
-        <div className="flex items-center justify-between flex-wrap gap-4">
-          <div className="flex items-center gap-4">
-            <Voting post={post} />
-            <Reblog author={post.author} permlink={post.permlink} />
-          </div>
+      <TagList tags={tags} category={post.category} />
 
-          <ShareMenu
-            url={postUrl}
-            title={post.title || 'Untitled'}
-            description={post.body?.substring(0, 200)}
-          />
+      <div className="PostFull__footer mx-auto flex max-w-[40rem] flex-wrap items-center justify-between gap-2 text-[94%] leading-[2rem]">
+        <div>
+          <Voting post={post} />
         </div>
-
-        {post.children !== undefined && (
-          <div className="mt-4 text-sm text-gray-600">
-            {post.children} {post.children === 1 ? 'comment' : 'comments'}
-          </div>
-        )}
-      </footer>
+        <div className="RightShare__Menu flex items-center">
+          <span className="mr-[0.4rem] border-r border-border pr-[0.4rem]">
+            <Reblog author={post.author} permlink={post.permlink} iconOnly />
+          </span>
+          <span className="PostFull__reply mr-[0.4rem] border-r border-border pr-[0.4rem]">
+            <a
+              href="#comments"
+              className="mx-[0.15rem] text-foreground hover:text-accent-foreground"
+            >
+              Reply
+            </a>
+          </span>
+          <span className="PostFull__responses pr-[0.4rem]">
+            <Link
+              href={`${postUrl}#comments`}
+              title={`${post.children ?? 0} responses`}
+              className="inline-flex items-center gap-1 text-foreground hover:text-accent-foreground"
+            >
+              <MessageSquare className="size-4" aria-hidden />
+              {post.children ?? 0}
+            </Link>
+          </span>
+          <ShareMenu url={postUrl} title={post.title || 'Untitled'} />
+          <button
+            type="button"
+            className="explore-post p-[2px] text-muted-foreground hover:text-accent-foreground"
+            title="Share this post"
+            aria-label="Copy post link"
+            onClick={copyLink}
+          >
+            <Link2 className="size-5" aria-hidden />
+          </button>
+        </div>
+      </div>
     </article>
   );
 }

--- a/components/cards/PostSummary.tsx
+++ b/components/cards/PostSummary.tsx
@@ -1,0 +1,229 @@
+"use client";
+
+import { useState } from "react";
+import Link from "next/link";
+import { ChevronUp, MessageCircle, Pin } from "lucide-react";
+
+import type { Post } from "@/lib/api/steem";
+import {
+  extractImageLink,
+  extractBodySummary,
+  summaryThumbnail,
+  reputation,
+} from "@/lib/extract-content";
+import Userpic from "@/components/elements/Userpic";
+import TimeAgo from "@/components/elements/TimeAgo";
+import Reputation from "@/components/elements/Reputation";
+import Reblog from "@/components/elements/Reblog";
+import { cn } from "@/lib/utils";
+
+interface PostSummaryProps {
+  post: Post;
+  /** Current sort order (payout order shows payout_at with a prefix). */
+  order?: string;
+}
+
+/** "$12.34" from "12.345 SBD" (legacy FormattedAsset). */
+function formatPayout(value?: string): string | null {
+  if (!value) return null;
+  const amount = Number.parseFloat(value);
+  if (!Number.isFinite(amount)) return null;
+  return `$${amount.toFixed(2)}`;
+}
+
+/**
+ * PostSummary — legacy feed card (PostSummary.jsx, layout-list mode):
+ * resteem row / author header / thumbnail + title + body excerpt / footer
+ * with payout, votes, comments and a reblog button.
+ */
+export default function PostSummary({ post, order }: PostSummaryProps) {
+  const [revealNsfw, setRevealNsfw] = useState(false);
+
+  const tags = post.json_metadata?.tags || [];
+  const isNsfw = tags.includes("nsfw");
+  const gray = Boolean(post.stats?.gray);
+  const isPinned = Boolean(post.stats?.is_pinned);
+  const powerUp100 = post.percent_steem_dollars === 0;
+  const rep = reputation(post.author_reputation);
+
+  // Community posts: display the community title instead of the hive- id.
+  const isCommunity = post.category?.startsWith("hive-");
+  const categoryLabel =
+    isCommunity && post.community_title ? post.community_title : post.category;
+
+  const postUrl = `/${post.category}/@${post.author}/${post.permlink}`;
+  const tagUrl = `/trending/${post.category}`;
+
+  const imageLink = gray
+    ? null
+    : extractImageLink(post.json_metadata, post.body);
+  const thumb = summaryThumbnail(imageLink);
+  const summary = extractBodySummary(post.body || "", true);
+
+  const rebloggedBy: string[] = Array.isArray(post.reblogged_by)
+    ? post.reblogged_by
+    : [];
+  const totalVotes = post.stats?.total_votes ?? post.active_votes?.length ?? 0;
+  const payout = formatPayout(post.pending_payout_value);
+
+  // NSFW warn preference: show a warning bar until the user reveals it.
+  if (isNsfw && !revealNsfw) {
+    return (
+      <li className="list-none border-b border-border px-2 py-3 min-[760px]:rounded-[6px] min-[760px]:border min-[760px]:bg-card min-[760px]:px-2 min-[760px]:py-1">
+        <div className="py-2 text-[15px] text-muted-foreground">
+          This post is <span className="font-semibold text-[#ff0264]">nsfw</span>
+          .{" "}
+          <button
+            type="button"
+            className="text-accent-foreground underline"
+            onClick={() => setRevealNsfw(true)}
+          >
+            Reveal it
+          </button>{" "}
+          or adjust your display preferences.
+        </div>
+      </li>
+    );
+  }
+
+  return (
+    <li
+      className={cn(
+        "list-none border-b border-border px-2 py-3",
+        "min-[760px]:rounded-[6px] min-[760px]:border min-[760px]:bg-card min-[760px]:px-2 min-[760px]:pb-1 min-[760px]:pt-0.5",
+        "min-[1200px]:transition-shadow min-[1200px]:hover:shadow-[2px_2px_3px_0_rgba(0,0,0,0.06)]"
+      )}
+    >
+      <div className="articles__summary">
+        {rebloggedBy.length > 0 && (
+          <div className="flex items-center gap-1 py-1 text-[13px] text-muted-foreground min-[760px]:text-[14px]">
+            <Reblog author={post.author} permlink={post.permlink} iconOnly />
+            <span>
+              <Link
+                href={`/@${rebloggedBy[0]}`}
+                className="font-semibold text-muted-foreground hover:text-accent-foreground"
+              >
+                {rebloggedBy[0]}
+              </Link>{" "}
+              resteemed
+            </span>
+          </div>
+        )}
+
+        {/* summary-header: avatar + author + rep + "in #tag ·" + time */}
+        <div className="flex items-center border-transparent py-0.5 text-[14px]">
+          <Link href={`/@${post.author}`} className="mr-2 shrink-0">
+            <Userpic account={post.author} className="!h-6 !w-6" />
+          </Link>
+          <span className="min-w-0 truncate">
+            <Link
+              href={`/@${post.author}`}
+              className="font-bold text-foreground hover:text-accent-foreground min-[760px]:text-[16px]"
+            >
+              {post.author}
+            </Link>{" "}
+            {rep !== null && <Reputation value={rep} />}{" "}
+            <span className="text-muted-foreground">
+              in{" "}
+              <Link
+                href={tagUrl}
+                className="text-muted-foreground hover:text-accent-foreground"
+              >
+                #{categoryLabel}
+              </Link>{" "}
+              •{" "}
+              {order === "payout" || order === "payout_comments" ? (
+                <TimeAgo date={post.payout_at || post.created} prefix="payout " />
+              ) : (
+                <TimeAgo date={post.created} />
+              )}
+            </span>
+            {powerUp100 && (
+              <span title="100% Steem Power payout" className="ml-1 align-middle">
+                ⚡
+              </span>
+            )}
+            {isPinned && (
+              <span className="ml-1 inline-flex items-center gap-0.5 rounded border border-accent-foreground px-1 py-px text-[11px] text-accent-foreground">
+                <Pin className="size-3" />
+                Pinned
+              </span>
+            )}
+          </span>
+        </div>
+
+        {/* content: thumbnail + title/excerpt */}
+        <div
+          className={cn(
+            "articles__content mt-1",
+            gray && "opacity-50",
+            "min-[760px]:flex min-[760px]:items-start"
+          )}
+        >
+          {thumb && (
+            <Link
+              href={postUrl}
+              className={cn(
+                "mb-2 block overflow-hidden",
+                "min-[760px]:mr-[14px] min-[760px]:mb-0 min-[760px]:inline-block min-[760px]:h-[77px] min-[760px]:w-[130px] min-[760px]:shrink-0"
+              )}
+            >
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                src={thumb}
+                alt=""
+                loading="lazy"
+                className="max-h-[220px] w-full object-cover min-[760px]:h-[77px] min-[760px]:w-[130px]"
+              />
+            </Link>
+          )}
+          <div className="min-w-0 flex-1">
+            <h2 className="articles__h2 truncate text-[15px] font-bold leading-snug">
+              {isNsfw && (
+                <span className="mr-1 rounded-[3px] border border-[#ff0264] px-[5px] py-[2px] align-middle font-[Arial] text-[75%] text-[#ff0264]">
+                  nsfw
+                </span>
+              )}
+              <Link
+                href={postUrl}
+                className="text-foreground visited:text-muted-foreground hover:text-accent-foreground"
+              >
+                {post.title || "Untitled"}
+              </Link>
+            </h2>
+            {summary && (
+              <div className="PostSummary__body truncate text-[15px] leading-[1.4] text-muted-foreground">
+                {summary}
+              </div>
+            )}
+          </div>
+        </div>
+
+        {/* footer: payout + votes + comments + reblog */}
+        <div className="articles__footer mt-1 border-t border-border">
+          <div className="articles__summary-footer flex items-center py-1 text-[15px]">
+            {payout && (
+              <span className="border-r border-border py-0.5 pr-3 font-semibold text-muted-foreground">
+                {payout}
+              </span>
+            )}
+            <span className="flex items-center gap-0.5 border-r border-border px-3 py-0.5 text-muted-foreground">
+              <ChevronUp className="size-4" aria-hidden />
+              {totalVotes}
+            </span>
+            <Link
+              href={`${postUrl}#comments`}
+              className="flex items-center gap-1 px-3 py-0.5 text-muted-foreground hover:text-accent-foreground"
+            >
+              <MessageCircle className="size-4" aria-hidden />
+              {post.children ?? 0}
+            </Link>
+            <span className="ml-auto">
+              <Reblog author={post.author} permlink={post.permlink} iconOnly />
+            </span>
+          </div>
+        </div>
+      </div>
+    </li>
+  );
+}

--- a/components/cards/PostsList.tsx
+++ b/components/cards/PostsList.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import { useEffect, useRef } from "react";
-import Link from "next/link";
+
 import { Post } from "@/lib/api/steem";
-import {
-  Card,
-  CardContent,
-  CardHeader,
-} from "@/components/ui/card";
+import PostSummary from "@/components/cards/PostSummary";
+import LoadingIndicator from "@/components/elements/LoadingIndicator";
 
 interface PostsListProps {
   posts: Post[];
@@ -17,8 +14,25 @@ interface PostsListProps {
   order?: string;
 }
 
+/** Legacy PostsIndex empty-state copy (Callout), keyed by order/category. */
+function emptyText(order?: string, category?: string): string {
+  switch (order) {
+    case "payout":
+    case "payout_comments":
+      return "No pending posts found. This view only shows posts within 12-36 hours of payout.";
+    case "muted":
+      return "No muted posts found.";
+    case "feed":
+      return "You haven't followed anyone yet! Explore Trending to find people to follow.";
+    default:
+      break;
+  }
+  if (category && category !== "my") return `No posts in #${category} yet!`;
+  return "No posts found.";
+}
+
 /**
- * Posts list with Legacy-style summary cards (border, hover shadow on md+).
+ * Posts list — legacy PostsList: summaries as <li> cards with infinite scroll.
  */
 export default function PostsList({
   posts,
@@ -62,81 +76,52 @@ export default function PostsList({
     window.addEventListener("scroll", scrollListenerRef.current, {
       passive: true,
     });
+    window.addEventListener("resize", scrollListenerRef.current, {
+      passive: true,
+    });
+    // Legacy fires the listener once on mount so short first pages
+    // auto-fetch more.
+    scrollListenerRef.current();
 
     return () => {
       if (scrollListenerRef.current) {
         window.removeEventListener("scroll", scrollListenerRef.current);
+        window.removeEventListener("resize", scrollListenerRef.current);
       }
       clearTimeout(scrollTimeout);
     };
   }, [posts.length, onLoadMore]);
 
-  const sortForTag = order?.trim() ? order : "trending";
-  void category;
-
   if (loading && posts.length === 0) {
     return (
       <div className="flex flex-col items-center justify-center gap-2 py-12">
-        <p className="text-muted-foreground">Loading posts...</p>
+        <LoadingIndicator type="circle" />
       </div>
     );
   }
 
   if (posts.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center gap-2 py-12">
-        <p className="text-muted-foreground">No posts found.</p>
+      <div className="my-8 rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
+        {emptyText(order, category)}
       </div>
     );
   }
 
   return (
-    <div id="posts_list" ref={listRef} className="flex flex-col gap-10">
-      <ul className="flex flex-col gap-10">
+    <div id="posts_list" ref={listRef}>
+      <ul className="PostsList__summaries flex flex-col gap-0 min-[760px]:gap-[0.8em]">
         {posts.map((post) => (
-          <li key={`${post.author}/${post.permlink}`} className="list-none">
-            <Card
-              className="rounded-[var(--radius)] border-transparent bg-transparent py-0 shadow-none md:border-border md:bg-card md:shadow-none md:transition-shadow md:duration-200 md:hover:shadow-[0px_5px_10px_0_rgba(0,0,0,0.03)]"
-              size="sm"
-            >
-              <CardHeader className="flex flex-col gap-1 border-0 px-0 py-2 md:border-b md:border-border md:px-4 md:py-2.5">
-                <h3 className="text-base font-semibold leading-snug text-foreground">
-                  <Link
-                    href={`/${post.category}/@${post.author}/${post.permlink}`}
-                    className="text-foreground transition-colors hover:text-accent-foreground"
-                  >
-                    {post.title || "Untitled"}
-                  </Link>
-                </h3>
-              </CardHeader>
-              <CardContent className="px-0 py-1 text-sm md:px-4">
-                <p className="text-muted-foreground">
-                  by{" "}
-                  <Link
-                    href={`/@${post.author}`}
-                    className="text-foreground hover:text-accent-foreground"
-                  >
-                    @{post.author}
-                  </Link>{" "}
-                  in{" "}
-                  <Link
-                    href={`/${sortForTag}/${post.category}`}
-                    className="text-foreground hover:text-accent-foreground"
-                  >
-                    #{post.category}
-                  </Link>
-                </p>
-                <p className="mt-1 text-xs text-muted-foreground">
-                  {new Date(post.created).toLocaleString()}
-                </p>
-              </CardContent>
-            </Card>
-          </li>
+          <PostSummary
+            key={`${post.author}/${post.permlink}`}
+            post={post}
+            order={order}
+          />
         ))}
       </ul>
       {loading && posts.length > 0 ? (
         <div className="flex flex-col items-center justify-center gap-2 py-4">
-          <p className="text-muted-foreground">Loading more...</p>
+          <LoadingIndicator type="circle" />
         </div>
       ) : null}
     </div>

--- a/components/cards/UserProfileHeader.tsx
+++ b/components/cards/UserProfileHeader.tsx
@@ -1,6 +1,12 @@
 'use client';
 
 import Link from 'next/link';
+import { Calendar, Link2, MapPin } from 'lucide-react';
+
+import { proxifyImageUrl } from '@/lib/media/proxify-url';
+import Userpic from '@/components/elements/Userpic';
+import Follow from '@/components/elements/Follow';
+import TimeAgo from '@/components/elements/TimeAgo';
 
 interface UserProfileHeaderProps {
   accountname: string;
@@ -11,23 +17,30 @@ interface UserProfileHeaderProps {
     website?: string;
     profile_image?: string;
     cover_image?: string;
-    [key: string]: any;
+    [key: string]: unknown;
   } | null;
   currentUser?: string;
   stats?: {
     rank: number;
     following: number;
     followers: number;
+    sp?: number;
   };
   reputation?: string;
   postCount?: number;
   created?: string;
+  /** Last account activity (bridge `active`), for "Active x ago". */
+  active?: string;
+  blacklists?: string[];
 }
 
+const numberWithCommas = (x: number): string =>
+  String(x).replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+
 /**
- * UserProfileHeader component
- * Displays user profile information header
- * Migrated from legacy/src/app/components/cards/UserProfileHeader.jsx
+ * UserProfileHeader — legacy full-bleed banner: cover image background,
+ * white text with shadow, centered, stats with divider links.
+ * (cards/UserProfileHeader.jsx + pages/UserProfile.scss)
  */
 export default function UserProfileHeader({
   accountname,
@@ -37,147 +50,142 @@ export default function UserProfileHeader({
   reputation,
   postCount,
   created,
+  active,
+  blacklists = [],
 }: UserProfileHeaderProps) {
-  const isMyAccount = currentUser === accountname;
   const displayName = profile?.name || accountname;
 
-  // Helper function to format reputation
-  const formatReputation = (rep?: string) => {
-    if (!rep) return '25';
-    const repNum = parseInt(rep);
-    if (repNum === 0) return '25';
-    const score = Math.log10(Math.abs(repNum)) - 9;
-    return Math.max(score * 9 + 25, 1).toFixed(0);
-  };
+  const coverImage = profile?.cover_image;
+  const coverStyle: React.CSSProperties = coverImage
+    ? { backgroundImage: `url(${proxifyImageUrl(coverImage, '2048x512')})` }
+    : {};
 
-  // Helper function to format date
-  const formatJoinDate = (dateStr?: string) => {
-    if (!dateStr) return '';
-    const date = new Date(dateStr);
-    return date.toLocaleDateString('en-US', { 
-      year: 'numeric', 
-      month: 'long' 
-    });
-  };
+  const websiteLabel = profile?.website
+    ? profile.website.replace(/^https?:\/\/(www\.)?/, '').replace(/\/$/, '')
+    : null;
+
+  const joinDate = created
+    ? new Date(created).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'long',
+      })
+    : null;
+
+  const rep =
+    reputation && !Number.isNaN(Number(reputation))
+      ? Math.floor(Number(reputation))
+      : null;
 
   return (
-    <div className="user-profile-header mb-8">
-      {/* Cover image */}
-      {profile?.cover_image && (
-        <div
-          className="h-48 bg-cover bg-center rounded-t-lg"
-          style={{ backgroundImage: `url(${profile.cover_image})` }}
-        />
-      )}
+    <div className="UserProfile__banner mb-4 text-center text-white [&_a]:text-white">
+      <div
+        className="bg-[#1C252B] bg-cover bg-center bg-no-repeat px-4 pb-4 [text-shadow:1px_1px_2px_black]"
+        style={{ ...coverStyle, minHeight: 155 }}
+      >
+        <div className="relative">
+          {/* desktop follow button (legacy .UserProfile__buttons) */}
+          <div className="absolute right-[5px] top-[15px] hidden min-[640px]:block [&_button]:!bg-white [&_button]:!text-black">
+            <Follow follower={currentUser} following={accountname} />
+          </div>
+        </div>
 
-      <div className="bg-white border border-gray-200 rounded-lg p-6">
-        <div className="flex items-start gap-6">
-          {/* Profile image */}
-          <div className="shrink-0">
-            {profile?.profile_image ? (
-              <img
-                src={profile.profile_image}
-                alt={displayName}
-                className="w-24 h-24 rounded-full border-4 border-white shadow-lg"
-              />
-            ) : (
-              <div className="w-24 h-24 rounded-full bg-gray-200 flex items-center justify-center text-2xl font-bold text-gray-400">
-                {accountname.charAt(0).toUpperCase()}
-              </div>
+        <h1 className="pt-[15px] text-[1.13095rem] font-semibold min-[640px]:text-[1.84524rem]">
+          <Userpic
+            account={accountname}
+            className="!mr-2 !inline-block !size-9 align-middle min-[640px]:!size-12"
+          />
+          {displayName}{' '}
+          {rep !== null && (
+            <span
+              className="UserProfile__rep text-[80%] font-extralight"
+              title={`This is ${accountname}'s reputation score. It is based on the history of votes.`}
+            >
+              ({rep})
+            </span>
+          )}
+          {blacklists.length > 0 && (
+            <span
+              className="account_warn ml-1 font-bold text-[#ff4d4f]"
+              title={`Blacklisted on: ${blacklists.join(', ')}`}
+            >
+              ({blacklists.length})
+            </span>
+          )}
+        </h1>
+
+        <div>
+          {profile?.about && (
+            <p className="UserProfile__bio mx-auto mb-2 mt-[-0.4rem] max-w-[420px] text-[95%] leading-[1.4]">
+              {profile.about}
+            </p>
+          )}
+
+          <div className="UserProfile__stats mb-[5px] pb-[5px] text-[90%]">
+            <span className="px-2.5">
+              <Link href={`/@${accountname}/followers`}>
+                <strong>{stats?.followers ?? 0}</strong> followers
+              </Link>
+            </span>
+            <span className="border-l border-[#ccc] px-2.5">
+              <Link href={`/@${accountname}`}>
+                <strong>{postCount ?? 0}</strong> posts
+              </Link>
+            </span>
+            <span className="border-l border-[#ccc] px-2.5">
+              <Link href={`/@${accountname}/followed`}>
+                <strong>{stats?.following ?? 0}</strong> following
+              </Link>
+            </span>
+            {typeof stats?.sp === 'number' && stats.sp > 0 && (
+              <span className="border-l border-[#ccc] px-2.5">
+                {numberWithCommas(Math.round(stats.sp))} SP
+              </span>
+            )}
+            {typeof stats?.rank === 'number' && stats.rank > 0 && (
+              <span className="border-l border-[#ccc] px-2.5">
+                #{numberWithCommas(stats.rank)}
+              </span>
             )}
           </div>
 
-          {/* Profile info */}
-          <div className="flex-1">
-            <h1 className="text-3xl font-bold mb-2">
-              {displayName}
-            </h1>
-            <p className="text-gray-600 mb-4">@{accountname}</p>
-
-            {profile?.about && (
-              <p className="text-gray-700 mb-4">{profile.about}</p>
+          <p className="UserProfile__info flex flex-wrap items-center justify-center gap-x-4 gap-y-1 text-[90%]">
+            {profile?.location && (
+              <span className="inline-flex items-center gap-1">
+                <MapPin className="size-4" aria-hidden /> {profile.location}
+              </span>
             )}
-
-            {/* Stats */}
-            <div className="flex flex-wrap gap-6 text-sm text-gray-600 mb-4">
-              {stats && (
-                <>
-                  <span>
-                    <strong className="text-gray-900">{stats.followers}</strong> followers
-                  </span>
-                  <span>
-                    <strong className="text-gray-900">{stats.following}</strong> following
-                  </span>
-                </>
-              )}
-              {postCount !== undefined && (
-                <span>
-                  <strong className="text-gray-900">{postCount}</strong> posts
-                </span>
-              )}
-              {reputation && (
-                <span>
-                  Reputation: <strong className="text-gray-900">{formatReputation(reputation)}</strong>
-                </span>
-              )}
-            </div>
-
-            {/* Location, website, join date */}
-            <div className="flex flex-wrap gap-4 text-sm text-gray-600 mb-4">
-              {profile?.location && (
-                <span className="flex items-center gap-1">
-                  📍 {profile.location}
-                </span>
-              )}
-              {profile?.website && (
+            {profile?.website && websiteLabel && (
+              <span className="inline-flex items-center gap-1">
+                <Link2 className="size-4" aria-hidden />{' '}
                 <a
                   href={profile.website}
                   target="_blank"
                   rel="noopener noreferrer"
-                  className="text-blue-600 hover:underline"
+                  className="underline"
                 >
-                  🔗 Website
+                  {websiteLabel}
                 </a>
-              )}
-              {created && (
-                <span className="flex items-center gap-1">
-                  📅 Joined {formatJoinDate(created)}
-                </span>
-              )}
-            </div>
+              </span>
+            )}
+            {joinDate && (
+              <span className="inline-flex items-center gap-1">
+                <Calendar className="size-4" aria-hidden /> Joined {joinDate}
+              </span>
+            )}
+            {active && (
+              <span className="inline-flex items-center gap-1">
+                <Calendar className="size-4" aria-hidden /> Active{' '}
+                <TimeAgo date={active} />
+              </span>
+            )}
+          </p>
+        </div>
 
-            {/* Action buttons */}
-            <div className="mt-4 flex gap-2">
-              {isMyAccount ? (
-                <>
-                  <Link
-                    href={`/@${accountname}/settings`}
-                    className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
-                  >
-                    Edit Profile
-                  </Link>
-                  <Link
-                    href="/submit"
-                    className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors"
-                  >
-                    New Post
-                  </Link>
-                </>
-              ) : (
-                <>
-                  <button className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors">
-                    Follow
-                  </button>
-                  <button className="px-4 py-2 bg-gray-200 text-gray-700 rounded-lg hover:bg-gray-300 transition-colors">
-                    Message
-                  </button>
-                </>
-              )}
-            </div>
-          </div>
+        {/* mobile follow button (legacy .UserProfile__buttons_mobile) */}
+        <div className="UserProfile__buttons_mobile mt-2 min-[640px]:hidden [&_button]:!bg-white [&_button]:!text-black">
+          <Follow follower={currentUser} following={accountname} />
         </div>
       </div>
     </div>
   );
 }
-

--- a/components/elements/LoadingIndicator.tsx
+++ b/components/elements/LoadingIndicator.tsx
@@ -22,9 +22,9 @@ export default function LoadingIndicator({
     case 'dots':
       return (
         <div style={style} className="flex items-center justify-center gap-1">
-          <div className="w-2 h-2 bg-blue-600 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-          <div className="w-2 h-2 bg-blue-600 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-          <div className="w-2 h-2 bg-blue-600 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+          <div className="w-2 h-2 bg-[#06D6A9] rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+          <div className="w-2 h-2 bg-[#06D6A9] rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+          <div className="w-2 h-2 bg-[#06D6A9] rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
         </div>
       );
 
@@ -35,7 +35,7 @@ export default function LoadingIndicator({
           className={`flex items-center justify-center ${inline ? 'inline-block' : ''}`}
         >
           <svg
-            className="animate-spin h-5 w-5 text-blue-600"
+            className="animate-spin h-5 w-5 text-[#06D6A9]"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -62,7 +62,7 @@ export default function LoadingIndicator({
       return (
         <div style={style} className="flex items-center justify-center">
           <svg
-            className="animate-spin h-6 w-6 text-blue-600"
+            className="animate-spin h-6 w-6 text-[#06D6A9]"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"
@@ -89,9 +89,9 @@ export default function LoadingIndicator({
       return (
         <div style={style} className="flex items-center justify-center">
           <div className="flex items-center gap-1">
-            <div className="w-2 h-2 bg-blue-600 rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
-            <div className="w-2 h-2 bg-blue-600 rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
-            <div className="w-2 h-2 bg-blue-600 rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
+            <div className="w-2 h-2 bg-[#06D6A9] rounded-full animate-bounce" style={{ animationDelay: '0ms' }} />
+            <div className="w-2 h-2 bg-[#06D6A9] rounded-full animate-bounce" style={{ animationDelay: '150ms' }} />
+            <div className="w-2 h-2 bg-[#06D6A9] rounded-full animate-bounce" style={{ animationDelay: '300ms' }} />
           </div>
         </div>
       );

--- a/components/elements/PostEditor.tsx
+++ b/components/elements/PostEditor.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 
 interface PostEditorProps {
   type: 'submit_story' | 'submit_comment' | 'edit';
@@ -75,8 +75,11 @@ export default function PostEditor({
       setError('Body is required');
       return;
     }
-    if (isStory && !category.trim()) {
-      setError('Category is required');
+    // Category = first tag (legacy ReplyEditor), unless a community
+    // category was forced by the caller.
+    const cat = (initialCategory || tags[0] || '').trim();
+    if (isStory && !cat) {
+      setError('At least one tag is required (the first tag is the category)');
       return;
     }
 
@@ -94,10 +97,10 @@ export default function PostEditor({
         author: 'testuser', // TODO: Get from authenticated user
         title: title.trim(),
         body: body.trim(),
-        category: category.trim(),
-        tags: tags.length > 0 ? tags : [category.trim()],
+        category: cat,
+        tags: tags.length > 0 ? tags : [cat],
         json_metadata: {
-          tags: tags.length > 0 ? tags : [category.trim()],
+          tags: tags.length > 0 ? tags : [cat],
           app: 'condenser/0.1',
           format: 'markdown',
         },
@@ -127,7 +130,7 @@ export default function PostEditor({
       }
 
       if (onSuccess) {
-        onSuccess(category, result.permlink);
+        onSuccess(cat, result.permlink);
       }
     } catch (err) {
       console.error('Error submitting post:', err);
@@ -163,63 +166,37 @@ export default function PostEditor({
       )}
 
       {isStory && (
-        <>
-          <div>
-            <label htmlFor="title" className="block text-sm font-medium text-gray-700 mb-2">
-              Title *
-            </label>
-            <input
-              id="title"
-              type="text"
-              value={title}
-              onChange={(e) => setTitle(e.target.value)}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              placeholder="Enter post title"
-              maxLength={255}
-              required
-            />
-          </div>
-
-          <div>
-            <label htmlFor="category" className="block text-sm font-medium text-gray-700 mb-2">
-              Category *
-            </label>
-            <input
-              id="category"
-              type="text"
-              value={category}
-              onChange={(e) => setCategory(e.target.value.toLowerCase().replace(/\s+/g, '-'))}
-              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-              placeholder="Enter category (e.g., technology, art)"
-              required
-            />
-          </div>
-        </>
+        <div>
+          <input
+            id="title"
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            className="w-full rounded-none border-0 border-b border-gray-300 px-2 py-2 text-[1rem] font-bold focus:border-gray-500 focus:outline-none"
+            placeholder="Title"
+            maxLength={255}
+            required
+          />
+        </div>
       )}
 
       <div>
-        <label htmlFor="body" className="block text-sm font-medium text-gray-700 mb-2">
-          Content *
-        </label>
         <textarea
           id="body"
           value={body}
           onChange={(e) => setBody(e.target.value)}
           rows={15}
           className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent font-mono text-sm"
-          placeholder="Write your post content here (Markdown supported)"
+          placeholder="Write your story..."
           required
         />
-        <p className="mt-2 text-sm text-gray-500">
+        <p className="mt-1 border-l border-[#ccc] bg-[#fafafa] px-2 py-[3px] text-[85%] text-[#767676]">
           Markdown is supported. Use **bold**, *italic*, [links](url), etc.
         </p>
       </div>
 
       {isStory && (
         <div>
-          <label htmlFor="tags" className="block text-sm font-medium text-gray-700 mb-2">
-            Tags (up to 5)
-          </label>
           <div className="flex flex-wrap gap-2 mb-2">
             {tags.map((tag) => (
               <span
@@ -242,7 +219,7 @@ export default function PostEditor({
             type="text"
             onKeyDown={handleTagInput}
             className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            placeholder="Add tags (press Enter or comma to add, max 5)"
+            placeholder="Add up to 5 tags (the first tag is the category)"
             disabled={tags.length >= 5}
           />
         </div>
@@ -254,9 +231,9 @@ export default function PostEditor({
           disabled={submitting}
           className="px-6 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
         >
-          {submitting ? 'Submitting...' : isStory ? 'Publish Post' : 'Submit'}
+          {submitting ? 'Submitting...' : isStory ? 'Post' : 'Submit'}
         </button>
-        
+
         {onCancel && (
           <button
             type="button"
@@ -266,6 +243,21 @@ export default function PostEditor({
             Cancel
           </button>
         )}
+
+        <button
+          type="button"
+          onClick={() => {
+            setTitle('');
+            setBody('');
+            setTags([]);
+            if (typeof window !== 'undefined') {
+              localStorage.removeItem(`replyEditorData-${formId}`);
+            }
+          }}
+          className="px-6 py-2 text-gray-700 hover:text-black transition-colors"
+        >
+          Clear
+        </button>
 
         <span className="text-sm text-gray-500 ml-auto">
           Draft saved automatically

--- a/components/elements/Reblog.tsx
+++ b/components/elements/Reblog.tsx
@@ -8,6 +8,8 @@ import { broadcastOperation } from '@/store/slices/transactionSlice';
 interface ReblogProps {
   author: string;
   permlink: string;
+  /** Icon-only rendering (legacy feed-card / post-footer style). */
+  iconOnly?: boolean;
 }
 
 /**
@@ -15,7 +17,7 @@ interface ReblogProps {
  * Allows users to reblog (repost) posts to their own blog
  * Migrated from legacy/src/app/components/elements/Reblog.jsx
  */
-export default function Reblog({ author, permlink }: ReblogProps) {
+export default function Reblog({ author, permlink, iconOnly = false }: ReblogProps) {
   const dispatch = useAppDispatch();
   const username = useAppSelector((state) => state.user.current?.username);
 
@@ -71,6 +73,38 @@ export default function Reblog({ author, permlink }: ReblogProps) {
       })
     );
   };
+
+  // Legacy icon-only style: gray reblog icon, teal when active, spinner while
+  // broadcasting (Reblog.scss).
+  if (iconOnly) {
+    return (
+      <button
+        onClick={handleReblog}
+        disabled={loading || active}
+        className={`inline-flex items-center p-0.5 transition-colors ${
+          loading ? 'opacity-50 cursor-not-allowed' : ''
+        }`}
+        title={active ? 'Already reblogged' : 'Reblog this post'}
+        aria-label={active ? 'Already reblogged' : 'Reblog this post'}
+      >
+        {loading ? (
+          <svg
+            className="h-4 w-4 animate-spin rounded-full border-2 border-[#06D6A9] border-t-transparent"
+            viewBox="0 0 24 24"
+          />
+        ) : (
+          <svg
+            className={`h-4 w-4 ${active ? 'text-[#06D6A9]' : 'text-[#cacaca] hover:text-[#06D6A9]'}`}
+            viewBox="0 0 24 24"
+            fill="currentColor"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <path d="M8 7h12m0 0l-4-4m4 4l-4 4m0 6H4m0 0l4 4m-4-4l4-4" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round" fill="none" />
+          </svg>
+        )}
+      </button>
+    );
+  }
 
   return (
     <button

--- a/components/elements/Reputation.tsx
+++ b/components/elements/Reputation.tsx
@@ -1,0 +1,15 @@
+/**
+ * Reputation — "(73)" style reputation number after an author name.
+ * Ported from legacy src/app/components/elements/Reputation.jsx.
+ */
+export default function Reputation({ value }: { value: number }) {
+  if (Number.isNaN(value)) {
+    console.log('Unexpected rep value:', value);
+    return null;
+  }
+  return (
+    <span className="Reputation" title="Reputation">
+      ({Math.floor(value)})
+    </span>
+  );
+}

--- a/components/elements/ShareMenu.tsx
+++ b/components/elements/ShareMenu.tsx
@@ -1,7 +1,16 @@
 'use client';
 
-import { useState } from 'react';
-import Link from 'next/link';
+import { Facebook, Linkedin, Twitter } from 'lucide-react';
+
+/** Legacy reddit icon (assets/icons/reddit.svg). */
+function RedditIcon({ className }: { className?: string }) {
+  return (
+    <svg viewBox="0 0 60 60" className={className} aria-hidden>
+      <circle cx="30.0074534" cy="30.0074534" r="29.9850932" />
+      <path d="M50.0049689,30.0074534 C49.915528,27.5925466 47.8881988,25.7068323 45.4658385,25.7888199 C44.3925466,25.826087 43.3714286,26.2658385 42.5962733,27.0037267 C39.1826087,24.6782609 35.1726708,23.4037267 31.0509317,23.3142857 L32.9962733,13.9602484 L39.4136646,15.3093168 C39.5925466,16.9565217 41.068323,18.1490683 42.715528,17.9701863 C44.3627329,17.7913043 45.5552795,16.315528 45.3763975,14.668323 C45.1975155,13.021118 43.7217391,11.8285714 42.0745342,12.0074534 C41.1279503,12.1043478 40.2782609,12.6559006 39.8086957,13.4757764 L32.4596273,12.0074534 C31.9602484,11.8956522 31.4608696,12.2086957 31.3490683,12.715528 C31.3490683,12.7229814 31.3490683,12.7229814 31.3490683,12.7304348 L29.1354037,23.1354037 C24.9614907,23.2024845 20.8993789,24.484472 17.4409938,26.8248447 C15.6819876,25.1701863 12.9093168,25.2521739 11.2546584,27.0186335 C9.6,28.7776398 9.68198758,31.5503106 11.4484472,33.2049689 C11.7913043,33.5254658 12.1863354,33.8012422 12.626087,33.9950311 C12.5962733,34.4347826 12.5962733,34.8745342 12.626087,35.3142857 C12.626087,42.0298137 20.4521739,47.4931677 30.1043478,47.4931677 C39.7565217,47.4931677 47.5826087,42.0372671 47.5826087,35.3142857 C47.6124224,34.8745342 47.6124224,34.4347826 47.5826087,33.9950311 C49.0881988,33.242236 50.0347826,31.6919255 50.0049689,30.0074534 Z M20.0198758,33.0111801 C20.0198758,31.3565217 21.3689441,30.0074534 23.0236025,30.0074534 C24.6782609,30.0074534 26.0273292,31.3565217 26.0273292,33.0111801 C26.0273292,34.6658385 24.6782609,36.0149068 23.0236025,36.0149068 C21.3614907,36 20.0198758,34.6658385 20.0198758,33.0111801 Z M34.1813665,33.0111801 C34.1813665,31.3565217 35.5304348,30.0074534 37.1850932,30.0074534 C38.8397516,30.0074534 40.1888199,31.3565217 40.1888199,33.0111801 C40.1888199,34.6658385 38.8397516,36.0149068 37.1850932,36.0149068 C35.5229814,36 34.1813665,34.6658385 34.1813665,33.0111801 Z M30.0298137,43.5652174 C27.3614907,43.6770186 24.752795,42.8571429 22.621118,41.2546584 C22.3378882,40.9118012 22.3900621,40.3975155 22.7329193,40.1142857 C23.0310559,39.868323 23.4559006,39.868323 23.7614907,40.1142857 C25.5652174,41.4335404 27.7639752,42.1043478 30,42 C32.2360248,42.1192547 34.442236,41.4782609 36.268323,40.173913 C36.5962733,39.8534161 37.1329193,39.8608696 37.4534161,40.1888199 C37.773913,40.5167702 37.7664596,41.0534161 37.4385093,41.373913 C35.3068323,42.9763975 32.6981366,43.6770186 30.0298137,43.5652174 Z" />
+    </svg>
+  );
+}
 
 interface ShareMenuProps {
   url: string;
@@ -10,85 +19,80 @@ interface ShareMenuProps {
 }
 
 /**
- * ShareMenu component
- * Provides sharing options for posts (Facebook, Twitter, Reddit, LinkedIn)
- * Migrated from legacy/src/app/components/elements/ShareMenu.jsx
+ * ShareMenu — legacy inline social icon row (ShareMenu.scss): four SVG
+ * icons side by side, each opening the share dialog in a popup window.
  */
-export default function ShareMenu({ url, title, description }: ShareMenuProps) {
-  const [isOpen, setIsOpen] = useState(false);
+export default function ShareMenu({ url, title }: ShareMenuProps) {
+  const fullUrl =
+    typeof window !== 'undefined' ? `${window.location.origin}${url}` : url;
 
-  const fullUrl = typeof window !== 'undefined' 
-    ? `${window.location.origin}${url}`
-    : url;
-
-  const shareLinks = {
-    facebook: `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(fullUrl)}`,
-    twitter: `https://twitter.com/share?text=${encodeURIComponent(title)}&url=${encodeURIComponent(fullUrl)}`,
-    reddit: `https://www.reddit.com/submit?title=${encodeURIComponent(title)}&url=${encodeURIComponent(fullUrl)}`,
-    linkedin: `https://www.linkedin.com/shareArticle?title=${encodeURIComponent(title)}&url=${encodeURIComponent(fullUrl)}&source=Steemit&mini=true`,
-  };
-
-  const handleShare = (platform: keyof typeof shareLinks) => {
-    const shareUrl = shareLinks[platform];
-    const width = 600;
-    const height = 400;
+  const open = (shareUrl: string, width: number, height: number) => {
     const left = (screen.width - width) / 2;
     const top = (screen.height - height) / 2;
-
     window.open(
       shareUrl,
       'Share',
       `width=${width},height=${height},left=${left},top=${top},toolbar=0,status=0`
     );
-    setIsOpen(false);
   };
 
-  return (
-    <div className="relative">
-      <button
-        onClick={() => setIsOpen(!isOpen)}
-        className="px-3 py-1 rounded bg-gray-100 text-gray-700 hover:bg-gray-200 transition-colors"
-      >
-        Share
-      </button>
+  const items = [
+    {
+      name: 'Facebook',
+      icon: Facebook,
+      onClick: () =>
+        open(
+          `https://www.facebook.com/sharer/sharer.php?u=${encodeURIComponent(fullUrl)}`,
+          600,
+          400
+        ),
+    },
+    {
+      name: 'Twitter',
+      icon: Twitter,
+      onClick: () =>
+        open(
+          `https://twitter.com/share?text=${encodeURIComponent(title)}&url=${encodeURIComponent(fullUrl)}`,
+          640,
+          320
+        ),
+    },
+    {
+      name: 'LinkedIn',
+      icon: Linkedin,
+      onClick: () =>
+        open(
+          `https://www.linkedin.com/shareArticle?title=${encodeURIComponent(title)}&url=${encodeURIComponent(fullUrl)}&source=Steemit&mini=true`,
+          720,
+          480
+        ),
+    },
+    {
+      name: 'Reddit',
+      icon: RedditIcon,
+      onClick: () =>
+        open(
+          `https://www.reddit.com/submit?title=${encodeURIComponent(title)}&url=${encodeURIComponent(fullUrl)}`,
+          600,
+          400
+        ),
+    },
+  ];
 
-      {isOpen && (
-        <>
-          <div
-            className="fixed inset-0 z-10"
-            onClick={() => setIsOpen(false)}
-          />
-          <div className="absolute right-0 mt-2 w-48 bg-white rounded-md shadow-lg z-20 border border-gray-200">
-            <div className="py-1">
-              <button
-                onClick={() => handleShare('facebook')}
-                className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-              >
-                Facebook
-              </button>
-              <button
-                onClick={() => handleShare('twitter')}
-                className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-              >
-                Twitter
-              </button>
-              <button
-                onClick={() => handleShare('reddit')}
-                className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-              >
-                Reddit
-              </button>
-              <button
-                onClick={() => handleShare('linkedin')}
-                className="block w-full text-left px-4 py-2 text-sm text-gray-700 hover:bg-gray-100"
-              >
-                LinkedIn
-              </button>
-            </div>
-          </div>
-        </>
-      )}
-    </div>
+  return (
+    <span className="shareMenu inline-block h-[2em]">
+      {items.map((item) => (
+        <button
+          key={item.name}
+          type="button"
+          onClick={item.onClick}
+          title={`Share on ${item.name}`}
+          aria-label={`Share on ${item.name}`}
+          className="p-[2px] text-muted-foreground transition-colors hover:text-accent-foreground"
+        >
+          <item.icon className="size-5 fill-current" aria-hidden />
+        </button>
+      ))}
+    </span>
   );
 }
-

--- a/components/elements/SubscribeButton.tsx
+++ b/components/elements/SubscribeButton.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { showLogin } from '@/store/slices/userSlice';
+import { broadcastOperation } from '@/store/slices/transactionSlice';
+import LoadingIndicator from '@/components/elements/LoadingIndicator';
+
+interface SubscribeButtonProps {
+  community: string;
+  /** Current subscription state (from bridge community context). */
+  subscribed?: boolean;
+}
+
+/**
+ * SubscribeButton — legacy community subscribe toggle (SubscribeButton.jsx).
+ * Text: Subscribe → Joined (hover: Leave); hollow style when subscribed.
+ */
+export default function SubscribeButton({
+  community,
+  subscribed = false,
+}: SubscribeButtonProps) {
+  const dispatch = useAppDispatch();
+  const username = useAppSelector((s) => s.user.current?.username);
+  const [loading, setLoading] = useState(false);
+  const [isHovered, setIsHovered] = useState(false);
+  const [isSubscribed, setIsSubscribed] = useState(subscribed);
+
+  const onClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    if (!username) {
+      dispatch(showLogin({}));
+      return;
+    }
+    if (loading) return;
+    setLoading(true);
+
+    const json = [
+      isSubscribed ? 'unsubscribe' : 'subscribe',
+      { community },
+    ];
+
+    dispatch(
+      broadcastOperation({
+        type: 'custom_json',
+        confirm: isSubscribed
+          ? `Unsubscribe from ${community}?`
+          : `Subscribe to ${community}?`,
+        operation: {
+          id: 'community',
+          required_posting_auths: [username],
+          json: JSON.stringify(json),
+        },
+        successCallback: () => {
+          setIsSubscribed(!isSubscribed);
+          setLoading(false);
+        },
+        errorCallback: () => {
+          setLoading(false);
+        },
+      })
+    );
+  };
+
+  const buttonText = isHovered
+    ? isSubscribed
+      ? 'Leave'
+      : 'Subscribe'
+    : isSubscribed
+      ? 'Joined'
+      : 'Subscribe';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onMouseEnter={() => setIsHovered(true)}
+      onMouseLeave={() => setIsHovered(false)}
+      disabled={loading}
+      className={`rounded-[3px] border border-[#06D6A9] px-4 py-1.5 text-sm font-bold transition-colors ${
+        isSubscribed
+          ? 'bg-transparent text-[#06D6A9] hover:bg-[#06D6A9] hover:text-white'
+          : 'bg-[#06D6A9] text-white hover:opacity-90'
+      } disabled:opacity-50`}
+    >
+      {loading ? <LoadingIndicator type="dots" /> : buttonText}
+    </button>
+  );
+}

--- a/components/elements/TagList.tsx
+++ b/components/elements/TagList.tsx
@@ -8,39 +8,27 @@ interface TagListProps {
 }
 
 /**
- * TagList component
- * Displays tags for a post
+ * TagList — legacy horizontal tag pills (TagList.scss): neutral gray chips,
+ * the post's own category is excluded from the list.
  */
 export default function TagList({ tags, category }: TagListProps) {
-  if (!tags || tags.length === 0) {
-    if (!category) return null;
-    return (
-      <div className="flex flex-wrap gap-2">
-        <Link
-          href={`/${category}`}
-          className="px-2 py-1 text-xs bg-blue-100 text-blue-700 rounded hover:bg-blue-200"
-        >
-          #{category}
-        </Link>
-      </div>
-    );
-  }
+  const list = (tags || [])
+    .map((t) => (t.startsWith('#') ? t.substring(1) : t))
+    .filter((t) => t && t !== category);
+
+  if (list.length === 0) return null;
 
   return (
-    <div className="flex flex-wrap gap-2">
-      {tags.map((tag, index) => {
-        const tagName = tag.startsWith('#') ? tag.substring(1) : tag;
-        return (
-          <Link
-            key={index}
-            href={`/${tagName}`}
-            className="px-2 py-1 text-xs bg-blue-100 text-blue-700 rounded hover:bg-blue-200"
-          >
-            #{tagName}
-          </Link>
-        );
-      })}
+    <div className="TagList__horizontal mx-auto mb-2 max-w-[40rem]">
+      {list.map((tag) => (
+        <Link
+          key={tag}
+          href={`/trending/${tag}`}
+          className="m-[0.1rem_0.4rem_0.1rem_0] inline-block rounded-[0.3rem] border border-border bg-background px-[0.3rem] py-[0.1rem] text-[95%] text-foreground transition-all hover:border-[#788187] hover:text-foreground"
+        >
+          #{tag}
+        </Link>
+      ))}
     </div>
   );
 }
-

--- a/components/elements/TimeAgo.tsx
+++ b/components/elements/TimeAgo.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+/**
+ * TimeAgo — relative timestamp like legacy's TimeAgoWrapper
+ * ("3 hours ago"), with the absolute date in the title tooltip.
+ * Re-renders every minute to stay fresh.
+ */
+
+const MINUTE = 60;
+const HOUR = 3600;
+const DAY = 86400;
+const WEEK = 604800;
+
+export function timeAgo(date: Date, now: number = Date.now()): string {
+  const seconds = Math.max(0, Math.floor((now - date.getTime()) / 1000));
+  if (seconds < 45) return 'just now';
+  const minutes = Math.floor(seconds / MINUTE);
+  if (minutes < 45) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  const hours = Math.floor(seconds / HOUR);
+  if (hours < 22) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  const days = Math.floor(seconds / DAY);
+  if (days < 7) return `${days} day${days === 1 ? '' : 's'} ago`;
+  const weeks = Math.floor(seconds / WEEK);
+  if (weeks < 4) return `${weeks} week${weeks === 1 ? '' : 's'} ago`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months} month${months === 1 ? '' : 's'} ago`;
+  const years = Math.floor(days / 365);
+  return `${years} year${years === 1 ? '' : 's'} ago`;
+}
+
+interface TimeAgoProps {
+  /** ISO date string (chain timestamps are UTC, e.g. "2024-01-01T12:00:00"). */
+  date: string;
+  className?: string;
+  /** Optional prefix (legacy shows "payout " before payout times). */
+  prefix?: string;
+}
+
+export default function TimeAgo({ date, className, prefix }: TimeAgoProps) {
+  // Chain timestamps have no timezone suffix; they are UTC.
+  const d = new Date(date.endsWith('Z') || /[+-]\d{2}:?\d{2}$/.test(date) ? date : date + 'Z');
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const id = setInterval(() => setTick((t) => t + 1), 60_000);
+    return () => clearInterval(id);
+  }, []);
+
+  return (
+    <span className={className} title={d.toLocaleString()}>
+      {prefix}
+      {timeAgo(d)}
+    </span>
+  );
+}

--- a/components/elements/Userpic.tsx
+++ b/components/elements/Userpic.tsx
@@ -1,0 +1,34 @@
+/**
+ * Userpic — account avatar via the image proxy, as a background-image div.
+ * Ported from legacy src/app/components/elements/Userpic.jsx.
+ * Size variants map to the proxy's avatar sizes: '' / '/small' / '/medium' / '/large'.
+ */
+
+import { imageProxy } from '@/lib/media/proxify-url';
+
+export const SIZE_SMALL = 'small';
+export const SIZE_MED = 'medium';
+export const SIZE_LARGE = 'large';
+
+const sizeList = [SIZE_SMALL, SIZE_MED, SIZE_LARGE] as const;
+
+interface UserpicProps {
+  account: string;
+  size?: string;
+  hide?: boolean;
+}
+
+export default function Userpic({ account, size, hide = false }: UserpicProps) {
+  if (hide) return null;
+  const name = account === 'steemitblog' ? 'steemitdev' : account;
+  const sizeSuffix = size && (sizeList as readonly string[]).includes(size) ? `/${size}` : '';
+  const url = `${imageProxy()}u/${name}/avatar${sizeSuffix}`;
+  return (
+    <div
+      className="Userpic"
+      style={{ backgroundImage: `url(${url})` }}
+      role="img"
+      aria-label={name}
+    />
+  );
+}

--- a/components/elements/Userpic.tsx
+++ b/components/elements/Userpic.tsx
@@ -16,16 +16,18 @@ interface UserpicProps {
   account: string;
   size?: string;
   hide?: boolean;
+  /** Extra classes, e.g. size overrides ("!h-6 !w-6"). */
+  className?: string;
 }
 
-export default function Userpic({ account, size, hide = false }: UserpicProps) {
+export default function Userpic({ account, size, hide = false, className }: UserpicProps) {
   if (hide) return null;
   const name = account === 'steemitblog' ? 'steemitdev' : account;
   const sizeSuffix = size && (sizeList as readonly string[]).includes(size) ? `/${size}` : '';
   const url = `${imageProxy()}u/${name}/avatar${sizeSuffix}`;
   return (
     <div
-      className="Userpic"
+      className={className ? `Userpic ${className}` : 'Userpic'}
       style={{ backgroundImage: `url(${url})` }}
       role="img"
       aria-label={name}

--- a/components/elements/Voting.tsx
+++ b/components/elements/Voting.tsx
@@ -1,11 +1,17 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useRef } from 'react';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import { showLogin } from '@/store/slices/userSlice';
 import { broadcastOperation } from '@/store/slices/transactionSlice';
 import { voted, set } from '@/store/slices/globalSlice';
 import { Post } from '@/lib/api/steem';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 
 interface VotingProps {
   post: Post;
@@ -15,14 +21,105 @@ interface VotingProps {
 }
 
 const MAX_WEIGHT = 10000;
-const MIN_WEIGHT = 1;
+const MIN_WEIGHT = 100;
+const MAX_VOTES_DISPLAY = 20;
+
+/** "$12.34" from "12.345 SBD" (legacy FormattedAsset). */
+function fmtPayout(value?: string | number): string {
+  if (value === undefined || value === null) return '$0.00';
+  const amount = typeof value === 'number' ? value : Number.parseFloat(value);
+  if (!Number.isFinite(amount)) return '$0.00';
+  return `$${amount.toFixed(2)}`;
+}
+
+/** Legacy chevron-up/down-circle icons (assets/icons/chevron-*-circle.svg). */
+function ChevronCircle({
+  dir,
+  className,
+}: {
+  dir: 'up' | 'down';
+  className?: string;
+}) {
+  return (
+    <svg viewBox="0 0 33 33" className={className} aria-hidden>
+      {dir === 'up' ? (
+        <path d="M16.699,11.293c-0.384-0.38-1.044-0.381-1.429,0l-6.999,6.899c-0.394,0.391-0.394,1.024,0,1.414 c0.395,0.391,1.034,0.391,1.429,0l6.285-6.195l6.285,6.196c0.394,0.391,1.034,0.391,1.429,0c0.394-0.391,0.394-1.024,0-1.414 L16.699,11.293z" />
+      ) : (
+        <path d="M22.3,12.393l-6.285,6.195l-6.285-6.196c-0.394-0.391-1.034-0.391-1.429,0 c-0.394,0.391-0.394,1.024,0,1.414l6.999,6.9c0.384,0.38,1.044,0.381,1.429,0l6.999-6.899c0.394-0.391,0.394-1.024,0-1.414 C23.334,12.003,22.695,12.003,22.3,12.393z" />
+      )}
+    </svg>
+  );
+}
+
+/** Circle outline + chevron, colored by direction/state (legacy Voting.scss). */
+function VoteCircle({
+  dir,
+  active,
+  voting,
+  onClick,
+  title,
+}: {
+  dir: 'up' | 'down';
+  active: boolean;
+  voting: boolean;
+  onClick: () => void;
+  title: string;
+}) {
+  const color = dir === 'up' ? 'text-[#1FBF8F] dark:text-[#06D6A9]' : 'text-[#f99]';
+  const hover =
+    dir === 'up'
+      ? 'hover:text-white hover:[&_.v-circle]:fill-[#004EFF] hover:[&_.v-circle]:stroke-[#004EFF] dark:hover:[&_.v-circle]:fill-[#06D6A9] dark:hover:[&_.v-circle]:stroke-[#06D6A9]'
+      : 'hover:text-white hover:[&_.v-circle]:fill-[#f66] hover:[&_.v-circle]:stroke-[#f66]';
+  const activeFill =
+    dir === 'up'
+      ? '[&_.v-circle]:fill-[#004EFF] [&_.v-circle]:stroke-[#004EFF] dark:[&_.v-circle]:fill-[#06D6A9] dark:[&_.v-circle]:stroke-[#06D6A9] text-white'
+      : '[&_.v-circle]:fill-[#f66] [&_.v-circle]:stroke-[#f66] text-white';
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      disabled={voting}
+      title={title}
+      className={`relative inline-flex rounded-full transition-colors ${color} ${hover} ${
+        active ? activeFill : ''
+      } ${voting ? 'cursor-not-allowed opacity-50' : ''}`}
+    >
+      {voting ? (
+        <span
+          className={`block size-[22px] animate-spin rounded-full border-2 ${
+            dir === 'up' ? 'border-[#06D6A9]' : 'border-[#f66]'
+          } border-t-transparent`}
+        />
+      ) : (
+        <span className="relative inline-flex size-[22px] items-center justify-center">
+          <svg viewBox="0 0 33 33" className="absolute inset-0 size-full" aria-hidden>
+            <circle
+              cx="16"
+              cy="16"
+              r="15"
+              fill="none"
+              stroke="currentColor"
+              className="v-circle"
+            />
+          </svg>
+          <ChevronCircle dir={dir} className="relative size-[14px] fill-current" />
+        </span>
+      )}
+    </button>
+  );
+}
 
 /**
- * Voting component
- * Handles upvoting and downvoting for posts/comments with weight slider
- * Migrated from legacy/src/app/components/elements/Voting.jsx
+ * Voting — legacy layout: circular up/down icons, $ payout with details
+ * dropdown, "N votes" dropdown listing voters (elements/Voting.jsx).
  */
-export default function Voting({ post, showList = true, enableSlider = false, isComment = false }: VotingProps) {
+export default function Voting({
+  post,
+  showList = true,
+  enableSlider = false,
+  isComment = false,
+}: VotingProps) {
   const dispatch = useAppDispatch();
   const username = useAppSelector((state) => state.user.current?.username);
   const voting = useAppSelector((state) => {
@@ -30,36 +127,37 @@ export default function Voting({ post, showList = true, enableSlider = false, is
     return state.global[key] || false;
   });
 
-  const [showWeight, setShowWeight] = useState(false);
+  const [showWeight, setShowWeight] = useState<'up' | 'down' | null>(null);
   const [sliderWeight, setSliderWeight] = useState({
     up: MAX_WEIGHT,
     down: MAX_WEIGHT,
   });
+  const sliderLoaded = useRef(false);
 
-  // Load saved slider weights from localStorage
-  useEffect(() => {
-    if (enableSlider && username && typeof window !== 'undefined') {
-      const savedUp = localStorage.getItem(`voteWeight-${username}${isComment ? '-comment' : ''}`);
-      const savedDown = localStorage.getItem(`voteWeightDown-${username}${isComment ? '-comment' : ''}`);
-      
-      if (savedUp) {
-        setSliderWeight(prev => ({ ...prev, up: Number(savedUp) }));
-      }
-      if (savedDown) {
-        setSliderWeight(prev => ({ ...prev, down: Number(savedDown) }));
-      }
-    }
-  }, [enableSlider, username, isComment]);
+  // Read saved slider weights on demand (when the slider opens) instead of
+  // in an effect, to keep this component SSR-safe without cascading renders.
+  const loadSliderWeights = () => {
+    if (!enableSlider || !username || typeof window === 'undefined') return;
+    if (sliderLoaded.current) return;
+    sliderLoaded.current = true;
+    const savedUp = localStorage.getItem(
+      `voteWeight-${username}${isComment ? '-comment' : ''}`
+    );
+    const savedDown = localStorage.getItem(
+      `voteWeightDown-${username}${isComment ? '-comment' : ''}`
+    );
+    setSliderWeight((prev) => ({
+      up: savedUp ? Number(savedUp) : prev.up,
+      down: savedDown ? Number(savedDown) : prev.down,
+    }));
+  };
 
   // Find user's vote
   const myVote = post.active_votes?.find((v) => v.voter === username);
   const myVoteWeight = myVote ? myVote.weight : 0;
-  const myVotePercent = myVoteWeight > 0 ? myVoteWeight : (myVoteWeight < 0 ? -myVoteWeight : 0);
 
-  // Calculate rshares (simplified, would need net_vests from user account)
   const calculateRshares = (weight: number): number => {
-    // Placeholder calculation - in real implementation, would use user's net_vests
-    const netVests = 1000000; // Mock value
+    const netVests = 1000000; // Mock value, as before
     return Math.floor(0.05 * netVests * 1e6 * (weight / 10000.0));
   };
 
@@ -68,28 +166,22 @@ export default function Voting({ post, showList = true, enableSlider = false, is
       dispatch(showLogin());
       return;
     }
-
     if (voting) return;
 
     let weight: number;
     if (myVoteWeight > 0 || myVoteWeight < 0) {
-      // If there is a current vote, we're clearing it
-      weight = 0;
+      weight = 0; // clearing an existing vote
     } else if (enableSlider && showWeight) {
-      // If slider is enabled and shown, read its value
       weight = up ? sliderWeight.up : -sliderWeight.down;
     } else {
-      // Otherwise, use max power
       weight = up ? MAX_WEIGHT : -MAX_WEIGHT;
     }
 
     const rshares = calculateRshares(Math.abs(weight));
     const isFlag = up ? null : true;
 
-    // Generate confirmation message
     const confirm = () => {
-      if (myVoteWeight == null) return null; // New vote, no confirmation needed
-
+      if (myVoteWeight == null) return null;
       if (weight === 0) {
         return isFlag
           ? 'Removing your vote'
@@ -108,7 +200,6 @@ export default function Voting({ post, showList = true, enableSlider = false, is
       return null;
     };
 
-    // Set voting state for immediate feedback
     dispatch(
       set({
         key: `transaction_vote_active_${post.author}_${post.permlink}`,
@@ -116,7 +207,6 @@ export default function Voting({ post, showList = true, enableSlider = false, is
       })
     );
 
-    // Update vote in global state immediately (optimistic update)
     dispatch(
       voted({
         voter: username!,
@@ -126,7 +216,6 @@ export default function Voting({ post, showList = true, enableSlider = false, is
       })
     );
 
-    // Dispatch vote operation
     dispatch(
       broadcastOperation({
         type: 'vote',
@@ -143,7 +232,6 @@ export default function Voting({ post, showList = true, enableSlider = false, is
         confirm: confirm(),
         errorCallback: (errorKey: string) => {
           console.error('Transaction Error:', errorKey);
-          // Reset voting state on error
           dispatch(
             set({
               key: `transaction_vote_active_${post.author}_${post.permlink}`,
@@ -154,71 +242,65 @@ export default function Voting({ post, showList = true, enableSlider = false, is
       })
     );
 
-    // Hide weight slider after voting
-    if (showWeight) {
-      setShowWeight(false);
-    }
+    if (showWeight) setShowWeight(null);
   };
 
-  const handleWeightChange = (up: boolean, weight: number) => {
-    if (up) {
-      setSliderWeight(prev => ({ ...prev, up: weight }));
-    } else {
-      setSliderWeight(prev => ({ ...prev, down: weight }));
+  const handleChevronClick = (up: boolean) => {
+    if (!username) {
+      dispatch(showLogin());
+      return;
     }
+    // Legacy: with the slider enabled and no existing vote, the chevron
+    // opens the weight dropdown; otherwise it votes directly.
+    if (enableSlider && myVoteWeight === 0) {
+      loadSliderWeights();
+      setShowWeight(showWeight === (up ? 'up' : 'down') ? null : up ? 'up' : 'down');
+      return;
+    }
+    handleVote(up);
   };
 
-  const saveSliderWeight = (up: boolean) => {
+  const saveSliderWeight = (up: boolean, weight: number) => {
     if (!username || !enableSlider) return;
-    
-    const weight = up ? sliderWeight.up : sliderWeight.down;
     const key = `voteWeight${up ? '' : 'Down'}-${username}${isComment ? '-comment' : ''}`;
-    
     if (typeof window !== 'undefined') {
       localStorage.setItem(key, weight.toString());
     }
   };
 
-  const toggleWeightSlider = () => {
-    setShowWeight(!showWeight);
-  };
-
   const upvoteActive = myVoteWeight > 0;
   const downvoteActive = myVoteWeight < 0;
 
-  // Format pending payout
-  const formatPayout = (payout: string | undefined): string => {
-    if (!payout) return '0.000 SBD';
-    return payout;
-  };
+  const totalVotes = post.stats?.total_votes ?? post.active_votes?.length ?? 0;
+  type Vote = { voter: string; weight: number; rshares?: number | string; percent?: number };
+  const votes = [...((post.active_votes ?? []) as Vote[])]
+    .sort(
+      (a, b) =>
+        Math.abs(Number(b.rshares ?? b.weight)) -
+        Math.abs(Number(a.rshares ?? a.weight))
+    )
+    .slice(0, MAX_VOTES_DISPLAY);
+  const extraVoters = Math.max(0, totalVotes - votes.length);
+
+  const payoutValue =
+    post.pending_payout_value ?? (post.payout !== undefined ? String(post.payout) : undefined);
 
   return (
-    <div className="Voting flex items-center gap-2">
-      {/* Upvote button */}
-      <div className="relative">
-        <button
-          onClick={() => handleVote(true)}
-          disabled={voting}
-          className={`flex items-center gap-1 px-3 py-1.5 rounded transition-colors ${
-            upvoteActive
-              ? 'bg-green-100 text-green-700 hover:bg-green-200'
-              : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-          } ${voting ? 'opacity-50 cursor-not-allowed' : ''}`}
-          title={upvoteActive ? 'Remove upvote' : 'Upvote'}
-        >
-          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-            <path fillRule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm1-11a1 1 0 10-2 0v3.586L7.707 9.293a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 10.586V7z" clipRule="evenodd" />
-          </svg>
-          {upvoteActive && <span className="text-xs">✓</span>}
-        </button>
-
-        {/* Weight slider for upvote */}
-        {enableSlider && showWeight && (
-          <div className="absolute bottom-full left-0 mb-2 p-3 bg-white border border-gray-300 rounded-lg shadow-lg z-10 min-w-[200px]">
-            <div className="mb-2">
-              <label className="block text-xs font-medium text-gray-700 mb-1">
-                Vote Weight: {sliderWeight.up / 100}%
-              </label>
+    <span className="Voting inline-flex items-center">
+      <span className="Voting__inner inline-flex items-center gap-1 border-r border-border py-0.5 pr-[0.8rem] mr-[0.6rem]">
+        <span className="relative">
+          <VoteCircle
+            dir="up"
+            active={upvoteActive}
+            voting={Boolean(voting)}
+            onClick={() => handleChevronClick(true)}
+            title={upvoteActive ? 'Remove Vote' : 'Upvote'}
+          />
+          {enableSlider && showWeight === 'up' && (
+            <div className="absolute left-1/2 top-full z-[100] mt-1 w-[180px] -translate-x-1/2 rounded-[6px] border border-border bg-card p-3 shadow-lg">
+              <div className="mb-1 text-center font-bold text-accent-foreground">
+                {sliderWeight.up / 100}%
+              </div>
               <input
                 type="range"
                 min={MIN_WEIGHT}
@@ -226,59 +308,37 @@ export default function Voting({ post, showList = true, enableSlider = false, is
                 step={100}
                 value={sliderWeight.up}
                 onChange={(e) => {
-                  const weight = Number(e.target.value);
-                  handleWeightChange(true, weight);
-                  saveSliderWeight(true);
+                  const w = Number(e.target.value);
+                  setSliderWeight((prev) => ({ ...prev, up: w }));
+                  saveSliderWeight(true, w);
                 }}
                 className="w-full"
+                aria-label="Vote weight"
               />
-              <div className="flex justify-between text-xs text-gray-500 mt-1">
-                <span>1%</span>
-                <span>100%</span>
-              </div>
+              <button
+                type="button"
+                onClick={() => handleVote(true)}
+                className="mt-2 w-full rounded bg-[#06D6A9] px-2 py-1 text-sm font-bold text-white"
+              >
+                Vote {sliderWeight.up / 100}%
+              </button>
             </div>
-            <button
-              onClick={() => handleVote(true)}
-              className="w-full px-3 py-1.5 bg-green-600 text-white rounded hover:bg-green-700 text-sm"
-            >
-              Vote {sliderWeight.up / 100}%
-            </button>
-          </div>
-        )}
-      </div>
-
-      {/* Pending payout */}
-      {post.pending_payout_value && (
-        <span className="text-sm text-gray-600">
-          {formatPayout(post.pending_payout_value)}
+          )}
         </span>
-      )}
 
-      {/* Downvote button */}
-      <div className="relative">
-        <button
-          onClick={() => handleVote(false)}
-          disabled={voting}
-          className={`flex items-center gap-1 px-3 py-1.5 rounded transition-colors ${
-            downvoteActive
-              ? 'bg-red-100 text-red-700 hover:bg-red-200'
-              : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
-          } ${voting ? 'opacity-50 cursor-not-allowed' : ''}`}
-          title={downvoteActive ? 'Remove downvote' : 'Downvote'}
-        >
-          <svg className="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
-            <path fillRule="evenodd" d="M10 2a8 8 0 100 16 8 8 0 000-16zm1 11a1 1 0 10-2 0v-3.586L7.707 10.707a1 1 0 00-1.414 1.414l3 3a1 1 0 001.414 0l3-3a1 1 0 00-1.414-1.414L11 9.414V13z" clipRule="evenodd" />
-          </svg>
-          {downvoteActive && <span className="text-xs">✓</span>}
-        </button>
-
-        {/* Weight slider for downvote */}
-        {enableSlider && showWeight && (
-          <div className="absolute bottom-full left-0 mb-2 p-3 bg-white border border-gray-300 rounded-lg shadow-lg z-10 min-w-[200px]">
-            <div className="mb-2">
-              <label className="block text-xs font-medium text-gray-700 mb-1">
-                Downvote Weight: {sliderWeight.down / 100}%
-              </label>
+        <span className="relative">
+          <VoteCircle
+            dir="down"
+            active={downvoteActive}
+            voting={Boolean(voting)}
+            onClick={() => handleChevronClick(false)}
+            title={downvoteActive ? 'Remove Vote' : 'Downvote'}
+          />
+          {enableSlider && showWeight === 'down' && (
+            <div className="absolute left-1/2 top-full z-[100] mt-1 w-[180px] -translate-x-1/2 rounded-[6px] border border-border bg-card p-3 shadow-lg">
+              <div className="mb-1 text-center font-bold text-[#f66]">
+                -{sliderWeight.down / 100}%
+              </div>
               <input
                 type="range"
                 min={MIN_WEIGHT}
@@ -286,51 +346,92 @@ export default function Voting({ post, showList = true, enableSlider = false, is
                 step={100}
                 value={sliderWeight.down}
                 onChange={(e) => {
-                  const weight = Number(e.target.value);
-                  handleWeightChange(false, weight);
-                  saveSliderWeight(false);
+                  const w = Number(e.target.value);
+                  setSliderWeight((prev) => ({ ...prev, down: w }));
+                  saveSliderWeight(false, w);
                 }}
                 className="w-full"
+                aria-label="Downvote weight"
               />
-              <div className="flex justify-between text-xs text-gray-500 mt-1">
-                <span>1%</span>
-                <span>100%</span>
-              </div>
+              <button
+                type="button"
+                onClick={() => handleVote(false)}
+                className="mt-2 w-full rounded bg-[#f66] px-2 py-1 text-sm font-bold text-white"
+              >
+                Downvote {sliderWeight.down / 100}%
+              </button>
             </div>
-            <button
-              onClick={() => handleVote(false)}
-              className="w-full px-3 py-1.5 bg-red-600 text-white rounded hover:bg-red-700 text-sm"
+          )}
+        </span>
+
+        {payoutValue !== undefined && (
+          <DropdownMenu>
+            <DropdownMenuTrigger
+              nativeButton={false}
+              render={
+                <button
+                  type="button"
+                  className="flex items-center gap-0.5 px-1 text-foreground hover:text-accent-foreground"
+                  title="Payout details"
+                />
+              }
             >
-              Downvote {sliderWeight.down / 100}%
-            </button>
-          </div>
+              <span>{fmtPayout(payoutValue)}</span>
+              <svg viewBox="0 0 10 6" className="size-2 fill-current" aria-hidden>
+                <path d="M0 0l5 6 5-6z" />
+              </svg>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="min-w-56">
+              <DropdownMenuItem disabled>
+                Pending Payout {fmtPayout(post.pending_payout_value)}
+              </DropdownMenuItem>
+              {post.payout_at && (
+                <DropdownItemText text={`Payout Date ${new Date(post.payout_at + 'Z').toLocaleString()}`} />
+              )}
+              {post.author_payout_value && (
+                <DropdownItemText text={`Author Payout ${fmtPayout(post.author_payout_value)}`} />
+              )}
+              {post.curator_payout_value && (
+                <DropdownItemText text={`Curator Payout ${fmtPayout(post.curator_payout_value)}`} />
+              )}
+            </DropdownMenuContent>
+          </DropdownMenu>
         )}
-      </div>
+      </span>
 
-      {/* Toggle weight slider button */}
-      {enableSlider && (
-        <button
-          onClick={toggleWeightSlider}
-          className="px-2 py-1 text-xs text-gray-600 hover:text-gray-800"
-          title="Adjust vote weight"
-        >
-          {showWeight ? 'Hide' : 'Weight'}
-        </button>
+      {showList && totalVotes > 0 && (
+        <DropdownMenu>
+          <DropdownMenuTrigger
+            nativeButton={false}
+            render={
+              <button
+                type="button"
+                className="px-1 text-foreground hover:text-accent-foreground"
+                title="Voters"
+              />
+            }
+          >
+            {totalVotes} vote{totalVotes === 1 ? '' : 's'}
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="min-w-[140px]">
+            {votes.map((v) => (
+              <DropdownItemText
+                key={v.voter}
+                text={`${Number(v.weight) < 0 ? '-' : '+'} ${v.voter}`}
+              />
+            ))}
+            {extraVoters > 0 && (
+              <DropdownItemText text={`and ${extraVoters} more`} />
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
       )}
+    </span>
+  );
+}
 
-      {/* Vote count */}
-      {showList && post.active_votes && post.active_votes.length > 0 && (
-        <span className="text-xs text-gray-500 ml-2">
-          ({post.active_votes.length} {post.active_votes.length === 1 ? 'vote' : 'votes'})
-        </span>
-      )}
-
-      {/* My vote percentage display */}
-      {myVotePercent > 0 && (
-        <span className="text-xs text-gray-600">
-          {myVotePercent / 100}%
-        </span>
-      )}
-    </div>
+function DropdownItemText({ text }: { text: string }) {
+  return (
+    <div className="px-2 py-1.5 text-sm text-foreground">{text}</div>
   );
 }

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -5,6 +5,7 @@ import { Header } from "@/components/layout/Header";
 import { DegradationBanner } from "@/components/layout/DegradationBanner";
 import { GlobalModals } from "@/components/modules/GlobalModals";
 import { ThemeSync } from "@/components/layout/ThemeSync";
+import { MobileTabBar } from "@/components/layout/MobileTabBar";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
   const [scrollVisible, setScrollVisible] = useState(false);
@@ -22,13 +23,14 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <Header />
       <DegradationBanner />
       <GlobalModals />
-      <main className="flex flex-1 flex-col px-0 pb-8 pt-4 md:pb-0">
+      <main className="flex flex-1 flex-col px-0 pb-[68px] pt-4 min-[760px]:pb-0">
         {children}
       </main>
+      <MobileTabBar />
       {scrollVisible ? (
         <button
           type="button"
-          className="scroll-to-top fixed bottom-6 right-6 z-40 flex size-10 items-center justify-center rounded-md border border-border bg-card text-lg text-foreground shadow-md transition-opacity hover:bg-muted"
+          className="scroll-to-top fixed bottom-[76px] right-6 z-40 flex size-10 items-center justify-center rounded-md border border-border bg-card text-lg text-foreground shadow-md transition-opacity hover:bg-muted min-[760px]:bottom-6"
           aria-label="Scroll to top"
           onClick={() =>
             window.scrollTo({ top: 0, behavior: "smooth" })

--- a/components/layout/FeedLayout.tsx
+++ b/components/layout/FeedLayout.tsx
@@ -19,31 +19,34 @@ export function FeedLayout({
 }) {
   const pathname = usePathname();
 
+  // Breakpoints follow legacy _layout.scss: M = 760px (left sidebar),
+  // L = 1200px (right sidebar). Margins/padding are legacy 1em (16px).
   return (
     <div
       className={cn(
-        "mx-auto grid w-full max-w-[1600px] grid-cols-1 md:grid-cols-[240px_minmax(0,1fr)] lg:grid-cols-[240px_minmax(0,1fr)_320px]",
+        "mx-auto grid w-full max-w-[1600px] grid-cols-1 min-[760px]:grid-cols-[240px_minmax(0,1fr)] min-[1200px]:grid-cols-[240px_minmax(0,1fr)_320px]",
         className
       )}
     >
-      <aside className="hidden w-[240px] min-w-[240px] max-w-[240px] md:block md:pl-3">
-        <div className="sticky top-20 rounded-lg bg-muted/50 py-4 pr-1.5">
+      <aside className="hidden w-[240px] min-w-[240px] max-w-[240px] min-[760px]:block min-[760px]:ml-4">
+        <div className="sticky top-20 rounded-[6px] border border-border py-4 pr-1.5">
           <PrimaryNavigation pathname={pathname} />
         </div>
       </aside>
 
       <article
         className={cn(
-          "min-w-0 w-full px-3 md:px-3",
-          centerClassName ?? "md:max-w-[1056px]",
+          "min-w-0 w-full px-4",
+          centerClassName ?? "min-[760px]:max-w-[1056px]",
           "mx-auto"
         )}
       >
         {children}
       </article>
 
-      <aside className="hidden w-[320px] min-w-[320px] max-w-[320px] lg:block lg:pr-3">
-        <div className="sticky top-20 py-1">
+      {/* Legacy right rail is not sticky (modules fade in at page load). */}
+      <aside className="hidden w-[320px] min-w-[320px] max-w-[320px] min-[1200px]:block min-[1200px]:mr-4">
+        <div className="py-1">
           <FeedSidebarWidgets />
         </div>
       </aside>

--- a/components/layout/FeedListHeader.tsx
+++ b/components/layout/FeedListHeader.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/lib/utils";
 
 /**
  * Feed column header — legacy PostsIndex articles__header:
- * title (e.g. All posts) + SortOrder dropdown.
+ * h1 (18px bold, only shown ≥1200px) + SortOrder dropdown.
  */
 export function FeedListHeader({
   title,
@@ -25,20 +25,22 @@ export function FeedListHeader({
     <header className={cn("mb-0", className)}>
       <div className="flex flex-col gap-4 sm:flex-row sm:items-start sm:justify-between">
         <div className="min-w-0 flex-1">
-          <h1 className="font-sans text-2xl font-bold tracking-tight text-foreground md:text-3xl">
+          {/* legacy h1.articles__h1 is show-for-mq-large (≥1200px) only */}
+          <h1 className="hidden font-sans text-[18px] font-bold text-foreground min-[1200px]:block">
             {title}
           </h1>
           {unmoderatedTagHint ? (
-            <p className="mt-1 text-sm text-muted-foreground">
+            <p className="mt-1 hidden text-[80%] text-muted-foreground min-[1200px]:block">
               Unmoderated tag
             </p>
           ) : null}
         </div>
-        <div className="shrink-0 sm:mt-1 sm:w-[200px]">
+        <div className="shrink-0 sm:mt-1 sm:w-[300px] sm:max-w-[300px]">
           <FeedSortDropdown sort={sort} categoryTag={categoryTag} />
         </div>
       </div>
-      <hr className="my-4 border-border" />
+      {/* legacy hr.articles__hr is hidden below the M (760px) breakpoint */}
+      <hr className="my-4 hidden border-border min-[760px]:block" />
     </header>
   );
 }

--- a/components/layout/FeedSidebarWidgets.tsx
+++ b/components/layout/FeedSidebarWidgets.tsx
@@ -1,40 +1,149 @@
 "use client";
 
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { useAppSelector } from "@/store/hooks";
 import {
-  Card,
-  CardContent,
-  CardDescription,
-  CardHeader,
-  CardTitle,
-} from "@/components/ui/card";
+  fetchCommunities,
+  type CommunitySubscription,
+} from "@/lib/api/steem";
+import SubscribeButton from "@/components/elements/SubscribeButton";
+
+/** Legacy c-sidebar__module chrome. */
+function SidebarModule({
+  title,
+  children,
+}: {
+  title?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="c-sidebar__module mb-4 rounded-[6px] border border-border bg-card p-[1.5em]">
+      {title && (
+        <div className="c-sidebar__header mb-2">
+          <h3 className="c-sidebar__h3 font-bold text-foreground">{title}</h3>
+        </div>
+      )}
+      <div className="c-sidebar__content">{children}</div>
+    </div>
+  );
+}
+
+/** Logged-out rail: "New to Steemit?" (legacy SidebarNewUsers). */
+function SidebarNewUsers() {
+  return (
+    <SidebarModule title="New to Steemit?">
+      <ul>
+        <li className="py-1">
+          <a
+            className="text-accent-foreground hover:underline"
+            href="https://steemit.com/guide/@steemitblog/steemit-a-guide-for-newcomers"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Welcome Guide
+          </a>
+        </li>
+      </ul>
+    </SidebarModule>
+  );
+}
+
+/** Logged-in rail: trending communities (legacy SidebarLinks). */
+function SidebarLinks() {
+  const [topics, setTopics] = useState<CommunitySubscription[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchCommunities({ sort: "rank", limit: 10 })
+      .then((data) => {
+        if (!cancelled) setTopics(data);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (topics.length === 0) return null;
+
+  return (
+    <SidebarModule>
+      <ul>
+        <li className="py-1 text-[#aaa]">Trending communities</li>
+        {topics.map((c) => (
+          <li key={c.name} className="py-1">
+            <Link
+              href={`/trending/${c.name}`}
+              className="text-accent-foreground hover:underline"
+            >
+              {c.title}
+            </Link>
+          </li>
+        ))}
+      </ul>
+    </SidebarModule>
+  );
+}
+
+/** Community info panel for /(sort)/hive-* pages (legacy CommunityPane). */
+function CommunityPane({ community }: { community: string }) {
+  const username = useAppSelector((s) => s.user.current?.username);
+  const [info, setInfo] = useState<CommunitySubscription | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchCommunities({ observer: username, query: community, limit: 20 })
+      .then((data) => {
+        if (cancelled) return;
+        setInfo(data.find((c) => c.name === community) ?? null);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, [community, username]);
+
+  if (!info) return null;
+
+  return (
+    <SidebarModule>
+      <h4 className="mb-1 font-bold text-foreground">{info.title}</h4>
+      {info.about && (
+        <p className="mb-2 text-sm text-muted-foreground">{info.about}</p>
+      )}
+      <p className="mb-3 text-sm text-muted-foreground">
+        {info.subscribers} subscribers &bull; {info.num_authors} active posters
+      </p>
+      <SubscribeButton
+        community={info.name}
+        subscribed={Boolean(info.context?.subscribed)}
+      />
+    </SidebarModule>
+  );
+}
 
 /**
- * Right rail modules (Legacy c-sidebar__module). SteemMarket / ads / links are stubs until migrated.
+ * Right rail modules (legacy PostsIndexLayout sidebar):
+ * community pane on community pages, then SidebarNewUsers (logged out) or
+ * SidebarLinks (logged in). SteemMarket is not migrated — the new stack has
+ * no market-data endpoint (legacy injects it server-side).
  */
 export function FeedSidebarWidgets() {
-  return (
-    <div className="flex flex-col gap-4">
-      <Card className="border-border shadow-none transition-shadow duration-200 hover:shadow-[0px_5px_10px_0_rgba(0,0,0,0.03)]">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-lg font-bold">Markets</CardTitle>
-          <CardDescription>
-            Token markets (SteemMarket placeholder)
-          </CardDescription>
-        </CardHeader>
-        <CardContent className="text-sm text-muted-foreground">
-          Market data will appear here after SteemMarket migration.
-        </CardContent>
-      </Card>
+  const pathname = usePathname();
+  const username = useAppSelector((s) => s.user.current?.username);
 
-      <Card className="border-border shadow-none transition-shadow duration-200 hover:shadow-[0px_5px_10px_0_rgba(0,0,0,0.03)]">
-        <CardHeader className="pb-2">
-          <CardTitle className="text-lg font-bold">Links</CardTitle>
-          <CardDescription>Sidebar links placeholder</CardDescription>
-        </CardHeader>
-        <CardContent className="text-sm text-muted-foreground">
-          New users, announcements, and topic links will be restored here.
-        </CardContent>
-      </Card>
+  const communityMatch = pathname?.match(
+    /^\/(?:trending|hot|created|promoted|payout|payout_comments|muted)\/(hive-[^/]+)/
+  );
+  const community = communityMatch?.[1];
+
+  return (
+    <div className="flex flex-col">
+      {community && <CommunityPane community={community} />}
+      {username ? <SidebarLinks /> : <SidebarNewUsers />}
     </div>
   );
 }

--- a/components/layout/FeedSortDropdown.tsx
+++ b/components/layout/FeedSortDropdown.tsx
@@ -7,16 +7,16 @@ import { ChevronDownIcon } from "lucide-react";
 import { cn } from "@/lib/utils";
 
 /**
- * Feed sort keys and labels — aligned with legacy SortOrder (vertical)
- * plus promoted / payout_comments used by this app’s /[sort] routes.
+ * Feed sort keys and labels — aligned with legacy SortOrder (vertical):
+ * Trending / Hot / New / Payouts / Muted. The /promoted and
+ * /payout_comments routes still exist but are not offered here (legacy
+ * does not list them).
  */
 const SORT_OPTIONS: { value: string; label: string }[] = [
   { value: "trending", label: "Trending" },
   { value: "hot", label: "Hot" },
   { value: "created", label: "New" },
-  { value: "promoted", label: "Promoted" },
   { value: "payout", label: "Payouts" },
-  { value: "payout_comments", label: "Comment payout" },
   { value: "muted", label: "Muted" },
 ];
 
@@ -37,6 +37,8 @@ export function FeedSortDropdown({
 }) {
   const router = useRouter();
   const normalized = sort.toLowerCase();
+  // Unknown sorts (promoted / payout_comments) fall back to "trending" in
+  // the dropdown, exactly like legacy when the sort isn't in the list.
   const value = SORT_OPTIONS.some((o) => o.value === normalized)
     ? normalized
     : "trending";
@@ -60,7 +62,7 @@ export function FeedSortDropdown({
         value={value}
         onChange={(e) => onChange(e.target.value)}
         className={cn(
-          "h-10 w-full cursor-pointer appearance-none rounded-md border border-input bg-card py-2 pl-3 pr-9 text-sm font-medium text-foreground shadow-sm",
+          "h-10 w-full cursor-pointer appearance-none border border-input bg-card py-2 pl-3 pr-9 text-sm text-foreground",
           "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
         )}
       >

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -2,14 +2,10 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import {
-  MenuIcon,
-  PenLineIcon,
-  SearchIcon,
-  UserRoundIcon,
-} from "lucide-react";
+import { useState } from "react";
+import { PenLineIcon, SearchIcon } from "lucide-react";
 
-import { Button, buttonVariants } from "@/components/ui/button";
+import { Button } from "@/components/ui/button";
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -19,21 +15,95 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
-import { Input } from "@/components/ui/input";
-import {
-  Sheet,
-  SheetContent,
-  SheetHeader,
-  SheetTitle,
-  SheetTrigger,
-} from "@/components/ui/sheet";
-import { cn } from "@/lib/utils";
 import { getSteemitWalletBaseUrl } from "@/lib/steemitWallet";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { toggleNightmode } from "@/store/slices/appSlice";
 import { showLogin } from "@/store/slices/userSlice";
-import { PrimaryNavigation } from "@/components/layout/PrimaryNavigation";
 import { SteemitLogo } from "@/components/layout/SteemitLogo";
+import { SidePanel } from "@/components/layout/SidePanel";
+import Userpic from "@/components/elements/Userpic";
+import NotificationBadge from "@/components/elements/NotificationBadge";
+
+const SEARCH_HISTORY_KEY = "steemit_search";
+
+function readHistory(): string[] {
+  if (typeof window === "undefined") return [];
+  try {
+    return JSON.parse(localStorage.getItem(SEARCH_HISTORY_KEY) || "[]");
+  } catch {
+    return [];
+  }
+}
+
+function addHistory(q: string) {
+  if (typeof window === "undefined" || !q) return;
+  const list = [q, ...readHistory().filter((h) => h !== q)].slice(0, 10);
+  localStorage.setItem(SEARCH_HISTORY_KEY, JSON.stringify(list));
+}
+
+/** Desktop capsule search box with icon + localStorage history (legacy SearchInput). */
+function HeaderSearch() {
+  const router = useRouter();
+  const [query, setQuery] = useState("");
+  const [history, setHistory] = useState<string[]>([]);
+  const [showHistory, setShowHistory] = useState(false);
+
+  const submit = (q: string) => {
+    const term = q.trim();
+    if (!term) return;
+    addHistory(term);
+    setShowHistory(false);
+    router.push(`/search?q=${encodeURIComponent(term)}`);
+  };
+
+  return (
+    <div className="relative mr-5 hidden min-[766px]:block">
+      <form
+        className="group relative h-[42px] w-[240px]"
+        onSubmit={(e) => {
+          e.preventDefault();
+          submit(query);
+        }}
+      >
+        <input
+          type="search"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          onFocus={() => {
+            setHistory(readHistory());
+            setShowHistory(true);
+          }}
+          onBlur={() => setTimeout(() => setShowHistory(false), 150)}
+          placeholder="Search"
+          aria-label="Search"
+          className="h-[42px] w-full rounded-full border border-[#cacaca99] bg-transparent py-[9px] pl-8 pr-10 text-[16px] text-foreground outline-none transition-colors placeholder:text-muted-foreground hover:bg-[#06D6A9] hover:text-white hover:placeholder:text-white"
+        />
+        <button
+          type="submit"
+          aria-label="Submit search"
+          className="absolute right-2.5 top-1/2 -translate-y-1/2 text-foreground group-hover:text-white"
+        >
+          <SearchIcon className="size-5" strokeWidth={1.2} />
+        </button>
+      </form>
+      {showHistory && history.length > 0 && (
+        <ul className="absolute left-0 top-full z-[100] mt-1 w-full rounded-[6px] border border-border bg-card py-1 shadow-md">
+          {history.map((h) => (
+            <li key={h}>
+              <button
+                type="button"
+                className="block w-full px-3 py-1.5 text-left text-sm text-foreground hover:bg-accent hover:text-accent-foreground"
+                onMouseDown={() => submit(h)}
+              >
+                {h}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}
 
 export function Header() {
   const pathname = usePathname();
@@ -41,11 +111,13 @@ export function Header() {
   const dispatch = useAppDispatch();
   const username = useAppSelector((s) => s.user.current?.username);
   const loggedIn = Boolean(username);
-  const unread = 0;
 
   const walletBase = getSteemitWalletBaseUrl();
   const signupUrl =
     process.env.NEXT_PUBLIC_SIGNUP_URL ?? "https://signup.steemit.com";
+
+  // legacy signup links carry a source tracker: #source=condenser|{routeTag}
+  const routeTag = pathname?.split("/")[1] || "trending";
 
   const openLoginModal = () => {
     dispatch(showLogin({}));
@@ -59,6 +131,14 @@ export function Header() {
     router.push("/submit");
   };
 
+  const handleSignup = () => {
+    const win = window.open(
+      `${signupUrl}/#source=condenser|${routeTag}`,
+      "_blank"
+    );
+    if (win) win.opener = null;
+  };
+
   const logout = async () => {
     await fetch("/api/auth/logout", {
       method: "POST",
@@ -69,10 +149,14 @@ export function Header() {
   };
 
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-border bg-card shadow-[0_2px_4px_0_rgba(0,0,0,0.05)]">
+    <header className="sticky top-0 z-[100] w-full border-b border-border bg-card shadow-[0_2px_4px_0_rgba(0,0,0,0.05)]">
       <nav className="mx-auto flex h-16 max-w-[100vw] items-center gap-2 px-3 sm:px-4">
         <div className="flex min-w-0 flex-1 items-center md:max-w-[40%] lg:max-w-[33%]">
-          <Link href="/" className="shrink-0" aria-label="Steemit home">
+          <Link
+            href="/"
+            className="Header__logotype flex h-[37px] shrink-0 items-baseline"
+            aria-label="Steemit home"
+          >
             <SteemitLogo />
           </Link>
         </div>
@@ -80,61 +164,45 @@ export function Header() {
         <div className="hidden flex-1 justify-center lg:flex" aria-hidden />
 
         <div className="flex flex-1 items-center justify-end gap-2 md:gap-3">
-          <div className="hidden min-w-[140px] max-w-[240px] md:block">
-            <form
-              action="/search"
-              method="get"
-              className="flex w-full items-center gap-2"
-            >
-              <Input
-                type="search"
-                name="q"
-                placeholder="Search"
-                className="h-8"
-                aria-label="Search"
-              />
-            </form>
-          </div>
+          <HeaderSearch />
 
           <Link
             href="/search"
-            className={cn(
-              buttonVariants({ variant: "ghost", size: "icon" }),
-              "md:hidden"
-            )}
+            className="text-foreground hover:text-accent-foreground min-[766px]:hidden"
             aria-label="Search"
           >
-            <SearchIcon />
+            <SearchIcon className="size-5" />
           </Link>
 
           {!loggedIn ? (
-            <span className="hidden items-center gap-2 text-sm sm:flex">
+            <span className="hidden items-center text-[1.125rem] sm:flex">
               <button
                 type="button"
                 onClick={openLoginModal}
-                className="text-foreground transition-colors hover:text-accent-foreground"
+                className="pr-1 text-foreground transition-colors hover:text-[#1FBF8F] dark:hover:text-[#06D6A9]"
               >
                 Login
               </button>
-              <a
-                href={signupUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="text-foreground transition-colors hover:text-accent-foreground"
+              <button
+                type="button"
+                onClick={handleSignup}
+                className="my-0 ml-2 mr-3 rounded-none bg-[#171F24] p-[0.6rem] font-bold text-[#fcfcfc] shadow-[0_0_0_0_transparent,2px_2px_0_0_#06D6A9] transition-all hover:bg-[#06D6A9] hover:shadow-[2px_2px_2px_rgba(0,0,0,0.1),4px_4px_0_0_#171F24]"
               >
                 Sign up
-              </a>
+              </button>
             </span>
           ) : null}
 
-          <Button
-            variant="ghost"
-            size="icon-sm"
+          {/* legacy circular pencil IconButton (36px, 42px ≥760px) */}
+          <button
+            type="button"
             onClick={goSubmit}
             aria-label="Create post"
+            title="Create post"
+            className="flex size-9 items-center justify-center rounded-full text-muted-foreground transition-colors hover:bg-[#171F24] hover:text-white min-[760px]:size-[42px] [&_svg]:size-5 min-[760px]:[&_svg]:size-6 [&_svg]:text-[#cacaca] hover:[&_svg]:text-white"
           >
             <PenLineIcon />
-          </Button>
+          </button>
 
           {loggedIn && username ? (
             <DropdownMenu>
@@ -144,16 +212,20 @@ export function Header() {
                   <Button
                     variant="ghost"
                     size="sm"
-                    className="gap-2 px-1"
+                    className="relative px-1"
                     aria-label="Account menu"
                   />
                 }
               >
-                <span className="flex size-8 items-center justify-center overflow-hidden rounded-full bg-muted">
-                  <UserRoundIcon className="text-muted-foreground" />
-                </span>
-                <span className="hidden max-w-[7rem] truncate md:inline">
-                  {username}
+                <span className="relative inline-flex">
+                  <Userpic
+                    account={username}
+                    className="!size-9 min-[760px]:!size-10"
+                  />
+                  <NotificationBadge
+                    username={username}
+                    className="absolute -right-1 -top-1 flex size-5 items-center justify-center rounded-full bg-[#ff0264] text-[11px] font-bold text-white"
+                  />
                 </span>
               </DropdownMenuTrigger>
               <DropdownMenuContent align="end" className="min-w-48">
@@ -173,7 +245,6 @@ export function Header() {
                     }
                   >
                     Notifications
-                    {unread > 0 ? ` (${unread})` : ""}
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={() =>
@@ -213,57 +284,19 @@ export function Header() {
             </DropdownMenu>
           ) : null}
 
-          <Sheet>
-            <SheetTrigger
-              nativeButton
-              render={
-                <Button
-                  variant="ghost"
-                  size="icon"
-                  className="md:hidden"
-                  aria-label="Open menu"
-                />
-              }
+          {/* legacy hamburger: three 7px-spaced bars, opens the SidePanel at
+              every breakpoint */}
+          <SidePanel>
+            <button
+              type="button"
+              aria-label="Open menu"
+              className="group ml-1 flex size-4 flex-col items-start justify-center gap-[5px] sm:ml-2 md:ml-3"
             >
-              <MenuIcon />
-            </SheetTrigger>
-            <SheetContent
-              side="right"
-              className="flex w-[min(100%,20rem)] flex-col gap-4"
-            >
-              <SheetHeader>
-                <SheetTitle className="sr-only">Menu</SheetTitle>
-              </SheetHeader>
-              <div className="flex flex-col gap-4 overflow-y-auto pr-2">
-                <PrimaryNavigation pathname={pathname} compact />
-                <Link
-                  href="/search"
-                  className="text-sm text-foreground hover:text-accent-foreground"
-                >
-                  Search
-                </Link>
-                {!loggedIn ? (
-                  <div className="flex flex-col gap-2 border-t border-border pt-4">
-                    <button
-                      type="button"
-                      onClick={openLoginModal}
-                      className="w-fit text-left text-sm text-foreground hover:text-accent-foreground"
-                    >
-                      Login
-                    </button>
-                    <a
-                      href={signupUrl}
-                      target="_blank"
-                      rel="noreferrer"
-                      className="text-sm text-foreground hover:text-accent-foreground"
-                    >
-                      Sign up
-                    </a>
-                  </div>
-                ) : null}
-              </div>
-            </SheetContent>
-          </Sheet>
+              <span className="h-[2px] w-4 bg-foreground transition-colors group-hover:bg-[#06D6A9]" />
+              <span className="h-[2px] w-4 bg-foreground transition-colors group-hover:bg-[#06D6A9]" />
+              <span className="h-[2px] w-4 bg-foreground transition-colors group-hover:bg-[#06D6A9]" />
+            </button>
+          </SidePanel>
         </div>
       </nav>
     </header>

--- a/components/layout/MobileTabBar.tsx
+++ b/components/layout/MobileTabBar.tsx
@@ -1,0 +1,85 @@
+"use client";
+
+import { usePathname, useRouter } from "next/navigation";
+import { BookMarkedIcon, UserRoundIcon, WalletIcon } from "lucide-react";
+
+import { getSteemitWalletBaseUrl } from "@/lib/steemitWallet";
+import { useAppDispatch, useAppSelector } from "@/store/hooks";
+import { showLogin } from "@/store/slices/userSlice";
+import { cn } from "@/lib/utils";
+
+/**
+ * Mobile bottom tab bar (legacy PrimaryNavigation on small screens):
+ * fixed 60px bar with Explore / My Profile / My Wallet, icon above label,
+ * active tab gets a teal bottom border. Visible only <760px.
+ */
+export function MobileTabBar() {
+  const pathname = usePathname();
+  const router = useRouter();
+  const dispatch = useAppDispatch();
+  const username = useAppSelector((s) => s.user.current?.username);
+  const walletBase = getSteemitWalletBaseUrl();
+
+  const tabs = [
+    {
+      key: "explore",
+      label: "Explore",
+      icon: BookMarkedIcon,
+      active: !pathname?.startsWith("/@"),
+      onClick: () => router.push("/trending"),
+    },
+    {
+      key: "profile",
+      label: "My Profile",
+      icon: UserRoundIcon,
+      active: Boolean(username && pathname?.startsWith(`/@${username}`)),
+      onClick: () => {
+        if (!username) {
+          dispatch(showLogin({}));
+          return;
+        }
+        router.push(`/@${username}/posts`);
+      },
+    },
+    {
+      key: "wallet",
+      label: "My Wallet",
+      icon: WalletIcon,
+      active: false,
+      onClick: () => {
+        window.open(
+          username ? `${walletBase}/@${username}` : walletBase,
+          "_blank",
+          "noopener,noreferrer"
+        );
+      },
+    },
+  ];
+
+  return (
+    <nav
+      className="PrimaryNavigation fixed inset-x-0 bottom-0 z-[100] block min-[760px]:hidden"
+      aria-label="Primary navigation"
+    >
+      <ul className="PrimaryNavTabs flex justify-around border-t border-border bg-card">
+        {tabs.map((tab) => (
+          <li key={tab.key} className="flex-1 text-center">
+            <button
+              type="button"
+              onClick={tab.onClick}
+              className={cn(
+                "flex h-[60px] w-full flex-col items-center justify-center gap-0.5 border-b-2 pt-1.5 text-[11px]",
+                tab.active
+                  ? "border-[#06D6A9] text-[#06D6A9]"
+                  : "border-transparent text-foreground"
+              )}
+            >
+              <tab.icon className="size-5" aria-hidden />
+              <span>{tab.label}</span>
+            </button>
+          </li>
+        ))}
+      </ul>
+    </nav>
+  );
+}

--- a/components/layout/PrimaryNavigation.tsx
+++ b/components/layout/PrimaryNavigation.tsx
@@ -61,8 +61,6 @@ const PROFILE_SECTIONS: { segment: string; label: string }[] = [
   { segment: "replies", label: "Replies" },
   { segment: "payout", label: "Payout" },
   { segment: "feed", label: "Feed" },
-  { segment: "followers", label: "Followers" },
-  { segment: "followed", label: "Following" },
   { segment: "notifications", label: "Notifications" },
   { segment: "communities", label: "Communities" },
   { segment: "settings", label: "Settings" },
@@ -167,12 +165,13 @@ function NavExploreItem({
   useLoginPrompt?: boolean;
   onLoginPrompt?: () => void;
 }) {
+  // Legacy sub-item (ul#FeedsNavigation li): padding 0.6rem 0.8rem; active =
+  // teal bold text (no background, no side bar); hover = highlight bg + teal.
   const className = cn(
-    "flex w-full items-center gap-2 rounded-md py-1.5 pl-2 pr-2 text-sm font-medium transition-colors",
-    "border-l-[3px] -ml-px",
+    "flex w-full items-center gap-2 py-[0.6rem] pl-[0.8rem] pr-2 text-sm transition-colors",
     active
-      ? "border-accent-foreground text-accent-foreground"
-      : "border-transparent text-foreground hover:bg-accent/80 hover:text-accent-foreground"
+      ? "font-bold text-accent-foreground"
+      : "text-foreground hover:bg-accent hover:text-accent-foreground"
   );
   return (
     <li>
@@ -209,11 +208,13 @@ function NavTopItem({
   useLoginPrompt?: boolean;
   onLoginPrompt?: () => void;
 }) {
+  // Legacy top-level tab active: highlight bg + 2px teal bottom border +
+  // teal text; hover: highlight bg + teal text.
   const className = cn(
-    "flex items-center gap-2 rounded-md px-2 py-2 text-sm font-medium transition-colors",
+    "flex items-center gap-2 border-b-2 px-2 py-[1em] text-sm transition-colors",
     active
-      ? "bg-accent/90 text-accent-foreground"
-      : "text-foreground hover:bg-accent/80 hover:text-accent-foreground"
+      ? "border-[#06D6A9] bg-accent text-accent-foreground"
+      : "border-transparent text-foreground hover:bg-accent hover:text-accent-foreground"
   );
   if (useLoginPrompt) {
     return (
@@ -289,7 +290,7 @@ export function PrimaryNavigation({
           <CompassIcon className="size-[1.15rem] shrink-0" aria-hidden />
           <span>Explore</span>
         </div>
-        <ul className="ml-1 flex flex-col gap-0.5 border-l border-border pl-2">
+        <ul className="ml-1 flex flex-col gap-0 pl-2">
           <NavExploreItem
             href="/trending"
             label="All Posts"
@@ -381,8 +382,8 @@ export function PrimaryNavigation({
                   <Link
                     href={href}
                     className={cn(
-                      "block rounded-md px-2 py-1.5 font-medium text-foreground transition-colors hover:bg-accent/80 hover:text-accent-foreground",
-                      active && "bg-accent font-semibold text-accent-foreground"
+                      "block py-[0.6rem] pl-[1.6rem] pr-2 text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground",
+                      active && "font-bold text-accent-foreground"
                     )}
                   >
                     {label}

--- a/components/layout/SidePanel.tsx
+++ b/components/layout/SidePanel.tsx
@@ -1,0 +1,202 @@
+"use client";
+
+import Link from "next/link";
+import { ExternalLink } from "lucide-react";
+
+import {
+  Sheet,
+  SheetContent,
+  SheetTitle,
+  SheetTrigger,
+} from "@/components/ui/sheet";
+import { getSteemitWalletBaseUrl } from "@/lib/steemitWallet";
+import { useAppDispatch, useAppSelector } from "@/store/hooks";
+import { toggleNightmode } from "@/store/slices/appSlice";
+import { showLogin } from "@/store/slices/userSlice";
+
+interface SidePanelLink {
+  label: string;
+  link?: string;
+  onClick?: () => void;
+  external?: boolean;
+}
+
+/**
+ * SidePanel — legacy right-side dark drawer (modules/SidePanel).
+ * 250px, #11161A background, link groups with hairline separators.
+ */
+export function SidePanel({ children }: { children: React.ReactNode }) {
+  const dispatch = useAppDispatch();
+  const username = useAppSelector((s) => s.user.current?.username);
+  const loggedIn = Boolean(username);
+  const walletBase = getSteemitWalletBaseUrl();
+  const signupUrl =
+    process.env.NEXT_PUBLIC_SIGNUP_URL ?? "https://signup.steemit.com";
+
+  const groups: { key: string; section?: string; items: SidePanelLink[] }[] = [
+    // extras — only when logged out (legacy hides this group when logged in)
+    ...(loggedIn
+      ? []
+      : [
+          {
+            key: "extras",
+            items: [
+              { label: "Sign in", onClick: () => dispatch(showLogin({})) },
+              { label: "Sign up", link: signupUrl, external: true },
+            ],
+          },
+        ]),
+    {
+      key: "internal",
+      items: [
+        // Legacy serves /faq.html itself; the rewrite does not host these
+        // static pages, so they point at the legacy site for now.
+        { label: "FAQ", link: "https://steemit.com/faq.html", external: true },
+        {
+          label: "Toggle night mode",
+          onClick: () => dispatch(toggleNightmode()),
+        },
+      ],
+    },
+    {
+      key: "wallet",
+      items: [
+        {
+          label: "Stolen Account Recovery",
+          link: `${walletBase}/recover_account_step_1`,
+          external: true,
+        },
+        {
+          label: "Change Account Password",
+          link: `${walletBase}/change_password`,
+          external: true,
+        },
+        {
+          label: "Vote for Witnesses",
+          link: `${walletBase}/~witnesses`,
+          external: true,
+        },
+        {
+          label: "Steem Proposals",
+          link: `${walletBase}/proposals`,
+          external: true,
+        },
+      ],
+    },
+    {
+      key: "exchanges",
+      section: "Third Party Exchanges",
+      items: [
+        {
+          label: "Poloniex",
+          link: "https://poloniex.com/exchange#trx_steem",
+          external: true,
+        },
+      ],
+    },
+    {
+      key: "external",
+      items: [
+        {
+          label: "Advertise",
+          link: "https://selfserve.steemit.com",
+          external: true,
+        },
+        {
+          label: "Jobs",
+          link: "https://recruiting.paylocity.com/recruiting/jobs/List/3288/Steemit-Inc",
+          external: true,
+        },
+      ],
+    },
+    {
+      key: "organizational",
+      items: [
+        {
+          label: "API Docs",
+          link: "https://developers.steem.io/",
+          external: true,
+        },
+        {
+          label: "Bluepaper",
+          link: "https://steem.io/steem-bluepaper.pdf",
+          external: true,
+        },
+        { label: "SMT Whitepaper", link: "https://smt.steem.io/", external: true },
+        {
+          label: "Whitepaper",
+          link: "https://steem.com/SteemWhitePaper.pdf",
+          external: true,
+        },
+      ],
+    },
+    {
+      key: "legal",
+      items: [
+        {
+          label: "Privacy Policy",
+          link: "https://steemit.com/privacy.html",
+          external: true,
+        },
+        {
+          label: "Terms of Service",
+          link: "https://steemit.com/tos.html",
+          external: true,
+        },
+      ],
+    },
+  ];
+
+  return (
+    <Sheet>
+      <SheetTrigger nativeButton={false} render={<span className="inline-flex" />}>
+        {children}
+      </SheetTrigger>
+      <SheetContent
+        side="right"
+        className="w-[250px] gap-0 overflow-y-auto border-none bg-[#11161A] p-0 text-white [&>button]:text-white"
+      >
+        <SheetTitle className="sr-only">Menu</SheetTitle>
+        {groups.map((group) => (
+          <ul key={group.key} className="flex flex-col py-1">
+            {group.section && (
+              <li>
+                <span className="block px-4 py-2 text-sm text-[#a6b2ba]">
+                  {group.section}
+                </span>
+              </li>
+            )}
+            {group.items.map((item) => (
+              <li key={item.label}>
+                {item.link ? (
+                  <Link
+                    href={item.link}
+                    target={item.external ? "_blank" : undefined}
+                    rel={item.external ? "noopener noreferrer" : undefined}
+                    className="flex items-center gap-1 border-t border-[#232F38] px-4 py-2.5 text-sm text-white transition-colors hover:border-b-[#06D6A9] hover:bg-[#171F24]"
+                  >
+                    {item.label}
+                    {item.external && (
+                      <>
+                        &nbsp;
+                        <ExternalLink className="size-3.5" aria-hidden />
+                      </>
+                    )}
+                  </Link>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={item.onClick}
+                    className="block w-full border-t border-[#232F38] px-4 py-2.5 text-left text-sm text-white transition-colors hover:border-b-[#06D6A9] hover:bg-[#171F24]"
+                  >
+                    {item.label}
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        ))}
+      </SheetContent>
+    </Sheet>
+  );
+}

--- a/components/layout/SteemitLogo.tsx
+++ b/components/layout/SteemitLogo.tsx
@@ -8,7 +8,7 @@ export function SteemitLogo({ className }: { className?: string }) {
   return (
     <span
       className={cn(
-        "inline-flex cursor-pointer transition-[filter] duration-300 ease-in-out hover:brightness-110",
+        "logo inline-flex cursor-pointer transition-all duration-300 ease-in-out",
         className
       )}
     >
@@ -17,7 +17,7 @@ export function SteemitLogo({ className }: { className?: string }) {
         width={150}
         height={40}
         viewBox="0 0 150 40"
-        className="h-9 w-auto max-w-[min(100%,9.375rem)] [&_path]:fill-[var(--ring)]"
+        className="h-10 w-auto max-w-[min(100%,9.375rem)] [&_path]:fill-[#06D6A9]"
         aria-hidden
       >
         <title>Home</title>

--- a/components/modules/LoginForm.tsx
+++ b/components/modules/LoginForm.tsx
@@ -197,10 +197,6 @@ export default function LoginForm({ embedded = false }: { embedded?: boolean }) 
     }
   };
 
-  const handleCancel = () => {
-    dispatch(hideLogin());
-  };
-
   const handleSignup = () => {
     // TODO: Open signup URL in new window
     // Safe access to process.env for UMD compatibility
@@ -211,17 +207,14 @@ export default function LoginForm({ embedded = false }: { embedded?: boolean }) 
   };
 
   return (
-    <div className="LoginForm">
+    <div className="LoginForm mx-auto mb-2 mt-4 max-w-[28rem]">
       {!embedded ? (
-        <h1 className="text-3xl font-bold mb-6 text-center">Login</h1>
+        <h3 className="mb-4 text-left text-xl font-bold">Login</h3>
       ) : null}
 
       <form onSubmit={handleSubmit} className="space-y-4">
         {/* Username input */}
         <div>
-          <label htmlFor="username" className="block text-sm font-medium text-gray-700 mb-1">
-            Username
-          </label>
           <div className="flex">
             <span className="inline-flex items-center px-3 rounded-l-md border border-r-0 border-gray-300 bg-gray-50 text-gray-500 text-sm">
               @
@@ -242,26 +235,17 @@ export default function LoginForm({ embedded = false }: { embedded?: boolean }) 
 
         {/* Posting Private Key input */}
         <div>
-          <label htmlFor="password" className="block text-sm font-medium text-gray-700 mb-1">
-            Posting Private Key (WIF)
-          </label>
           <input
             id="password"
             type="password"
             value={password}
             onChange={(e) => setPassword(e.target.value)}
-            placeholder="Enter your posting private key (WIF format, starts with 5...)"
+            placeholder="Enter your posting private key (WIF)"
             className="block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
             autoComplete="off"
             disabled={submitting}
             required
           />
-          <p className="mt-1 text-xs text-gray-500">
-            Only posting private keys in WIF format are accepted. Master passwords are not supported.
-          </p>
-          <p className="mt-1 text-xs text-gray-500">
-            Your private key starts with &quot;5&quot; and is typically 51-52 characters long.
-          </p>
           {validatingKey && (
             <p className="mt-1 text-xs text-blue-600">
               Validating posting private key...
@@ -294,40 +278,28 @@ export default function LoginForm({ embedded = false }: { embedded?: boolean }) 
             />
             <span className="ml-2 text-sm text-gray-700">Keep me logged in</span>
           </label>
-          <p className="mt-1 text-xs text-gray-500 ml-6">
-            Only for low-security keys (like posting keys). Never save owner or active keys.
-          </p>
         </div>
 
-        {/* Submit button */}
-        <div className="flex gap-3">
+        {/* Submit button + register link on one row (legacy login-modal-buttons) */}
+        <div className="flex items-center gap-3">
           <button
             type="submit"
             disabled={submitting}
-            className="flex-1 px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+            className="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
           >
-{submitting ? (validatingKey ? 'Validating key...' : 'Logging in...') : 'Login'}
+            {submitting ? (validatingKey ? 'Validating key...' : 'Logging in...') : 'Login'}
           </button>
-          <button
-            type="button"
-            onClick={handleCancel}
-            className="px-4 py-2 border border-gray-300 rounded-md text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            disabled={submitting}
-          >
-            Cancel
-          </button>
-        </div>
-
-        {/* Sign up link */}
-        <div className="text-center pt-4 border-t border-gray-200">
-          <p className="text-sm text-gray-600 mb-2">Not a Steemit user?</p>
-          <button
-            type="button"
-            onClick={handleSignup}
-            className="text-sm text-blue-600 hover:text-blue-800 underline"
-          >
-            Sign up for free and get STEEM
-          </button>
+          <span className="register ml-auto text-right text-sm text-gray-600">
+            Not a Steemit user?
+            <br />
+            <button
+              type="button"
+              onClick={handleSignup}
+              className="text-blue-600 hover:text-blue-800 underline"
+            >
+              Sign up for free and get STEEM
+            </button>
+          </span>
         </div>
       </form>
     </div>

--- a/lib/extract-content.ts
+++ b/lib/extract-content.ts
@@ -1,0 +1,110 @@
+/**
+ * Post content extraction for summary cards.
+ * Ported from legacy src/app/utils/ExtractContent.js.
+ */
+
+import MarkdownIt from 'markdown-it';
+import sanitizeHtml from 'sanitize-html';
+import htmlReady from '@/lib/html-ready';
+import { proxifyImageUrl } from '@/lib/media/proxify-url';
+
+const md = new MarkdownIt({ html: true, linkify: false });
+
+const getValidImage = (arr: unknown): string | null =>
+  Array.isArray(arr) && arr.length >= 1 && typeof arr[0] === 'string'
+    ? arr[0]
+    : null;
+
+/** Minimal HTML entity decode for the entities sanitize-html leaves behind. */
+function htmlDecode(text: string): string {
+  return text
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ');
+}
+
+interface JsonMetadata {
+  image?: unknown;
+  [key: string]: unknown;
+}
+
+/** First usable image for a post: json_metadata.image[0], else first body image. */
+export function extractImageLink(
+  jsonMetadata: JsonMetadata | undefined,
+  body: string | null = null
+): string | null {
+  let imageLink: string | null = null;
+  try {
+    imageLink = jsonMetadata ? getValidImage(jsonMetadata.image) : null;
+  } catch {
+    /* fall through to body parsing */
+  }
+
+  if (!imageLink && body) {
+    const isHtml = /^<html>([\S\s]*)<\/html>$/.test(body);
+    const htmlText = isHtml
+      ? body
+      : md.render(
+          body.replace(/<!--([\s\S]+?)(-->|$)/g, '(html comment removed: $1)')
+        );
+    const rtags = htmlReady(htmlText, { mutate: false });
+    [imageLink] = Array.from(rtags.images);
+  }
+
+  return imageLink;
+}
+
+/** Short plain-text description: strip markdown/html, URLs, truncate to ~140. */
+export function extractBodySummary(body: string, stripQuotes = false): string {
+  let desc = body;
+  if (stripQuotes) {
+    desc = desc.replace(/(^(\n|\r|\s)*)>([\s\S]*?).*\s*/g, '');
+  }
+  // Render markdown to HTML, then drop all tags, leaving text.
+  desc = md.render(desc);
+  desc = sanitizeHtml(desc, { allowedTags: [] });
+  desc = htmlDecode(desc);
+
+  // Strip any raw URLs from preview text.
+  desc = desc.replace(/https?:\/\/[^\s]+/g, '');
+
+  // Grab only the first line.
+  desc = desc.trim().split('\n')[0];
+
+  if (desc.length > 140) {
+    desc = desc.substring(0, 140).trim();
+    // Truncate, remove the last (likely partial) word, add ellipsis.
+    desc = desc
+      .substring(0, 120)
+      .trim()
+      .replace(/[,!?]?\s+[^\s]+$/, '…');
+  }
+
+  return desc;
+}
+
+/** Thumbnail URL for a summary card (proxied, capped at 640px wide). */
+export function summaryThumbnail(imageLink: string | null): string | null {
+  if (!imageLink) return null;
+  return proxifyImageUrl(imageLink, '640x0/');
+}
+
+/**
+ * Convert a raw chain reputation (big number string/number) to the familiar
+ * 25-based score, e.g. (73). Ported from legacy ParsersAndFormatters.reputation.
+ */
+export function reputation(raw: string | number | undefined | null): number | null {
+  if (raw === undefined || raw === null || raw === '') return null;
+  let rep = typeof raw === 'string' ? Number(raw) : raw;
+  if (!Number.isFinite(rep)) return null;
+  const neg = rep < 0;
+  rep = Math.abs(rep);
+  let out = Math.log10(rep);
+  out = Math.max(out - 9, 0);
+  out = (neg ? -1 : 1) * out;
+  out = out * 9 + 25;
+  return Math.floor(out);
+}


### PR DESCRIPTION
1:1 UI parity pass over the `next` rewrite, guided by a full-page audit against `condenser-legacy` (four-area audit: header/nav, feed, post page, profile & misc pages — 793-line diff report). Big structure was already replicated; this PR closes the visual/detail gaps.

## Wave 1 — Foundation
- Source Serif Pro body font (Google Fonts, same as legacy `server-html.jsx`)
- Full `.Markdown` typography port (`markdown.scss`: h1–h6 margins/sizes, blockquote, code, pull-right/left, text-justify/rtl, videoWrapper, `--small` comment variant)
- Legacy text-link colors: light theme blue `#004EFF` (was dark-theme teal everywhere), correct hover colors
- Feed grid breakpoints aligned: left sidebar ≥760px, right rail ≥1200px (was 768/1024)

## Wave 2 — Chrome & lists
- **Header**: solid Sign up button (dark + teal offset shadow, `#source=condenser|{route}` tracker), real user avatar via image proxy + unread red badge, 42px capsule search with icon/hover-teal/localStorage history, circular pencil post button, hamburger at all breakpoints opening a new **SidePanel** (250px dark drawer with legacy link groups incl. night mode for logged-out users), nav active states (highlight bg + 2px teal underline for tabs, teal bold for sub-items), logo 40px + fill-flip hover, z-index 100
- **Feed cards**: rewritten to legacy `PostSummary` — resteem row, 24px avatar + bold author + reputation + relative time, 130×77 thumbnail (proxied, object-fit cover, full-width on mobile), 15px clamped title with nsfw flag + visited gray, body excerpt, footer with `$` payout, votes/comments icons, reblog; NSFW warn bar, gray dimming, 100% power-up + Pinned badges, community-title substitution, 5-option sort dropdown, per-order empty states, spinner loading, short-page auto-load
- **Profile**: full-bleed cover banner (proxified 2048x512, white text + shadow, centered, stats row with divider links followers→posts→following, Joined + Active, Follow top-right/mobile-bottom), removed in-content tab bar, per-section empty states, FollowList as table + page-number pagination, NotificationsList legacy layout (pipe filters, avatars, unread dot, score-tinted rows, bold-text actions)
- **Misc pages**: communities explore as legacy table (search + rank/subs/new sort + SubscribeButton), subscriptions as simple list, search page (`#00FFC8` tabs, mobile-only input, two sort options, account results list), standalone `/login` form (28rem, placeholders, legacy button row), legacy 404 (steem icon + pipe menu), PostEditor de-labeled with category=first-tag

## Wave 3 — Post page
- **PostFull**: bordered card with 40rem centered header/body, 48px avatar author row with reputation + relative time + `(edited)`, 240%/800 title, tags below body in neutral chips (category excluded), legacy footer (Voting | Reblog icon | Reply | responses count | 4 inline share icons | copy link), schema.org microdata
- **Voting**: circular outline chevron icons (teal up/red down, fill on hover/voted, spinner while broadcasting), `$xx.xx` payout with details dropdown, "N votes" voters dropdown, weight slider opens on chevron click when enabled
- **Comments**: three-part bordered cards (48px avatar column, 62px indent, dotted reply lines), `[+]/[-]` collapse on the right, Voting in footer, gray-comment reveal (sunk to bottom), recursive nesting fix (depth ≥3 replies now render), depth-7 "Show more" link, gray sorting, top-right bold sort control, top reply editor, green **LOAD MORE COMMENTS** button (10/page)

## Wave 4 — Rails
- Right rail: `SidebarNewUsers` (logged out), `SidebarLinks` with live trending communities (logged in), `CommunityPane` on hive-* pages
- Mobile 60px bottom tab bar (Explore / My Profile / My Wallet, teal active underline)

## Verification
- `tsc --noEmit` clean, `next build` ✓
- `pnpm test:render` (legacy-vs-next render pipeline comparison) 31/31 pass
- eslint: zero issues in touched files (17 pre-existing errors in `app/api/**` and Reblog's existing effect pattern predate this PR)

## Known remaining gaps (documented, non-styling)
- SteemMarket coin widget: no market-data endpoint in the new stack (legacy injects it server-side)
- Pinned-post carousel, sidebar scroll-pinning, Headroom auto-hiding header: interaction mechanisms not ported
- Post-level pin/mute/edit/delete actions, full payout breakdown: out of functional scope
- Vote-weight slider doesn't auto-enable (legacy uses `net_vests > 1e6`, not available client-side; `enableSlider` prop exists)
