### PR TITLE
fix(deploy): listen on 8080 + serve /.well-known/healthcheck.json for EB openresty

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,12 +63,13 @@ COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 # Switch to non-root user
 USER nextjs
 
-# Expose port
-EXPOSE 3000
+# Expose port (8080 matches the EB openresty upstream for APP_TYPE=condenser;
+# can still be overridden with -e PORT=...)
+EXPOSE 8080
 
 # Set environment variables
 ENV NODE_ENV=production
-ENV PORT=3000
+ENV PORT=8080
 ENV HOSTNAME=0.0.0.0
 
 # Start the application

--- a/app/.well-known/healthcheck.json/route.ts
+++ b/app/.well-known/healthcheck.json/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from 'next/server';
+
+/**
+ * GET /.well-known/healthcheck.json
+ *
+ * Liveness probe consumed by the openresty sidecar (and through it the ELB
+ * health check) on the EB Docker deployment. Legacy condenser serves this
+ * exact path; any 200 response marks the instance healthy.
+ */
+export async function GET() {
+  return NextResponse.json({ status: 'ok' }, { status: 200 });
+}


### PR DESCRIPTION
## Problem

Deploying PR #3988 to `steemit-dev-condenser-001` failed the ELB health check and rolled back:

- The openresty sidecar health-checks the condenser container at a hardcoded upstream: `http://<condenser>:8080/.well-known/healthcheck.json`
- The Next.js standalone server listens on **3000**, and the app had **no such route** → `connect() failed (111: Connection refused)` in the openresty logs → instance never passed the health check → EB aborted the deployment and terminated the new instance (see the instance log bundle from the failed deploy)

## Fix

- `Dockerfile` (production stage): `ENV PORT=8080` / `EXPOSE 8080` to match the openresty upstream (still overridable with `-e PORT=...`)
- New route `app/.well-known/healthcheck.json/route.ts` returning `200 {"status":"ok"}`, matching the legacy condenser health-check contract consumed by openresty/ELB

## Verification

- `tsc --noEmit` clean
- Image `steemit/condenser:next-pr3988.1` built from this commit and redeployed to `steemit-dev-condenser-001`: environment is **Green / Ready**, and via SSM on the instance: openresty → condenser:8080 healthcheck returns **200**, direct condenser:8080 healthcheck returns **200**
