### PR TITLE
fix: add helmet mediaSrc CSP directive for IPFS video playback

### DIFF
--- a/config/custom-environment-variables.json
+++ b/config/custom-environment-variables.json
@@ -12,6 +12,7 @@
       "objectSrc": "SDC_HELMET_OBJECTSRC",
       "scriptSrc": "SDC_HELMET_SCRIPTSRC",
       "styleSrc": "SDC_HELMET_STYLESRC",
+      "mediaSrc": "SDC_HELMET_MEDIASRC",
       "reportUri": "SDC_HELMET_REPORTURI"
     }
   },

--- a/config/default.json
+++ b/config/default.json
@@ -13,6 +13,7 @@
             "objectSrc": "'self' application/pdf",
             "scriptSrc": "'self' www.google-analytics.com www.googletagmanager.com connect.facebook.net *.tronads.io",
             "styleSrc": "'self' fonts.googleapis.com 'unsafe-inline'",
+            "mediaSrc": "'self' gateway.pinata.cloud",
             "reportUri": "/api/v1/csp_violation"
         },
         "reportOnly": false,

--- a/config/development.json
+++ b/config/development.json
@@ -13,6 +13,7 @@
             "objectSrc": "'self' application/pdf",
             "scriptSrc": "'self' www.google-analytics.com www.googletagmanager.com connect.facebook.net *.tronads.io",
             "styleSrc": "'self' fonts.googleapis.com 'unsafe-inline'",
+            "mediaSrc": "'self' gateway.pinata.cloud",
             "reportUri": "/api/v1/csp_violation"
         },
         "reportOnly": false,

--- a/config/production.json
+++ b/config/production.json
@@ -13,6 +13,7 @@
             "objectSrc": "'self' application/pdf",
             "scriptSrc": "'self' www.google-analytics.com www.googletagmanager.com connect.facebook.net *.tronads.io",
             "styleSrc": "'self' fonts.googleapis.com 'unsafe-inline'",
+            "mediaSrc": "'self' gateway.pinata.cloud",
             "reportUri": "/api/v1/csp_violation"
         },
         "reportOnly": false,


### PR DESCRIPTION
### Description

This PR fixes a blocking Content Security Policy (CSP) issue introduced with the new native IPFS video player. 

During testing on the dev environment (`steemitdev.com`), the browser refused to load the video assets from the IPFS gateway, throwing the following CSP error:
> `Refused to load https://gateway.pinata.cloud/... because it appears in neither the media-src directive nor the default-src directive of the Content Security Policy.`

Because the `media-src` directive (which controls where media such as `<audio>` and `<video>` tags can be loaded from) was not declared in the `koa-helmet` security configuration, browsers defaulted back to the strict `default-src` directive which does not list the IPFS gateway.

### Changes implemented:

1. **Declared `media-src` directive:** Added `"mediaSrc": "'self' gateway.pinata.cloud"` to the helmet configuration across all environment configs:
   * `config/default.json`
   * `config/development.json`
   * `config/production.json`
2. **Environment configuration binding:** Mapped the directive to a new environment variable `"mediaSrc": "SDC_HELMET_MEDIASRC"` in `config/custom-environment-variables.json`. This allows system administrators to easily configure or expand allowed IPFS gateways in production/staging environments dynamically using standard environment variables without altering the code.

All existing unit tests are passing successfully.
