### PR TITLE
fix(security): resolve whitehat findings F35/F36/F47 (title XSS, sanitizer stack, open redirect)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15850,11 +15850,16 @@
           "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
         },
         "postcss": {
-          "version": "8.5.26",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
-          "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+          "version": "8.4.49",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz",
+          "integrity": "sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==",
           "requires": {
             "nanoid": "^3.3.17",
+            "picocolors": "^1.1.1",
+            "source-map-js": "^1.2.1"
+          },
+          "dependencies": {
+            "nanoid": "^3.3.7",
             "picocolors": "^1.1.1",
             "source-map-js": "^1.2.1"
           }

--- a/package-lock.json
+++ b/package-lock.json
@@ -339,7 +339,8 @@
         "ws": {
           "version": "7.4.6",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.4.6.tgz",
-          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A=="
+          "integrity": "sha512-YmhHDO4MzaDLB+M9ym/mDA5z0naX8j7SIlT8f8z+I0VtzsRbekxEutHSme7NPS2qE8StCYQNUnfWdXta/Yu85A==",
+          "requires": {}
         }
       }
     },
@@ -490,7 +491,8 @@
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/@icons/material/-/material-0.2.4.tgz",
       "integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@steem/crypto-session": {
       "version": "git+https://github.com/steemit/crypto-session.git#83a90b319ce5bc6a70362d52a15a815de7e729bb",
@@ -726,7 +728,8 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "ansi-regex": {
           "version": "3.0.1",
@@ -1284,6 +1287,11 @@
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz",
       "integrity": "sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ=="
     },
+    "@xmldom/xmldom": {
+      "version": "0.8.10",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz",
+      "integrity": "sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw=="
+    },
     "abab": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.6.tgz",
@@ -1425,7 +1433,8 @@
     "ajv-keywords": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-2.1.1.tgz",
-      "integrity": "sha512-ZFztHzVRdGLAzJmpUT9LNFLe1YiVOEylcaNpEutM26PVTCtOD919IMfD01CgbRouB42Dd9atjx1HseC15DgOZA=="
+      "integrity": "sha512-ZFztHzVRdGLAzJmpUT9LNFLe1YiVOEylcaNpEutM26PVTCtOD919IMfD01CgbRouB42Dd9atjx1HseC15DgOZA==",
+      "requires": {}
     },
     "align-text": {
       "version": "0.1.4",
@@ -1577,6 +1586,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha512-dtXTVMkh6VkEEA7OhXnN1Ecb8aAGFdZ1LFxtOCoqj4qkyOJMt7+qs6Ahdy6p/NQCPYsRSXXivhSB/J5E9jmYKA==",
+      "devOptional": true,
       "requires": {
         "arr-flatten": "^1.0.1"
       }
@@ -1584,12 +1594,14 @@
     "arr-flatten": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg=="
+      "integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
+      "devOptional": true
     },
     "arr-union": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q=="
+      "integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
+      "devOptional": true
     },
     "array-buffer-byte-length": {
       "version": "1.0.0",
@@ -1640,7 +1652,8 @@
     "array-unique": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.2.1.tgz",
-      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg=="
+      "integrity": "sha512-G2n5bG5fSUCpnsXz4+8FUkYsGPkNfLn9YvS66U5qbTIXI2Ynnlo4Bi42bWv+omKUCqz+ejzfClwne0alJWJPhg==",
+      "devOptional": true
     },
     "array.prototype.find": {
       "version": "2.2.1",
@@ -1747,7 +1760,8 @@
     "assign-symbols": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw=="
+      "integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
+      "devOptional": true
     },
     "ast-types": {
       "version": "0.11.7",
@@ -2493,6 +2507,7 @@
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-decorators-legacy/-/babel-plugin-transform-decorators-legacy-1.3.4.tgz",
       "integrity": "sha512-0Rk/D1ZSdFw9lHwklOhCelGS7ZCF4J55QLYrJ+OGnbIGRYN9zR0YbAcnE61G9zth1AbwQ5/IkyuQmeHCC+cbXg==",
+      "dev": true,
       "requires": {
         "babel-plugin-syntax-decorators": "^6.1.18",
         "babel-runtime": "^6.2.0",
@@ -3268,6 +3283,7 @@
       "version": "0.11.2",
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
+      "devOptional": true,
       "requires": {
         "cache-base": "^1.0.1",
         "class-utils": "^0.3.5",
@@ -3282,6 +3298,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+          "devOptional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -3290,6 +3307,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "devOptional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -3298,6 +3316,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "devOptional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -3306,6 +3325,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "devOptional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -3315,12 +3335,14 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+          "devOptional": true
         },
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "devOptional": true
         }
       }
     },
@@ -3495,6 +3517,7 @@
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha512-xU7bpz2ytJl1bH9cgIurjpg/n8Gohy9GTw81heDYLJQ4RU60dlyJsa+atVF2pI0yMMvKxI9HkKwjePCj5XI1hw==",
+      "devOptional": true,
       "requires": {
         "expand-range": "^1.8.1",
         "preserve": "^0.2.0",
@@ -3706,6 +3729,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
+      "devOptional": true,
       "requires": {
         "collection-visit": "^1.0.0",
         "component-emitter": "^1.2.1",
@@ -3721,7 +3745,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+          "devOptional": true
         }
       }
     },
@@ -4073,6 +4098,7 @@
       "version": "0.3.6",
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
+      "devOptional": true,
       "requires": {
         "arr-union": "^3.1.0",
         "define-property": "^0.2.5",
@@ -4084,6 +4110,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "devOptional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -4091,7 +4118,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+          "devOptional": true
         }
       }
     },
@@ -4242,7 +4270,8 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/co-supertest/-/co-supertest-0.0.10.tgz",
       "integrity": "sha512-uJXzzdYdD3YtZWbgJp8DuLg9bG4gPdU3YqsJknhK6kFdQhXxRbQBzsqCylEt9kMINrRI4MRP0CazLjvyNKGn2g==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "coa": {
       "version": "1.0.4",
@@ -4266,6 +4295,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
+      "devOptional": true,
       "requires": {
         "map-visit": "^1.0.0",
         "object-visit": "^1.0.0"
@@ -4344,7 +4374,8 @@
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
-      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg=="
+      "integrity": "sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==",
+      "devOptional": true
     },
     "composition": {
       "version": "2.3.0",
@@ -4525,7 +4556,8 @@
     "copy-descriptor": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw=="
+      "integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
+      "devOptional": true
     },
     "copy-to-clipboard": {
       "version": "3.3.3",
@@ -5070,6 +5102,11 @@
       "resolved": "https://registry.npmjs.org/date-names/-/date-names-0.1.13.tgz",
       "integrity": "sha512-IxxoeD9tdx8pXVcmqaRlPvrXIsSrSrIZzfzlOkm9u+hyzKp5Wk/odt9O/gd7Ockzy8n/WHeEpTVJ2bF3mMV4LA=="
     },
+    "dayjs": {
+      "version": "1.11.23",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz",
+      "integrity": "sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ=="
+    },
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -5086,7 +5123,8 @@
     "decode-uri-component": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
-      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="
+      "integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+      "devOptional": true
     },
     "dedent": {
       "version": "0.7.0",
@@ -5113,6 +5151,11 @@
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true
     },
+    "deepmerge": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz",
+      "integrity": "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="
+    },
     "default-require-extensions": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/default-require-extensions/-/default-require-extensions-1.0.0.tgz",
@@ -5135,6 +5178,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
       "integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
+      "devOptional": true,
       "requires": {
         "is-descriptor": "^1.0.2",
         "isobject": "^3.0.1"
@@ -5144,6 +5188,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "devOptional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -5152,6 +5197,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "devOptional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -5160,6 +5206,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "devOptional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -5169,12 +5216,14 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+          "devOptional": true
         },
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "devOptional": true
         }
       }
     },
@@ -5361,9 +5410,9 @@
       "optional": true
     },
     "domutils": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.1.0.tgz",
-      "integrity": "sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==",
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+      "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
       "requires": {
         "dom-serializer": "^2.0.0",
         "domelementtype": "^2.3.0",
@@ -6082,7 +6131,8 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-4.1.2.tgz",
       "integrity": "sha512-CXj4vPuVPac2pahcvDlMR/C+jRFQLWyK0jCgYqyrMCjL5o9vL6UYCio/Yb6vVWdzOH8BKcSTT6rTe0a1MvzdNg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-import": {
       "version": "2.7.0",
@@ -6291,7 +6341,8 @@
     "estraverse-fb": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/estraverse-fb/-/estraverse-fb-1.3.2.tgz",
-      "integrity": "sha512-wp3lfRrWy5EQD9TqesuYM1SKVP4ERT0cUatb4e8Vznf4K5IOpREhuyXZxGj3a9s9mvX5vGZKNHA4R9D4kp9Q9A=="
+      "integrity": "sha512-wp3lfRrWy5EQD9TqesuYM1SKVP4ERT0cUatb4e8Vznf4K5IOpREhuyXZxGj3a9s9mvX5vGZKNHA4R9D4kp9Q9A==",
+      "requires": {}
     },
     "esutils": {
       "version": "2.0.3",
@@ -6433,6 +6484,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha512-hxx03P2dJxss6ceIeri9cmYOT4SRs3Zk3afZwWpOsRqLqprhTR8u++SlC+sFGsQr7WGFPdMF7Gjc1njDLDK6UA==",
+      "devOptional": true,
       "requires": {
         "is-posix-bracket": "^0.1.0"
       }
@@ -6441,6 +6493,7 @@
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha512-AFASGfIlnIbkKPQwX1yHaDjFvh/1gyKJODme52V6IORh69uEYgZp0o9C+qsIGNVEiuuhQU0CSSl++Rlegg1qvA==",
+      "devOptional": true,
       "requires": {
         "fill-range": "^2.1.0"
       }
@@ -6543,6 +6596,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
       "integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
+      "devOptional": true,
       "requires": {
         "assign-symbols": "^1.0.0",
         "is-extendable": "^1.0.1"
@@ -6552,6 +6606,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "devOptional": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -6584,6 +6639,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha512-1FOj1LOwn42TMrruOHGt18HemVnbwAmAak7krWk+wa93KXxGbK+2jpezm+ytJYDaBX0/SPLZFHKM7m+tKobWGg==",
+      "devOptional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -6714,11 +6770,6 @@
       "resolved": "https://registry.npmjs.org/feature-policy/-/feature-policy-0.3.0.tgz",
       "integrity": "sha512-ZtijOTFN7TzCujt1fnNhfWPFPSHeZkesff9AXZj+UEjYBynWNUIYpC87Ve4wHzyexQsImicLu7WsC2LHq7/xrQ=="
     },
-    "fflate": {
-      "version": "0.4.8",
-      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
-      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
-    },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
@@ -6785,7 +6836,8 @@
     "filename-regex": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/filename-regex/-/filename-regex-2.0.1.tgz",
-      "integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ=="
+      "integrity": "sha512-BTCqyBaWBTsauvnHiE8i562+EdJj+oUpkqWp2R1iCoR8f6oo8STRu3of7WJJ0TqWtxN50a5YFpzYK4Jj9esYfQ==",
+      "devOptional": true
     },
     "fileset": {
       "version": "2.0.3",
@@ -6807,6 +6859,7 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
       "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
+      "devOptional": true,
       "requires": {
         "is-number": "^2.1.0",
         "isobject": "^2.0.0",
@@ -6918,6 +6971,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha512-SKmowqGTJoPzLO1T0BBJpkfp3EMacCMOuH40hOUbrbzElVktk4DioXVM99QkLCyKoiuOmyjgcWMpVz2xjE7LZw==",
+      "devOptional": true,
       "requires": {
         "for-in": "^1.0.1"
       }
@@ -6969,6 +7023,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
+      "devOptional": true,
       "requires": {
         "map-cache": "^0.2.2"
       }
@@ -7127,7 +7182,8 @@
     "get-value": {
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA=="
+      "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
+      "devOptional": true
     },
     "get-window": {
       "version": "1.1.2",
@@ -7208,6 +7264,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha512-ab1S1g1EbO7YzauaJLkgLp7DZVAqj9M/dvKlTt8DkXA2tiOIcSMrlVI2J1RZyB5iJVccEscjGn+kpOG9788MHA==",
+      "devOptional": true,
       "requires": {
         "glob-parent": "^2.0.0",
         "is-glob": "^2.0.0"
@@ -7217,6 +7274,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha512-JDYOvfxio/t42HKdxkAYaCiBN7oYiuxykOxKxdaUW5Qn0zaYN3gRQWolrwdnf0shM9/EP0ebuuTmyoXNr1cC5w==",
+      "devOptional": true,
       "requires": {
         "is-glob": "^2.0.0"
       }
@@ -7418,6 +7476,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
+      "devOptional": true,
       "requires": {
         "get-value": "^2.0.6",
         "has-values": "^1.0.0",
@@ -7427,7 +7486,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+          "devOptional": true
         }
       }
     },
@@ -7435,6 +7495,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
+      "devOptional": true,
       "requires": {
         "is-number": "^3.0.0",
         "kind-of": "^4.0.0"
@@ -7443,12 +7504,14 @@
         "is-buffer": {
           "version": "1.1.6",
           "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+          "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+          "devOptional": true
         },
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+          "devOptional": true,
           "requires": {
             "kind-of": "^3.0.2"
           },
@@ -7457,6 +7520,7 @@
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+              "devOptional": true,
               "requires": {
                 "is-buffer": "^1.1.5"
               }
@@ -7467,6 +7531,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
+          "devOptional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -7665,6 +7730,14 @@
         }
       }
     },
+    "http_ece": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-0.5.2.tgz",
+      "integrity": "sha512-H76QVCahvvdgQqeb0aMe2XF7S0MiWRtEShLzDveGt8XQM9vw9jSxPYdI2RinSWyqspz0X4Nz07UPbzAxsooUHQ==",
+      "requires": {
+        "urlsafe-base64": "~1.0.0"
+      }
+    },
     "http-assert": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/http-assert/-/http-assert-1.5.0.tgz",
@@ -7745,14 +7818,6 @@
         "assert-plus": "^1.0.0",
         "jsprim": "^1.2.2",
         "sshpk": "^1.7.0"
-      }
-    },
-    "http_ece": {
-      "version": "0.5.2",
-      "resolved": "https://registry.npmjs.org/http_ece/-/http_ece-0.5.2.tgz",
-      "integrity": "sha512-H76QVCahvvdgQqeb0aMe2XF7S0MiWRtEShLzDveGt8XQM9vw9jSxPYdI2RinSWyqspz0X4Nz07UPbzAxsooUHQ==",
-      "requires": {
-        "urlsafe-base64": "~1.0.0"
       }
     },
     "https-browserify": {
@@ -8217,6 +8282,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
       "integrity": "sha512-e1BM1qnDbMRG3ll2U9dSK0UMHuWOs3pY3AtcFsmvwPtKL3MML/Q86i+GilLfvqEs4GW+ExB91tQ3Ig9noDIZ+A==",
+      "devOptional": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -8320,6 +8386,7 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
       "integrity": "sha512-+w9D5ulSoBNlmw9OHn3U2v51SyoCd0he+bB3xMl62oijhrspxowjU+AIcDY0N3iEJbUEkB15IlMASQsxYigvXg==",
+      "devOptional": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -8349,6 +8416,7 @@
       "version": "0.1.6",
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
       "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
+      "devOptional": true,
       "requires": {
         "is-accessor-descriptor": "^0.1.6",
         "is-data-descriptor": "^0.1.4",
@@ -8358,7 +8426,8 @@
         "kind-of": {
           "version": "5.1.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-5.1.0.tgz",
-          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw=="
+          "integrity": "sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==",
+          "devOptional": true
         }
       }
     },
@@ -8381,7 +8450,8 @@
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
-      "integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg=="
+      "integrity": "sha512-9YclgOGtN/f8zx0Pr4FQYMdibBiTaH3sn52vjYip4ZSf6C4/6RfTEZ+MR4GvKhCxdPh21Bg42/WL55f6KSnKpg==",
+      "devOptional": true
     },
     "is-empty": {
       "version": "1.2.0",
@@ -8392,6 +8462,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha512-0EygVC5qPvIyb+gSz7zdD5/AAoS6Qrx1e//6N4yv4oNm30kqvdmG66oZFWVlQHUWe5OjP08FuTw2IdT0EOTcYA==",
+      "devOptional": true,
       "requires": {
         "is-primitive": "^2.0.0"
       }
@@ -8404,7 +8475,8 @@
     "is-extglob": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-1.0.0.tgz",
-      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww=="
+      "integrity": "sha512-7Q+VbVafe6x2T+Tu6NcOf6sRklazEPmBoB3IWk3WdGZM2iGUwU/Oe3Wtq5lSEkDTTlpp8yx+5t4pzO/i9Ty1ww==",
+      "devOptional": true
     },
     "is-finite": {
       "version": "1.1.0",
@@ -8435,6 +8507,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha512-a1dBeB19NXsf/E0+FHqkagizel/LQw2DjSQpvQrj3zT+jYPpaUCryPnrQajXKFLCMuf4I6FhRpaGtw4lPrG6Eg==",
+      "devOptional": true,
       "requires": {
         "is-extglob": "^1.0.0"
       }
@@ -8462,6 +8535,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha512-QUzH43Gfb9+5yckcrSA0VBDwEtDUchrk4F6tfJZQuNzDJbEDB9cZNzSfXGQ1jqmdDY/kl41lUOWM9syA8z8jlg==",
+      "devOptional": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -8527,12 +8601,14 @@
     "is-posix-bracket": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/is-posix-bracket/-/is-posix-bracket-0.1.1.tgz",
-      "integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ=="
+      "integrity": "sha512-Yu68oeXJ7LeWNmZ3Zov/xg/oDBnBK2RNxwYY1ilNJX+tKKZqgPK+qOn/Gs9jEu66KDY9Netf5XLKNGzas/vPfQ==",
+      "devOptional": true
     },
     "is-primitive": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/is-primitive/-/is-primitive-2.0.0.tgz",
-      "integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q=="
+      "integrity": "sha512-N3w1tFaRfk3UrPfqeRyD+GYDASU3W5VinKhlORy8EWVf/sIdDL9GAcew85XmktCfH+ngG7SRXEVDoO18WMdB/Q==",
+      "devOptional": true
     },
     "is-promise": {
       "version": "2.2.2",
@@ -8652,7 +8728,8 @@
     "is-windows": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="
+      "integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
+      "devOptional": true
     },
     "is-wsl": {
       "version": "1.1.0",
@@ -8679,6 +8756,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+      "devOptional": true,
       "requires": {
         "isarray": "1.0.0"
       }
@@ -10540,6 +10618,14 @@
         "webpack-hot-middleware": "2.x"
       }
     },
+    "launder": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz",
+      "integrity": "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==",
+      "requires": {
+        "dayjs": "^1.11.7"
+      }
+    },
     "lazy-cache": {
       "version": "0.2.7",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-0.2.7.tgz",
@@ -11340,7 +11426,8 @@
     "map-cache": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg=="
+      "integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
+      "devOptional": true
     },
     "map-obj": {
       "version": "1.0.1",
@@ -11351,6 +11438,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
+      "devOptional": true,
       "requires": {
         "object-visit": "^1.0.0"
       }
@@ -11396,7 +11484,8 @@
     "math-random": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.4.tgz",
-      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A=="
+      "integrity": "sha512-rUxjysqif/BZQH2yhd5Aaq7vXMSx9NdEsQcyA07uEzIvxgI7zIr33gGsh+RU0/XjmQpCW7RsVof1vlkvQVCK5A==",
+      "devOptional": true
     },
     "md5.js": {
       "version": "1.3.5",
@@ -11602,6 +11691,7 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha512-LnU2XFEk9xxSJ6rfgAry/ty5qwUTyHYOBU0g4R6tIw5ljwgGIBmiKhRWLw5NpMOnrgUNcDJ4WMp8rl3sYVHLNA==",
+      "devOptional": true,
       "requires": {
         "arr-diff": "^2.0.0",
         "array-unique": "^0.2.1",
@@ -11686,6 +11776,7 @@
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
       "integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
+      "devOptional": true,
       "requires": {
         "for-in": "^1.0.2",
         "is-extendable": "^1.0.1"
@@ -11695,6 +11786,7 @@
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
+          "devOptional": true,
           "requires": {
             "is-plain-object": "^2.0.4"
           }
@@ -11786,10 +11878,16 @@
       "resolved": "https://registry.npmjs.org/nan/-/nan-2.17.0.tgz",
       "integrity": "sha512-2ZTgtl0nJsO0KQCjEpxcIr5D+Yv90plTitZt9JBfQvVJDS5seMl3FOvsh3+9CoYWXf/1l5OaZzzF6nDm4cagaQ=="
     },
+    "nanoid": {
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="
+    },
     "nanomatch": {
       "version": "1.2.13",
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
       "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
+      "devOptional": true,
       "requires": {
         "arr-diff": "^4.0.0",
         "array-unique": "^0.3.2",
@@ -11807,17 +11905,20 @@
         "arr-diff": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-          "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA=="
+          "integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
+          "devOptional": true
         },
         "array-unique": {
           "version": "0.3.2",
           "resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-          "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ=="
+          "integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
+          "devOptional": true
         },
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "devOptional": true
         }
       }
     },
@@ -12108,6 +12209,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha512-3pKJwH184Xo/lnH6oyP1q2pMd7HcypqqmRs91/6/i2CGtWwIKGCkOOMTm/zXbgTEWHw1uNpNi/igc3ePOYHb6w==",
+      "devOptional": true,
       "requires": {
         "remove-trailing-separator": "^1.0.1"
       }
@@ -12211,6 +12313,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
+      "devOptional": true,
       "requires": {
         "copy-descriptor": "^0.1.0",
         "define-property": "^0.2.5",
@@ -12221,6 +12324,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "devOptional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -12250,6 +12354,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
+      "devOptional": true,
       "requires": {
         "isobject": "^3.0.0"
       },
@@ -12257,7 +12362,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+          "devOptional": true
         }
       }
     },
@@ -12313,6 +12419,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha512-UiAM5mhmIuKLsOvrL+B0U2d1hXHF3bFYWIuH1LMpuV2EJEHG1Ntz06PgLEHjm6VFd87NpH8rastvPoyv6UW2fA==",
+      "devOptional": true,
       "requires": {
         "for-own": "^0.1.4",
         "is-extendable": "^0.1.1"
@@ -12322,6 +12429,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
+      "devOptional": true,
       "requires": {
         "isobject": "^3.0.1"
       },
@@ -12329,7 +12437,8 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+          "devOptional": true
         }
       }
     },
@@ -12566,6 +12675,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha512-FC5TeK0AwXzq3tUBFtH74naWkPQCEWs4K+xMxWZBlKDWu0bVHXGZa+KKqxKidd7xwhdZ19ZNuF2uO1M/r196HA==",
+      "devOptional": true,
       "requires": {
         "glob-base": "^0.3.0",
         "is-dotfile": "^1.0.0",
@@ -12580,6 +12690,11 @@
       "requires": {
         "error-ex": "^1.2.0"
       }
+    },
+    "parse-srcset": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz",
+      "integrity": "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="
     },
     "parse5": {
       "version": "7.1.2",
@@ -12616,7 +12731,8 @@
     "pascalcase": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw=="
+      "integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
+      "devOptional": true
     },
     "passthrough-counter": {
       "version": "1.0.0",
@@ -12709,6 +12825,11 @@
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
+    "picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -12766,7 +12887,8 @@
     "posix-character-classes": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg=="
+      "integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
+      "devOptional": true
     },
     "postcss": {
       "version": "5.2.18",
@@ -12946,7 +13068,8 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "ansi-styles": {
           "version": "3.2.1",
@@ -13470,7 +13593,8 @@
     "preserve": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/preserve/-/preserve-0.2.0.tgz",
-      "integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ=="
+      "integrity": "sha512-s/46sYeylUfHNjI+sA/78FAHlmIuKqI9wNnzEOGehAlUUYeObv5C2mOinXBjyUyWmJ2SfcS2/ydApH4hTF4WXQ==",
+      "devOptional": true
     },
     "prettier": {
       "version": "1.8.2",
@@ -13763,6 +13887,7 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
       "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
+      "devOptional": true,
       "requires": {
         "is-number": "^4.0.0",
         "kind-of": "^6.0.0",
@@ -13772,12 +13897,14 @@
         "is-number": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ=="
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "devOptional": true
         },
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "devOptional": true
         }
       }
     },
@@ -14019,7 +14146,8 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/react-icon-base/-/react-icon-base-2.1.0.tgz",
       "integrity": "sha512-9wwKJa2LB8ujtJB5MAXYYEM7JfYThZTj0YnfGxzLLWkifaLIGc7iTde2EpJ7ka5MjneRHnlxbIn5VV9k2WjUVA==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-icons": {
       "version": "2.2.7",
@@ -14162,7 +14290,8 @@
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/react-onclickoutside/-/react-onclickoutside-6.13.0.tgz",
       "integrity": "sha512-ty8So6tcUpIb+ZE+1HAhbLROvAIJYyJe/1vRrrcmW+jLsaM+/powDRqxzo6hSh9CuRZGSL1Q8mvcF5WRD93a0A==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "react-overlays": {
       "version": "0.7.2",
@@ -14338,7 +14467,8 @@
     "react-timeago": {
       "version": "3.4.3",
       "resolved": "https://registry.npmjs.org/react-timeago/-/react-timeago-3.4.3.tgz",
-      "integrity": "sha512-krYNg2r6XO2anGR+5xhwWu3RvpJ6lSRBdeF8i3xwdGb2Uvpl7uf52Z69Ahf9ie/7hne0ZdOe9CZdLX4kt675iw=="
+      "integrity": "sha512-krYNg2r6XO2anGR+5xhwWu3RvpJ6lSRBdeF8i3xwdGb2Uvpl7uf52Z69Ahf9ie/7hne0ZdOe9CZdLX4kt675iw==",
+      "requires": {}
     },
     "react-transform-catch-errors": {
       "version": "1.0.2",
@@ -14871,7 +15001,8 @@
       "version": "2.13.5",
       "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.5.tgz",
       "integrity": "sha512-QQ9BRy77oURHMdGys9rfQcCQDzXZ1T4oW+eUyE5Cg7DNVau69HJzc4YNDMOmpi0Dzpi1zOQgQ2rUpgJta4Lfqg==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "redux-form": {
       "version": "5.3.4",
@@ -14941,6 +15072,7 @@
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
+      "devOptional": true,
       "requires": {
         "is-equal-shallow": "^0.1.3"
       }
@@ -14949,15 +15081,11 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
       "integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
+      "devOptional": true,
       "requires": {
         "extend-shallow": "^3.0.2",
         "safe-regex": "^1.1.0"
       }
-    },
-    "regexp-quote": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/regexp-quote/-/regexp-quote-0.0.0.tgz",
-      "integrity": "sha512-R9elSUXyJeACXh7raO50vvfZyTdQ1bxYm0KlN2XD8eEzPAnedJTHMk4F7lCaggu9DrfUWP3CDUjAgyW1f2DpgA=="
     },
     "regexp.prototype.flags": {
       "version": "1.5.0",
@@ -15035,12 +15163,14 @@
     "remove-trailing-separator": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
-      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw=="
+      "integrity": "sha512-/hS+Y0u3aOfIETiaiirUFwDBDzmXPvO+jAfKTitUngIPzdKc6Z0LoFjM/CK5PL4C+eKwHohlHAb6H0VFfmmUsw==",
+      "devOptional": true
     },
     "repeat-element": {
       "version": "1.1.4",
       "resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
-      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ=="
+      "integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
+      "devOptional": true
     },
     "repeat-string": {
       "version": "1.6.1",
@@ -15200,7 +15330,8 @@
     "resolve-url": {
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
-      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg=="
+      "integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
+      "devOptional": true
     },
     "restore-cursor": {
       "version": "2.0.0",
@@ -15215,7 +15346,8 @@
     "ret": {
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg=="
+      "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
+      "devOptional": true
     },
     "retry": {
       "version": "0.12.0",
@@ -15341,6 +15473,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
       "integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
+      "devOptional": true,
       "requires": {
         "ret": "~0.1.10"
       }
@@ -15677,74 +15810,53 @@
       }
     },
     "sanitize-html": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-1.14.1.tgz",
-      "integrity": "sha512-jNDMpBFd1vqwwOh6Wmmyt49cGSkfJ+YjpUbE0i2cw4s5jXNFr4FexRL/UBqWKRXdfGHmw7/NeULVaHp+zIAYBg==",
+      "version": "2.17.5",
+      "resolved": "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz",
+      "integrity": "sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==",
       "requires": {
-        "htmlparser2": "^3.9.0",
-        "regexp-quote": "0.0.0",
-        "xtend": "^4.0.0"
+        "deepmerge": "^4.2.2",
+        "escape-string-regexp": "^4.0.0",
+        "htmlparser2": "^10.1.0",
+        "is-plain-object": "^5.0.0",
+        "launder": "^1.7.1",
+        "parse-srcset": "^1.0.2",
+        "postcss": "^8.3.11"
       },
       "dependencies": {
-        "dom-serializer": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-0.2.2.tgz",
-          "integrity": "sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==",
-          "requires": {
-            "domelementtype": "^2.0.1",
-            "entities": "^2.0.0"
-          },
-          "dependencies": {
-            "domelementtype": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
-              "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="
-            },
-            "entities": {
-              "version": "2.2.0",
-              "resolved": "https://registry.npmjs.org/entities/-/entities-2.2.0.tgz",
-              "integrity": "sha512-p92if5Nz619I0w+akJrLZH0MX0Pb5DX39XOwQTtXSdQQOaYH03S1uIQp4mhOZtAXrxq4ViO67YTiLBo2638o9A=="
-            }
-          }
-        },
-        "domelementtype": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-1.3.1.tgz",
-          "integrity": "sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w=="
-        },
-        "domhandler": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-2.4.2.tgz",
-          "integrity": "sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==",
-          "requires": {
-            "domelementtype": "1"
-          }
-        },
-        "domutils": {
-          "version": "1.7.0",
-          "resolved": "https://registry.npmjs.org/domutils/-/domutils-1.7.0.tgz",
-          "integrity": "sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==",
-          "requires": {
-            "dom-serializer": "0",
-            "domelementtype": "1"
-          }
-        },
         "entities": {
-          "version": "1.1.2",
-          "resolved": "https://registry.npmjs.org/entities/-/entities-1.1.2.tgz",
-          "integrity": "sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w=="
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+          "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="
+        },
+        "escape-string-regexp": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+          "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
         },
         "htmlparser2": {
-          "version": "3.10.1",
-          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.10.1.tgz",
-          "integrity": "sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==",
+          "version": "10.1.0",
+          "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+          "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
           "requires": {
-            "domelementtype": "^1.3.1",
-            "domhandler": "^2.3.0",
-            "domutils": "^1.5.1",
-            "entities": "^1.1.1",
-            "inherits": "^2.0.1",
-            "readable-stream": "^3.1.1"
+            "domelementtype": "^2.3.0",
+            "domhandler": "^5.0.3",
+            "domutils": "^3.2.2",
+            "entities": "^7.0.1"
+          }
+        },
+        "is-plain-object": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
+          "integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="
+        },
+        "postcss": {
+          "version": "8.5.26",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz",
+          "integrity": "sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==",
+          "requires": {
+            "nanoid": "^3.3.17",
+            "picocolors": "^1.1.1",
+            "source-map-js": "^1.2.1"
           }
         }
       }
@@ -15963,6 +16075,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
       "integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
+      "devOptional": true,
       "requires": {
         "extend-shallow": "^2.0.1",
         "is-extendable": "^0.1.1",
@@ -15974,6 +16087,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+          "devOptional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -16139,7 +16253,8 @@
     "slate-trailing-block": {
       "version": "0.2.4",
       "resolved": "https://registry.npmjs.org/slate-trailing-block/-/slate-trailing-block-0.2.4.tgz",
-      "integrity": "sha512-O/1F8RQ6kHBX2H+0gASWRuKsGNcwGylXkrOYIHAaVYnzGVmrBjJ6f07U1Rlq7o1Izqg6LcVZ3+Ts+X3hUXAFHg=="
+      "integrity": "sha512-O/1F8RQ6kHBX2H+0gASWRuKsGNcwGylXkrOYIHAaVYnzGVmrBjJ6f07U1Rlq7o1Izqg6LcVZ3+Ts+X3hUXAFHg==",
+      "requires": {}
     },
     "slice-ansi": {
       "version": "1.0.0",
@@ -16162,6 +16277,7 @@
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
       "integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
+      "devOptional": true,
       "requires": {
         "base": "^0.11.1",
         "debug": "^2.2.0",
@@ -16177,6 +16293,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "devOptional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -16185,6 +16302,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
           "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+          "devOptional": true,
           "requires": {
             "is-extendable": "^0.1.0"
           }
@@ -16195,6 +16313,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
+      "devOptional": true,
       "requires": {
         "define-property": "^1.0.0",
         "isobject": "^3.0.0",
@@ -16205,6 +16324,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
           "integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
+          "devOptional": true,
           "requires": {
             "is-descriptor": "^1.0.0"
           }
@@ -16213,6 +16333,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
           "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
+          "devOptional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -16221,6 +16342,7 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
           "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
+          "devOptional": true,
           "requires": {
             "kind-of": "^6.0.0"
           }
@@ -16229,6 +16351,7 @@
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
           "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
+          "devOptional": true,
           "requires": {
             "is-accessor-descriptor": "^1.0.0",
             "is-data-descriptor": "^1.0.0",
@@ -16238,12 +16361,14 @@
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+          "devOptional": true
         },
         "kind-of": {
           "version": "6.0.3",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="
+          "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+          "devOptional": true
         }
       }
     },
@@ -16251,6 +16376,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
+      "devOptional": true,
       "requires": {
         "kind-of": "^3.2.0"
       }
@@ -16273,10 +16399,16 @@
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
       "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ=="
     },
+    "source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="
+    },
     "source-map-resolve": {
       "version": "0.5.3",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
       "integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
+      "devOptional": true,
       "requires": {
         "atob": "^2.1.2",
         "decode-uri-component": "^0.2.0",
@@ -16296,7 +16428,8 @@
     "source-map-url": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
-      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw=="
+      "integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
+      "devOptional": true
     },
     "spdx-correct": {
       "version": "3.2.0",
@@ -16335,6 +16468,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
+      "devOptional": true,
       "requires": {
         "extend-shallow": "^3.0.0"
       }
@@ -16411,6 +16545,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
+      "devOptional": true,
       "requires": {
         "define-property": "^0.2.5",
         "object-copy": "^0.1.0"
@@ -16420,6 +16555,7 @@
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
+          "devOptional": true,
           "requires": {
             "is-descriptor": "^0.1.0"
           }
@@ -16591,6 +16727,14 @@
       "resolved": "https://registry.npmjs.org/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz",
       "integrity": "sha512-R3f198pcvnB+5IpnBlRkphuE9n46WyVl8I39W/ZUTZLz4nqSP/oLYUrcnJrw462Ds8he4YKMov2efsTIw1BDGQ=="
     },
+    "string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "requires": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
     "string-length": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-2.0.0.tgz",
@@ -16694,14 +16838,6 @@
         "call-bind": "^1.0.2",
         "define-properties": "^1.1.4",
         "es-abstract": "^1.20.4"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "stringify-object": {
@@ -16911,7 +17047,8 @@
     "svg-inline-react": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/svg-inline-react/-/svg-inline-react-1.0.3.tgz",
-      "integrity": "sha512-qGwiEKfKiaqiP5YJ0Fa0e6CN74Gma0XDJZ5LYMYcPdfMM+I6sPVZMbYRJ2sEkAY7B7jJzUphoimEl4LnqzBZ5g=="
+      "integrity": "sha512-qGwiEKfKiaqiP5YJ0Fa0e6CN74Gma0XDJZ5LYMYcPdfMM+I6sPVZMbYRJ2sEkAY7B7jJzUphoimEl4LnqzBZ5g==",
+      "requires": {}
     },
     "svg-pathdata": {
       "version": "6.0.3",
@@ -17037,7 +17174,8 @@
           "version": "3.5.2",
           "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
           "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-          "dev": true
+          "dev": true,
+          "requires": {}
         },
         "ansi-regex": {
           "version": "3.0.1",
@@ -17254,6 +17392,7 @@
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
+      "devOptional": true,
       "requires": {
         "kind-of": "^3.0.2"
       }
@@ -17262,6 +17401,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
       "integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
+      "devOptional": true,
       "requires": {
         "define-property": "^2.0.2",
         "extend-shallow": "^3.0.2",
@@ -17273,6 +17413,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
+      "devOptional": true,
       "requires": {
         "is-number": "^3.0.0",
         "repeat-string": "^1.6.1"
@@ -17282,6 +17423,7 @@
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
+          "devOptional": true,
           "requires": {
             "kind-of": "^3.0.2"
           }
@@ -17588,6 +17730,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
       "integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
+      "devOptional": true,
       "requires": {
         "arr-union": "^3.1.0",
         "get-value": "^2.0.6",
@@ -17668,6 +17811,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
+      "devOptional": true,
       "requires": {
         "has-value": "^0.3.1",
         "isobject": "^3.0.0"
@@ -17677,6 +17821,7 @@
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
+          "devOptional": true,
           "requires": {
             "get-value": "^2.0.3",
             "has-values": "^0.1.4",
@@ -17687,6 +17832,7 @@
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
+              "devOptional": true,
               "requires": {
                 "isarray": "1.0.0"
               }
@@ -17696,12 +17842,14 @@
         "has-values": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-          "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ=="
+          "integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
+          "devOptional": true
         },
         "isobject": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg=="
+          "integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
+          "devOptional": true
         }
       }
     },
@@ -17722,7 +17870,8 @@
     "urix": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
-      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg=="
+      "integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
+      "devOptional": true
     },
     "url": {
       "version": "0.11.0",
@@ -17788,7 +17937,8 @@
     "use": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ=="
+      "integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
+      "devOptional": true
     },
     "user-home": {
       "version": "1.1.1",
@@ -19114,11 +19264,6 @@
       "integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
       "dev": true
     },
-    "xmldom": {
-      "version": "0.1.27",
-      "resolved": "https://registry.npmjs.org/xmldom/-/xmldom-0.1.27.tgz",
-      "integrity": "sha512-7WpJBYwyhvsddFJA51SOIU0Be9W44sbGGjc6Z3ly8Wx/Wl7nriMPZ5xf6Np9ASlJ6gACfXcTLukm4DtX372lFw=="
-    },
     "xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -19239,6 +19384,11 @@
           "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg=="
         }
       }
+    },
+    "fflate": {
+      "version": "0.4.8",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.4.8.tgz",
+      "integrity": "sha512-FJqqoDBR00Mdj9ppamLa/Y7vxm+PRmNWA67N846RvsoYVMKB4q3y/de5PA7gUmRMYK/8CMz2GDZQmCRN1wBcWA=="
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@steem/crypto-session": "git+https://github.com/steemit/crypto-session.git#83a90b319ce5bc6a70362d52a15a815de7e729bb",
     "@steemfans/auth-data": "^1.0.2",
     "@steemit/steem-js": "0.7.9",
+    "@xmldom/xmldom": "0.8.10",
     "assert": "1.4.1",
     "autoprefixer-loader": "3.2.0",
     "axios": "^0.18.0",
@@ -130,7 +131,7 @@
     "redux-form": "5.3.4",
     "redux-saga": "0.16.0",
     "remarkable": "1.7.1",
-    "sanitize-html": "1.14.1",
+    "sanitize-html": "2.17.5",
     "sass-loader": "6.0.6",
     "secure-random": "1.1.1",
     "selection-position": "^1.0.0",
@@ -157,8 +158,7 @@
     "webpack-isomorphic-tools": "3.0.5",
     "websocket": "1.0.24",
     "whatwg-fetch": "0.11.1",
-    "wrap-md-editor": "^0.2.20",
-    "xmldom": "0.1.27"
+    "wrap-md-editor": "^0.2.20"
   },
   "devDependencies": {
     "@storybook/addon-knobs": "3.2.19",

--- a/src/app/components/cards/DraftSummary.jsx
+++ b/src/app/components/cards/DraftSummary.jsx
@@ -5,7 +5,7 @@ import { connect } from 'react-redux';
 import {
     extractBodySummary,
     extractImageLink,
-    highlightKeyword,
+    highlightSegments,
 } from 'app/utils/ExtractContent';
 import { proxifyImageUrl } from 'app/utils/ProxifyUrl';
 import * as userActions from 'app/redux/UserReducer';
@@ -14,6 +14,22 @@ import Userpic, { SIZE_SMALL } from 'app/components/elements/Userpic';
 import tt from 'counterpart';
 // TODO: document why ` ` => `%20` is needed, and/or move to base fucntion
 const proxify = (url, size) => proxifyImageUrl(url, size).replace(/ /g, '%20');
+
+// Render keyword-highlighted text as React nodes; drafts may contain raw
+// HTML in titles/bodies and must not pass through dangerouslySetInnerHTML.
+const renderHighlight = (text, keyword, color) =>
+    highlightSegments(text, keyword).map(
+        (seg, i) =>
+            typeof seg === 'string' ? (
+                seg
+            ) : (
+                // Segments have no stable identity; position is the key.
+                // eslint-disable-next-line react/no-array-index-key
+                <span key={i} style={{ background: color }}>
+                    {seg.match}
+                </span>
+            )
+    );
 
 class DraftSummary extends React.Component {
     static propTypes = {
@@ -58,31 +74,17 @@ class DraftSummary extends React.Component {
         const highlightColor = '#00FFC8';
         const content_body = (
             <div className="DraftSummary__body entry-content">
-                <span
-                    onClick={onClickContent}
-                    dangerouslySetInnerHTML={{
-                        __html: highlightKeyword(
-                            summary,
-                            keyWord,
-                            highlightColor
-                        ),
-                    }}
-                />
+                <span onClick={onClickContent}>
+                    {renderHighlight(summary, keyWord, highlightColor)}
+                </span>
             </div>
         );
 
         const content_title = (
             <h2 className="drafts__h2 entry-title">
-                <span
-                    onClick={onClickContent}
-                    dangerouslySetInnerHTML={{
-                        __html: highlightKeyword(
-                            post.title,
-                            keyWord,
-                            highlightColor
-                        ),
-                    }}
-                />
+                <span onClick={onClickContent}>
+                    {renderHighlight(post.title, keyWord, highlightColor)}
+                </span>
             </h2>
         );
 

--- a/src/app/components/cards/PostSummary.jsx
+++ b/src/app/components/cards/PostSummary.jsx
@@ -10,7 +10,7 @@ import { immutableAccessor } from 'app/utils/Accessors';
 import {
     extractBodySummary,
     extractImageLink,
-    highlightKeyword,
+    highlightSegments,
 } from 'app/utils/ExtractContent';
 import VotesAndComments from 'app/components/elements/VotesAndComments';
 import { List, Map } from 'immutable';
@@ -26,6 +26,22 @@ import { SIGNUP_URL } from 'shared/constants';
 import { hasNsfwTag } from 'app/utils/StateFunctions';
 
 const CURATOR_VESTS_THRESHOLD = 1.0 * 1000.0 * 1000.0;
+
+// Render keyword-highlighted text as React nodes. Titles/summaries are
+// user-controlled and must never pass through dangerouslySetInnerHTML.
+const renderHighlight = (text, keyword, color) =>
+    highlightSegments(text, keyword).map(
+        (seg, i) =>
+            typeof seg === 'string' ? (
+                seg
+            ) : (
+                // Segments have no stable identity; position is the key.
+                // eslint-disable-next-line react/no-array-index-key
+                <span key={i} style={{ background: color }}>
+                    {seg.match}
+                </span>
+            )
+    );
 
 // TODO: document why ` ` => `%20` is needed, and/or move to base fucntion
 const proxify = (url, size) => proxifyImageUrl(url, size).replace(/ /g, '%20');
@@ -138,16 +154,9 @@ class PostSummary extends React.Component {
         const highlightColor = '#00FFC8';
         const content_body = (
             <div className="PostSummary__body entry-content">
-                <Link
-                    to={post_url}
-                    dangerouslySetInnerHTML={{
-                        __html: highlightKeyword(
-                            summary,
-                            keyWord,
-                            highlightColor
-                        ),
-                    }}
-                />
+                <Link to={post_url}>
+                    {renderHighlight(summary, keyWord, highlightColor)}
+                </Link>
             </div>
         );
 
@@ -155,15 +164,13 @@ class PostSummary extends React.Component {
             <h2 className="articles__h2 entry-title">
                 <Link to={post_url}>
                     {isNsfw && <span className="nsfw-flag">nsfw</span>}
-                    <span
-                        dangerouslySetInnerHTML={{
-                            __html: highlightKeyword(
-                                post.get('title'),
-                                keyWord,
-                                highlightColor
-                            ),
-                        }}
-                    />
+                    <span>
+                        {renderHighlight(
+                            post.get('title'),
+                            keyWord,
+                            highlightColor
+                        )}
+                    </span>
                 </Link>
             </h2>
         );

--- a/src/app/components/cards/SearchUserList.jsx
+++ b/src/app/components/cards/SearchUserList.jsx
@@ -3,7 +3,7 @@ import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Link, browserHistory } from 'react-router';
 import { imageProxy } from 'app/utils/ProxifyUrl';
-import { highlightKeyword } from 'app/utils/ExtractContent';
+import { highlightSegments } from 'app/utils/ExtractContent';
 import * as userActions from 'app/redux/UserReducer';
 import * as transactionActions from 'app/redux/TransactionReducer';
 import tt from 'counterpart';
@@ -13,6 +13,22 @@ import { Set, Map } from 'immutable';
 export const SIZE_SMALL = 'small';
 export const SIZE_MED = 'medium';
 export const SIZE_LARGE = 'large';
+
+// Render keyword-highlighted text as React nodes; the search keyword comes
+// from the url and must never pass through dangerouslySetInnerHTML.
+const renderHighlight = (text, keyword, color) =>
+    highlightSegments(text, keyword).map(
+        (seg, i) =>
+            typeof seg === 'string' ? (
+                seg
+            ) : (
+                // Segments have no stable identity; position is the key.
+                // eslint-disable-next-line react/no-array-index-key
+                <span key={i} style={{ background: color }}>
+                    {seg.match}
+                </span>
+            )
+    );
 
 class SearchUserList extends Component {
     imgErrorFun(event) {
@@ -96,16 +112,9 @@ class SearchUserList extends Component {
                                 onError={event => this.imgErrorFun(event)}
                             />
                         </a>
-                        <span
-                            className="user-name"
-                            dangerouslySetInnerHTML={{
-                                __html: highlightKeyword(
-                                    name,
-                                    keyWord,
-                                    highlightColor
-                                ),
-                            }}
-                        />
+                        <span className="user-name">
+                            {renderHighlight(name, keyWord, highlightColor)}
+                        </span>
                         <span className="user-repution">{`(${Math.floor(
                             reputation
                         )})`}</span>

--- a/src/app/utils/ExtractContent.js
+++ b/src/app/utils/ExtractContent.js
@@ -84,11 +84,22 @@ export function extractBodySummary(body, strip_quotes = false) {
     return desc;
 }
 
-export function highlightKeyword(text, keyword, color) {
-    if (!text) return '';
-    var content = text.split(keyword);
-    var newText = content.join(
-        `<span style="background: ${color};">${keyword}</span>`
-    );
-    return newText;
+/**
+ * Split `text` into plain-text segments around `keyword` matches. Match
+ * results are returned as { match } objects so callers can render the
+ * highlight themselves. Unlike the old highlightKeyword (which returned an
+ * HTML string for dangerouslySetInnerHTML), no raw markup ever passes
+ * through here, so user-controlled titles/summaries cannot inject HTML.
+ */
+export function highlightSegments(text, keyword) {
+    if (!text) return [];
+    const str = String(text);
+    if (!keyword) return [str];
+    const parts = str.split(keyword);
+    const segments = [];
+    parts.forEach((part, i) => {
+        if (part !== '') segments.push(part);
+        if (i < parts.length - 1) segments.push({ match: keyword });
+    });
+    return segments;
 }

--- a/src/app/utils/ExtractContent.test.js
+++ b/src/app/utils/ExtractContent.test.js
@@ -1,0 +1,106 @@
+/* global describe, it, expect */
+import { highlightSegments, extractBodySummary } from './ExtractContent';
+import { htmlDecode } from './Html';
+
+describe('highlightSegments', () => {
+    it('returns an empty list for empty input', () => {
+        expect(highlightSegments('', 'x')).toEqual([]);
+        expect(highlightSegments(null, 'x')).toEqual([]);
+    });
+
+    it('returns the text as a single inert string when no keyword is given', () => {
+        expect(highlightSegments('hello world', null)).toEqual(['hello world']);
+        expect(highlightSegments('hello world', undefined)).toEqual([
+            'hello world',
+        ]);
+    });
+
+    it('does not split on the literal string "null" when keyword is null', () => {
+        expect(highlightSegments('a null b', null)).toEqual(['a null b']);
+    });
+
+    it('splits text around keyword matches and marks them as objects', () => {
+        expect(highlightSegments('one two one', 'one')).toEqual([
+            { match: 'one' },
+            ' two ',
+            { match: 'one' },
+        ]);
+    });
+
+    it('returns a single string when the keyword is absent', () => {
+        expect(highlightSegments('abc', 'xyz')).toEqual(['abc']);
+    });
+
+    it('keeps markup-looking input as plain strings (never returns HTML)', () => {
+        const payloads = [
+            `<iframe srcdoc='<script src=data:text/javascript,alert(1)></script>'></iframe>`,
+            '<img src=x onerror=alert(1)>',
+            'a<b>bold</b>c',
+        ];
+        payloads.forEach(payload => {
+            const segments = highlightSegments(payload, null);
+            expect(segments.every(s => typeof s === 'string')).toBe(true);
+            expect(segments.join('')).toEqual(payload);
+        });
+    });
+
+    it('keeps a markup-looking keyword inert as a match object', () => {
+        const segments = highlightSegments(
+            'hello <img src=x onerror=alert(1)> world',
+            '<img src=x onerror=alert(1)>'
+        );
+        expect(segments).toEqual([
+            'hello ',
+            { match: '<img src=x onerror=alert(1)>' },
+            ' world',
+        ]);
+    });
+});
+
+describe('extractBodySummary', () => {
+    it('returns plain text with no markup or angle-bracket entities', () => {
+        const summary = extractBodySummary(
+            'start <b>bold</b> <script>alert(1)</script> end'
+        );
+        expect(summary).not.toMatch(/[<>]/);
+        expect(summary).not.toMatch(/&lt;|&gt;|&amp;/);
+        expect(summary).toContain('start');
+        expect(summary).toContain('end');
+    });
+
+    it('decodes entities so summaries render correctly as React text', () => {
+        expect(extractBodySummary('fish &amp; chips')).toMatch('fish & chips');
+    });
+
+    it('strips raw urls', () => {
+        expect(
+            extractBodySummary('see https://example.com/page for more')
+        ).not.toMatch(/https?:\/\//);
+    });
+
+    it('truncates long bodies', () => {
+        const summary = extractBodySummary('word '.repeat(60));
+        expect(summary.length).toBeLessThanOrEqual(141);
+        expect(summary).toMatch(/…$/);
+    });
+});
+
+describe('htmlDecode', () => {
+    it('decodes angle brackets and ampersands', () => {
+        expect(htmlDecode('&lt;b&gt; &amp; &quot;q&quot;')).toEqual(
+            '<b> & "q"'
+        );
+    });
+
+    it('decodes numeric entities (decimal and hex)', () => {
+        expect(htmlDecode('&#65;&#x42;C')).toEqual('ABC');
+    });
+
+    it('leaves unknown entities untouched', () => {
+        expect(htmlDecode('&nope;')).toEqual('&nope;');
+    });
+
+    it('does not double-decode', () => {
+        expect(htmlDecode('&amp;lt;')).toEqual('&lt;');
+    });
+});

--- a/src/app/utils/ExtractContent.test.js
+++ b/src/app/utils/ExtractContent.test.js
@@ -1,5 +1,9 @@
 /* global describe, it, expect */
-import { highlightSegments, extractBodySummary } from './ExtractContent';
+import {
+    highlightSegments,
+    extractBodySummary,
+    extractImageLink,
+} from './ExtractContent';
 import { htmlDecode } from './Html';
 
 describe('highlightSegments', () => {
@@ -54,6 +58,23 @@ describe('highlightSegments', () => {
             { match: '<img src=x onerror=alert(1)>' },
             ' world',
         ]);
+    });
+});
+
+describe('extractImageLink', () => {
+    it('finds images in markdown bodies (unwrapped multi-root html)', () => {
+        expect(
+            extractImageLink({}, 'words ![alt](https://example.com/x.png) end')
+        ).toBe('https://example.com/x.png');
+    });
+
+    it('reads the first json_metadata image when present', () => {
+        expect(
+            extractImageLink(
+                { image: ['https://example.com/a.jpg', 'https://e.com/b.jpg'] },
+                'no images here'
+            )
+        ).toBe('https://example.com/a.jpg');
     });
 });
 

--- a/src/app/utils/Html.js
+++ b/src/app/utils/Html.js
@@ -1,21 +1,69 @@
 export const htmlDecode = txt =>
-    txt.replace(/&[a-z]+;/g, ch => {
-        const char = htmlCharMap[ch.substring(1, ch.length - 1)];
+    txt.replace(/&(#x?[0-9a-f]+|[a-z]+);/gi, ch => {
+        const body = ch.substring(1, ch.length - 1);
+        if (body[0] === '#') {
+            const code =
+                body[1] === 'x' || body[1] === 'X'
+                    ? parseInt(body.substring(2), 16)
+                    : parseInt(body.substring(1), 10);
+            return Number.isFinite(code) && code > 0 && code <= 0x10ffff
+                ? String.fromCodePoint(code)
+                : ch;
+        }
+        const char = htmlCharMap[body];
         return char ? char : ch;
     });
 
 const htmlCharMap = {
     amp: '&',
     quot: '"',
+    apos: "'",
+    lt: '<',
+    gt: '>',
+    nbsp: ' ',
+    iexcl: '¡',
+    cent: '¢',
+    pound: '£',
+    curren: '¤',
+    yen: '¥',
+    sect: '§',
+    copy: '©',
+    reg: '®',
+    deg: '°',
+    plusmn: '±',
+    sup2: '²',
+    sup3: '³',
+    middot: '·',
+    frac14: '¼',
+    frac12: '½',
+    frac34: '¾',
+    iquest: '¿',
+    times: '×',
+    divide: '÷',
+    ndash: '–',
+    mdash: '—',
     lsquo: '‘',
     rsquo: '’',
     sbquo: '‚',
     ldquo: '“',
     rdquo: '”',
     bdquo: '„',
-    hearts: '♥',
-    trade: '™',
+    bull: '•',
     hellip: '…',
-    pound: '£',
-    copy: '',
+    prime: '′',
+    Prime: '″',
+    oline: '‾',
+    frasl: '⁄',
+    euro: '€',
+    trade: '™',
+    larr: '←',
+    uarr: '↑',
+    rarr: '→',
+    darr: '↓',
+    minus: '−',
+    infin: '∞',
+    ne: '≠',
+    le: '≤',
+    ge: '≥',
+    hearts: '♥',
 };

--- a/src/server/__tests__/redirect.test.js
+++ b/src/server/__tests__/redirect.test.js
@@ -1,0 +1,28 @@
+/* global describe, it, expect */
+const { isSafeRedirectTarget } = require('../server');
+
+describe('isSafeRedirectTarget', () => {
+    it('rejects protocol-relative targets', () => {
+        expect(isSafeRedirectTarget('//evil.com')).toBe(false);
+        expect(isSafeRedirectTarget('%2F%2Fevil.com')).toBe(false);
+        expect(isSafeRedirectTarget('/%2F%2Fevil.com')).toBe(false);
+    });
+
+    it('rejects scheme-prefixed targets', () => {
+        expect(isSafeRedirectTarget('http://evil.com')).toBe(false);
+        expect(isSafeRedirectTarget('https:evil')).toBe(false);
+        expect(isSafeRedirectTarget('javascript:alert(1)')).toBe(false);
+    });
+
+    it('accepts same-origin relative paths', () => {
+        expect(isSafeRedirectTarget('/foo/bar')).toBe(true);
+        expect(isSafeRedirectTarget('/')).toBe(true);
+        expect(isSafeRedirectTarget('/path?x=1#frag')).toBe(true);
+    });
+
+    it('rejects non-string or empty inputs', () => {
+        expect(isSafeRedirectTarget(null)).toBe(false);
+        expect(isSafeRedirectTarget(undefined)).toBe(false);
+        expect(isSafeRedirectTarget('')).toBe(false);
+    });
+});

--- a/src/server/__tests__/redirect.test.js
+++ b/src/server/__tests__/redirect.test.js
@@ -1,28 +1,40 @@
 /* global describe, it, expect */
-const { isSafeRedirectTarget } = require('../server');
+import isSafeRedirectTarget from '../utils/RedirectTarget';
 
 describe('isSafeRedirectTarget', () => {
     it('rejects protocol-relative targets', () => {
         expect(isSafeRedirectTarget('//evil.com')).toBe(false);
         expect(isSafeRedirectTarget('%2F%2Fevil.com')).toBe(false);
         expect(isSafeRedirectTarget('/%2F%2Fevil.com')).toBe(false);
+        expect(isSafeRedirectTarget('///evil.com')).toBe(false);
     });
 
     it('rejects scheme-prefixed targets', () => {
         expect(isSafeRedirectTarget('http://evil.com')).toBe(false);
         expect(isSafeRedirectTarget('https:evil')).toBe(false);
+        // eslint-disable-next-line no-script-url
         expect(isSafeRedirectTarget('javascript:alert(1)')).toBe(false);
+        // scheme check runs after decoding too
+        expect(isSafeRedirectTarget('%68ttp%3a%2f%2fevil.com')).toBe(false);
     });
 
     it('accepts same-origin relative paths', () => {
         expect(isSafeRedirectTarget('/foo/bar')).toBe(true);
         expect(isSafeRedirectTarget('/')).toBe(true);
         expect(isSafeRedirectTarget('/path?x=1#frag')).toBe(true);
+        // encoded characters that decode to harmless path content
+        expect(isSafeRedirectTarget('/trending?next=%2Fhot')).toBe(true);
     });
 
     it('rejects non-string or empty inputs', () => {
         expect(isSafeRedirectTarget(null)).toBe(false);
         expect(isSafeRedirectTarget(undefined)).toBe(false);
         expect(isSafeRedirectTarget('')).toBe(false);
+    });
+
+    it('falls back to the raw token when decoding fails', () => {
+        // '%' alone is malformed; the raw form still decides
+        expect(isSafeRedirectTarget('/%')).toBe(true);
+        expect(isSafeRedirectTarget('%2F%2F')).toBe(false);
     });
 });

--- a/src/server/server.exports.js
+++ b/src/server/server.exports.js
@@ -1,0 +1,2 @@
+module.exports = app;
+module.exports.isSafeRedirectTarget = isSafeRedirectTarget;

--- a/src/server/server.exports.js
+++ b/src/server/server.exports.js
@@ -1,2 +1,0 @@
-module.exports = app;
-module.exports.isSafeRedirectTarget = isSafeRedirectTarget;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -7,6 +7,7 @@ import koa_router from 'koa-router';
 import requestTime from './requesttimings';
 import StatsLoggerClient from './utils/StatsLoggerClient';
 import { SteemMarket } from './utils/SteemMarket';
+import isSafeRedirectTarget from './utils/RedirectTarget';
 import hardwareStats from './hardwarestats';
 import cluster from 'cluster';
 import os from 'os';
@@ -241,33 +242,11 @@ app.use(function*(next) {
         // Only redirect to same-origin relative paths. A url like
         // `//evil.com?ch=1` strips down to the protocol-relative `//evil.com`,
         // which would send the user to an external host (open redirect).
-        // Decode and normalize the target before testing to prevent encoded
-        // bypasses such as "%2F%2Fevil.com".
-        const isSafeRedirectTarget = raw => {
-            if (!raw || typeof raw !== 'string') return false;
-            // keep the raw token for redirects that include querystring/fragments
-            const token = raw;
-            // Try decode once; if decoding fails just fall back to raw token.
-            let decoded = token;
-            try {
-                // decodeURIComponent throws on malformed sequences
-                decoded = decodeURIComponent(token);
-            } catch (e) {
-                decoded = token;
-            }
-            // Disallow any absolute/scheme-prefixed targets like 'http:' or 'https:'
-            if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(decoded)) return false;
-            // Disallow protocol-relative '//' (decoded or raw)
-            if (/^\/\//.test(decoded) || /^\/\//.test(token)) return false;
-            // Only allow same-origin relative paths that start with a single '/'
-            return /^\/(?!\/)/.test(decoded);
-        };
-
+        // Decoding/scheme checks live in isSafeRedirectTarget.
         if (!isSafeRedirectTarget(redir)) {
             yield next;
             return;
         }
-
         console.log(`server redirect ${this.url} -> ${redir}`);
         this.status = 302;
         this.redirect(redir);
@@ -470,5 +449,4 @@ if (env !== 'test') {
 if (process.env.PERFORMANCE_TRACING)
     setInterval(hardwareStats, 1000 * process.env.PERFORMANCE_TRACING);
 
-// export helper for tests: isSafeRedirectTarget
 module.exports = app;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -241,10 +241,33 @@ app.use(function*(next) {
         // Only redirect to same-origin relative paths. A url like
         // `//evil.com?ch=1` strips down to the protocol-relative `//evil.com`,
         // which would send the user to an external host (open redirect).
-        if (!/^\/(?!\/)/.test(redir)) {
+        // Decode and normalize the target before testing to prevent encoded
+        // bypasses such as "%2F%2Fevil.com".
+        const isSafeRedirectTarget = raw => {
+            if (!raw || typeof raw !== 'string') return false;
+            // keep the raw token for redirects that include querystring/fragments
+            const token = raw;
+            // Try decode once; if decoding fails just fall back to raw token.
+            let decoded = token;
+            try {
+                // decodeURIComponent throws on malformed sequences
+                decoded = decodeURIComponent(token);
+            } catch (e) {
+                decoded = token;
+            }
+            // Disallow any absolute/scheme-prefixed targets like 'http:' or 'https:'
+            if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(decoded)) return false;
+            // Disallow protocol-relative '//' (decoded or raw)
+            if (/^\/\//.test(decoded) || /^\/\//.test(token)) return false;
+            // Only allow same-origin relative paths that start with a single '/'
+            return /^\/(?!\/)/.test(decoded);
+        };
+
+        if (!isSafeRedirectTarget(redir)) {
             yield next;
             return;
         }
+
         console.log(`server redirect ${this.url} -> ${redir}`);
         this.status = 302;
         this.redirect(redir);
@@ -447,4 +470,5 @@ if (env !== 'test') {
 if (process.env.PERFORMANCE_TRACING)
     setInterval(hardwareStats, 1000 * process.env.PERFORMANCE_TRACING);
 
+// export helper for tests: isSafeRedirectTarget
 module.exports = app;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -238,6 +238,13 @@ app.use(function*(next) {
         });
         redir = redir.replace(/&&&?/, '');
         redir = redir.replace(/\?&?$/, '');
+        // Only redirect to same-origin relative paths. A url like
+        // `//evil.com?ch=1` strips down to the protocol-relative `//evil.com`,
+        // which would send the user to an external host (open redirect).
+        if (!/^\/(?!\/)/.test(redir)) {
+            yield next;
+            return;
+        }
         console.log(`server redirect ${this.url} -> ${redir}`);
         this.status = 302;
         this.redirect(redir);

--- a/src/server/utils/RedirectTarget.js
+++ b/src/server/utils/RedirectTarget.js
@@ -1,0 +1,31 @@
+/**
+ * Validate redirect targets produced from user-controlled urls.
+ *
+ * The ch=/cn=/r= middleware in server.js strips session params and
+ * redirects to the remaining path. A stripped url like `//evil.com`
+ * is protocol-relative and would send the user to an external host
+ * (open redirect), so only same-origin relative paths may pass.
+ *
+ * The target is decoded once before testing to also reject encoded
+ * bypasses such as `%2F%2Fevil.com` or `/%2F%2Fevil.com`, and any
+ * scheme-prefixed form (`http:`, `javascript:`, ...) is rejected.
+ * Kept dependency-free on purpose: unit tests import this module
+ * directly without booting the whole server (config/steem-js chain).
+ */
+export default function isSafeRedirectTarget(raw) {
+    if (!raw || typeof raw !== 'string') return false;
+    const token = raw;
+    let decoded = token;
+    try {
+        // decodeURIComponent throws on malformed sequences
+        decoded = decodeURIComponent(token);
+    } catch (e) {
+        decoded = token;
+    }
+    // Disallow absolute/scheme-prefixed targets like 'http:' or 'https:'
+    if (/^[a-zA-Z][a-zA-Z0-9+.-]*:/.test(decoded)) return false;
+    // Disallow protocol-relative '//' (decoded or raw)
+    if (/^\/\//.test(decoded) || /^\/\//.test(token)) return false;
+    // Only allow same-origin relative paths starting with a single '/'
+    return /^\/(?!\/)/.test(decoded);
+}

--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -1,4 +1,4 @@
-import xmldom from 'xmldom';
+import xmldom from '@xmldom/xmldom';
 import tt from 'counterpart';
 import linksRe, { any as linksAny } from 'app/utils/Links';
 import { validate_account_name } from 'app/utils/ChainValidation';
@@ -11,10 +11,15 @@ export const getExternalLinkWarningMessage = () =>
 export const getInternalImageMessage = () => tt('g.internal_image_message');
 
 const noop = () => {};
-const DOMParser = new xmldom.DOMParser({
-    errorHandler: { warning: noop, error: noop },
-});
+// User-supplied markdown is expected to be malformed HTML; keep parsing.
+// (True fatal errors throw ParseError, caught by HtmlReady's try/catch.)
+const DOMParser = new xmldom.DOMParser({ onError: noop });
 const XMLSerializer = new xmldom.XMLSerializer();
+
+// Parse an HTML fragment and return its root element. xmldom returns a
+// Document, and a Document node cannot be inserted into another tree.
+const parseFragment = fragment =>
+    DOMParser.parseFromString(fragment, 'text/html').documentElement;
 
 /**
  * Functions performed by HTMLReady
@@ -263,7 +268,7 @@ function iframe(state, child) {
         return;
     const html = XMLSerializer.serializeToString(child);
     child.parentNode.replaceChild(
-        DOMParser.parseFromString(`<div class="videoWrapper">${html}</div>`),
+        parseFragment(`<div class="videoWrapper">${html}</div>`),
         child
     );
 }
@@ -285,7 +290,7 @@ function img(state, child) {
     }
     if (child.parentNode && child.parentNode.nodeName.toLowerCase() !== 'a') {
         child.parentNode.replaceChild(
-            DOMParser.parseFromString(
+            parseFragment(
                 `<a href="` +
                     proxifyImageUrl(url, '0x0/') +
                     `" target="_blank">${child}</a>`
@@ -342,9 +347,7 @@ function linkifyNode(child, state) {
             state.links
         );
         if (mutate && content !== data) {
-            const newChild = DOMParser.parseFromString(
-                `<span>${content}</span>`
-            );
+            const newChild = parseFragment(`<span>${content}</span>`);
             child.parentNode.replaceChild(newChild, child);
             return newChild;
         }

--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -12,8 +12,11 @@ export const getInternalImageMessage = () => tt('g.internal_image_message');
 
 const noop = () => {};
 // User-supplied markdown is expected to be malformed HTML; keep parsing.
-// (True fatal errors throw ParseError, caught by HtmlReady's try/catch.)
-const DOMParser = new xmldom.DOMParser({ onError: noop });
+// NOTE: @xmldom/xmldom 0.8 consumes the `errorHandler` object (the 0.9+
+// line replaced it with an `onError` callback).
+const DOMParser = new xmldom.DOMParser({
+    errorHandler: { warning: noop, error: noop, fatalError: noop },
+});
 const XMLSerializer = new xmldom.XMLSerializer();
 
 // Parse an HTML fragment and return its root element. xmldom returns a
@@ -96,10 +99,15 @@ export default function(
     state.images = new Set();
     state.links = new Set();
     try {
-        const doc = DOMParser.parseFromString(
-            preprocessHtml(html),
-            'text/html'
-        );
+        // Callers such as extractImageLink pass rendered markdown that is
+        // NOT wrapped in a root element (multiple top-level blocks).
+        // @xmldom/xmldom only accepts a single root element, so fragment
+        // input is parsed inside a synthetic <html> root and unwrapped
+        // again on serialization; already-wrapped input passes through.
+        const prepared = preprocessHtml(html);
+        const hadWrapper = /^\s*<html[\s>]/i.test(prepared);
+        const source = hadWrapper ? prepared : `<html>${prepared}</html>`;
+        const doc = DOMParser.parseFromString(source, 'text/html');
         traverse(doc, state);
         if (mutate) {
             if (hideImages) {
@@ -125,7 +133,7 @@ export default function(
         // console.log('state', state)
         if (!mutate) return state;
         return {
-            html: doc ? XMLSerializer.serializeToString(doc) : '',
+            html: doc ? serializeDoc(doc, hadWrapper) : '',
             ...state,
         };
     } catch (error) {
@@ -134,7 +142,9 @@ export default function(
             'rendering error',
             JSON.stringify({ error: error.message, html })
         );
-        return { html: '' };
+        // Keep the state collections in the failure path: callers using
+        // mutate:false (e.g. extractImageLink) read rtags.images directly.
+        return { html: '', ...state };
     }
 }
 
@@ -143,6 +153,20 @@ function preprocessHtml(html) {
     html = embedThreeSpeakNode(html);
 
     return html;
+}
+
+// Serialize a parsed document. Input that arrived without an <html> root
+// was parsed inside a synthetic one; unwrap it so the output shape matches
+// the input shape (HtmlReady used to pass fragments through unchanged).
+function serializeDoc(doc, hadWrapper) {
+    if (hadWrapper) return XMLSerializer.serializeToString(doc);
+    const root = doc.documentElement;
+    if (!root) return XMLSerializer.serializeToString(doc);
+    let out = '';
+    Array.prototype.slice.call(root.childNodes).forEach(node => {
+        out += XMLSerializer.serializeToString(node);
+    });
+    return out;
 }
 function detectImageLinksOrLinkify(textNode, state) {
     const imageRegex = /(https?:\/\/\S+\.(?:jpg|jpeg|png|gif)(?:\?[^\s]*)?)/gi;

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -6,6 +6,23 @@ beforeEach(() => {
 });
 
 describe('htmlready', () => {
+    it('should extract state from unwrapped multi-root input', () => {
+        // extractImageLink passes remarkable output with multiple
+        // top-level blocks and no <html> wrapper; the state collections
+        // must still be populated (@xmldom/xmldom needs a single root).
+        const res = HtmlReady(
+            '<p>text</p>\n<hr>\n<p><img src="https://example.com/pic.png"></p>',
+            { mutate: false }
+        );
+        expect(Array.from(res.images)).toContain('https://example.com/pic.png');
+        expect(res.html).toBeUndefined();
+    });
+
+    it('should keep state collections on the error path', () => {
+        const res = HtmlReady('teststring lol', { mutate: false });
+        expect(res.images instanceof Set).toBe(true);
+    });
+
     it('should pass bare text through unchanged', () => {
         // xmldom 0.1.x errored out on input without a root element;
         // @xmldom/xmldom 0.8.x parses it and returns the text as-is.

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -1,4 +1,4 @@
-/* global describe, it, before, beforeEach, after, afterEach */
+/* global describe, it, expect, before, beforeEach, after, afterEach */
 import HtmlReady from './HtmlReady';
 
 beforeEach(() => {
@@ -6,9 +6,11 @@ beforeEach(() => {
 });
 
 describe('htmlready', () => {
-    it('should return an empty string if input cannot be parsed', () => {
-        const teststring = 'teststring lol'; // this string causes the xmldom parser to fail & error out
-        expect(HtmlReady(teststring).html).toEqual('');
+    it('should pass bare text through unchanged', () => {
+        // xmldom 0.1.x errored out on input without a root element;
+        // @xmldom/xmldom 0.8.x parses it and returns the text as-is.
+        const teststring = 'teststring lol';
+        expect(HtmlReady(teststring).html).toEqual('teststring lol');
     });
 
     it('should allow links where the text portion and href contains steemit.com', () => {

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -63,6 +63,10 @@ module.exports = {
         rules: [
             {test: /\.(jpe?g|png|gif)/, use: 'url-loader?limit=4096'},
             {test: /\.json$/, use: 'json-loader'},
+            // The sanitizer dependency tree (sanitize-html 2.x, @xmldom/xmldom)
+            // ships post-ES2017 syntax (e.g. object spread in postcss 8) that
+            // webpack 3's acorn 5 parser cannot read; run it through babel.
+            {test: /\.js$/, include: [/node_modules\/(sanitize-html|htmlparser2|postcss|@xmldom\/xmldom|entities|domutils|domhandler|domelementtype|launder|parse-srcset|deepmerge|escape-string-regexp|is-plain-object|nanoid|picocolors|source-map-js)\//], use: 'babel-loader'},
             {test: /\.js$|\.jsx$/, exclude: [/node_modules/, /\*\/app\/assets\/static\/\*\.js/], use: 'babel-loader'},
             {test: /\.svg$/, use: 'svg-inline-loader'},
             {
@@ -130,6 +134,10 @@ module.exports = {
         ),
     ],
     resolve: {
+        // Prefer the commonjs `main` entry: several sanitizer deps
+        // (htmlparser2 etc.) point `module` at ESM builds that webpack 3's
+        // acorn 5 parser cannot handle.
+        mainFields: ['browser', 'main'],
         alias: {
             react: path.join(__dirname, '../node_modules', 'react'),
             assets: path.join(__dirname, '../src/app/assets'),

--- a/yarn.lock
+++ b/yarn.lock
@@ -657,6 +657,11 @@
   resolved "https://registry.yarnpkg.com/@types/unist/-/unist-2.0.10.tgz#04ffa7f406ab628f7f7e97ca23e290cd8ab15efc"
   integrity sha512-IfYcSBWE3hLpBg8+X2SEa8LVkJdJEkT2Ese2aaLs3ptGdVtABxndrMaxuFlQ1qdFf9Q5rDvDpxI3WwgvKFAsQA==
 
+"@xmldom/xmldom@0.8.10":
+  version "0.8.10"
+  resolved "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.10.tgz"
+  integrity sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==
+
 abab@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/abab/-/abab-1.0.4.tgz#5faad9c2c07f60dd76770f71cf025b62a63cfd4e"
@@ -4082,6 +4087,11 @@ date-names@^0.1.7:
   resolved "https://registry.yarnpkg.com/date-names/-/date-names-0.1.13.tgz#c4358f6f77c8056e2f5ea68fdbb05f0bf1e53bd0"
   integrity sha512-IxxoeD9tdx8pXVcmqaRlPvrXIsSrSrIZzfzlOkm9u+hyzKp5Wk/odt9O/gd7Ockzy8n/WHeEpTVJ2bF3mMV4LA==
 
+dayjs@^1.11.7:
+  version "1.11.23"
+  resolved "https://registry.npmjs.org/dayjs/-/dayjs-1.11.23.tgz"
+  integrity sha512-QDTCU0M0MxR3hQfnlDJfwekQiaanm1ubOD231u73WBckQ/fsamwRLiE2GBz6D3a/xF1NgfiDLJjXBa1hYOYTtQ==
+
 debug@*, debug@^4.0.0:
   version "4.3.4"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.4.tgz#1319f6579357f2338d3337d2cdd4914bb5dcc865"
@@ -4146,6 +4156,11 @@ deep-is@~0.1.3:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
+
+deepmerge@^4.2.2:
+  version "4.3.1"
+  resolved "https://registry.npmjs.org/deepmerge/-/deepmerge-4.3.1.tgz"
+  integrity sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==
 
 default-require-extensions@^1.0.0:
   version "1.0.0"
@@ -4409,10 +4424,10 @@ domutils@^1.5.1:
     dom-serializer "0"
     domelementtype "1"
 
-domutils@^3.0.1, domutils@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/domutils/-/domutils-3.1.0.tgz#c47f551278d3dc4b0b1ab8cbb42d751a6f0d824e"
-  integrity sha512-H78uMmQtI2AhgDJjWeQmHwJJ2bLPD3GMmO7Zja/ZZh84wkm+4ut+IUnUdRa8uCGX88DiVx1j6FRe1XfxEgjEZA==
+domutils@^3.0.1, domutils@^3.1.0, domutils@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz"
+  integrity sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==
   dependencies:
     dom-serializer "^2.0.0"
     domelementtype "^2.3.0"
@@ -4604,6 +4619,11 @@ entities@^4.2.0, entities@^4.4.0, entities@^4.5.0:
   version "4.5.0"
   resolved "https://registry.yarnpkg.com/entities/-/entities-4.5.0.tgz#5d268ea5e7113ec74c4d033b79ea5a35a488fb48"
   integrity sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==
+
+entities@^7.0.1:
+  version "7.0.1"
+  resolved "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz"
+  integrity sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==
 
 entities@~2.1.0:
   version "2.1.0"
@@ -4866,6 +4886,11 @@ escape-string-regexp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz#a30304e99daa32e23b2fd20f51babd07cffca344"
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+
+escape-string-regexp@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz"
+  integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
 escodegen@^1.6.1, escodegen@^1.9.1:
   version "1.14.3"
@@ -6317,7 +6342,17 @@ html2canvas@^1.0.0-rc.5:
     css-line-break "^2.1.0"
     text-segmentation "^1.0.3"
 
-htmlparser2@^3.9.0, htmlparser2@^3.9.1:
+htmlparser2@^10.1.0:
+  version "10.1.0"
+  resolved "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz"
+  integrity sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==
+  dependencies:
+    domelementtype "^2.3.0"
+    domhandler "^5.0.3"
+    domutils "^3.2.2"
+    entities "^7.0.1"
+
+htmlparser2@^3.9.1:
   version "3.10.1"
   resolved "https://registry.yarnpkg.com/htmlparser2/-/htmlparser2-3.10.1.tgz#bd679dc3f59897b6a34bb10749c855bb53a9392f"
   integrity sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
@@ -7044,6 +7079,11 @@ is-plain-object@^2.0.1, is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   integrity sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
   dependencies:
     isobject "^3.0.1"
+
+is-plain-object@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz"
+  integrity sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==
 
 is-posix-bracket@^0.1.0:
   version "0.1.1"
@@ -8068,6 +8108,13 @@ koa@1.4.1:
     type-is "^1.5.5"
     vary "^1.0.0"
 
+launder@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.npmjs.org/launder/-/launder-1.7.1.tgz"
+  integrity sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw==
+  dependencies:
+    dayjs "^1.11.7"
+
 lazy-cache@^0.2.3:
   version "0.2.7"
   resolved "https://registry.yarnpkg.com/lazy-cache/-/lazy-cache-0.2.7.tgz#7feddf2dcb6edb77d11ef1d117ab5ffdf0ab1b65"
@@ -8922,6 +8969,11 @@ nan@^2.12.1, nan@^2.13.2, nan@^2.3.3:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
   integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
 
+nanoid@^3.3.17:
+  version "3.3.18"
+  resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz"
+  integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
+
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"
@@ -9569,6 +9621,11 @@ parse-json@^4.0.0:
     error-ex "^1.3.1"
     json-parse-better-errors "^1.0.1"
 
+parse-srcset@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.npmjs.org/parse-srcset/-/parse-srcset-1.0.2.tgz"
+  integrity sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q==
+
 parse5-htmlparser2-tree-adapter@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.0.0.tgz#23c2cc233bcf09bb7beba8b8a69d46b08c62c2f1"
@@ -9699,6 +9756,11 @@ picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
   integrity sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ==
+
+picocolors@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz"
+  integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
 
 picomatch@^2.0.4, picomatch@^2.2.1:
   version "2.3.1"
@@ -10074,6 +10136,15 @@ postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.17:
     chalk "^2.4.1"
     source-map "^0.6.1"
     supports-color "^5.4.0"
+
+postcss@^8.3.11:
+  version "8.5.26"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz"
+  integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==
+  dependencies:
+    nanoid "^3.3.17"
+    picocolors "^1.1.1"
+    source-map-js "^1.2.1"
 
 prelude-ls@~1.1.2:
   version "1.1.2"
@@ -11044,11 +11115,6 @@ regex-not@^1.0.0, regex-not@^1.0.2:
     extend-shallow "^3.0.2"
     safe-regex "^1.1.0"
 
-regexp-quote@0.0.0:
-  version "0.0.0"
-  resolved "https://registry.yarnpkg.com/regexp-quote/-/regexp-quote-0.0.0.tgz#1e0f4650c862dcbfed54fd42b148e9bb1721fcf2"
-  integrity sha512-R9elSUXyJeACXh7raO50vvfZyTdQ1bxYm0KlN2XD8eEzPAnedJTHMk4F7lCaggu9DrfUWP3CDUjAgyW1f2DpgA==
-
 regexp.prototype.flags@^1.2.0, regexp.prototype.flags@^1.5.1, regexp.prototype.flags@^1.5.2:
   version "1.5.2"
   resolved "https://registry.yarnpkg.com/regexp.prototype.flags/-/regexp.prototype.flags-1.5.2.tgz#138f644a3350f981a858c44f6bb1a61ff59be334"
@@ -11415,14 +11481,18 @@ sane@^2.0.0:
   optionalDependencies:
     fsevents "^1.2.3"
 
-sanitize-html@1.14.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/sanitize-html/-/sanitize-html-1.14.1.tgz#730ffa2249bdf18333effe45b286173c9c5ad0b8"
-  integrity sha512-jNDMpBFd1vqwwOh6Wmmyt49cGSkfJ+YjpUbE0i2cw4s5jXNFr4FexRL/UBqWKRXdfGHmw7/NeULVaHp+zIAYBg==
+sanitize-html@2.17.5:
+  version "2.17.5"
+  resolved "https://registry.npmjs.org/sanitize-html/-/sanitize-html-2.17.5.tgz"
+  integrity sha512-ZmU1joGRrvoyctKIiuwUxqR6moLoU2Wk+2bMccN6f7UwhAmwYDvWziqPxRDDN2Qip62NqnIrVrT9akbL6Wretg==
   dependencies:
-    htmlparser2 "^3.9.0"
-    regexp-quote "0.0.0"
-    xtend "^4.0.0"
+    deepmerge "^4.2.2"
+    escape-string-regexp "^4.0.0"
+    htmlparser2 "^10.1.0"
+    is-plain-object "^5.0.0"
+    launder "^1.7.1"
+    parse-srcset "^1.0.2"
+    postcss "^8.3.11"
 
 sass-graph@2.2.5:
   version "2.2.5"
@@ -11803,6 +11873,11 @@ source-list-map@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/source-list-map/-/source-list-map-2.0.1.tgz#3993bd873bfc48479cca9ea3a547835c7c154b34"
   integrity sha512-qnQ7gVMxGNxsiL4lEuJwe/To8UnK7fAnmbGEEH8RpLouuKbeEm0lhbQVFIrNSuB+G7tVrAlVsZgETT5nljf+Iw==
+
+source-map-js@^1.2.1:
+  version "1.2.1"
+  resolved "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz"
+  integrity sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==
 
 source-map-resolve@^0.5.0:
   version "0.5.3"
@@ -13521,11 +13596,6 @@ xml-name-validator@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/xml-name-validator/-/xml-name-validator-3.0.0.tgz#6ae73e06de4d8c6e47f9fb181f78d648ad457c6a"
   integrity sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
-
-xmldom@0.1.27:
-  version "0.1.27"
-  resolved "https://registry.yarnpkg.com/xmldom/-/xmldom-0.1.27.tgz#d501f97b3bdb403af8ef9ecc20573187aadac0e9"
-  integrity sha512-7WpJBYwyhvsddFJA51SOIU0Be9W44sbGGjc6Z3ly8Wx/Wl7nriMPZ5xf6Np9ASlJ6gACfXcTLukm4DtX372lFw==
 
 xtend@^4.0.0, xtend@^4.0.1:
   version "4.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8969,7 +8969,7 @@ nan@^2.12.1, nan@^2.13.2, nan@^2.3.3:
   resolved "https://registry.yarnpkg.com/nan/-/nan-2.19.0.tgz#bb58122ad55a6c5bc973303908d5b16cfdd5a8c0"
   integrity sha512-nO1xXxfh/RWNxfd/XPfbIfFk5vgLsAxUR9y5O0cHMJu/AW9U95JLXqthYHjEp+8gQ5p96K9jUp8nbVOxCdRbtw==
 
-nanoid@^3.3.17:
+nanoid@^3.3.7, nanoid@^3.3.17:
   version "3.3.18"
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz"
   integrity sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==
@@ -10138,11 +10138,11 @@ postcss@^6.0.0, postcss@^6.0.1, postcss@^6.0.17:
     supports-color "^5.4.0"
 
 postcss@^8.3.11:
-  version "8.5.26"
-  resolved "https://registry.npmjs.org/postcss/-/postcss-8.5.26.tgz"
-  integrity sha512-u82N74LFzG8ca+dD8puPnplTXoGH4fTPpVGuIbt36G3qvNlkvfD0lEAZSxaly3KX8TS/L1A1gsCEmvKmBcVbkQ==
+  version "8.4.49"
+  resolved "https://registry.npmjs.org/postcss/-/postcss-8.4.49.tgz"
+  integrity sha512-OCVPnIObs4N29kxTjzLfUryOkvZEq+pf8jTF0lg8E7uETuWHA+v7j3c/xJmiqpX450191LlmZfUKkXxkTry7nA==
   dependencies:
-    nanoid "^3.3.17"
+    nanoid "^3.3.7"
     picocolors "^1.1.1"
     source-map-js "^1.2.1"
 


### PR DESCRIPTION
## Summary

Fixes the three findings from the external whitehat vulnerability report of 2026-08-10 (report IDs 35/36/47), verified against current `master` before fixing.

| Finding | Severity | Issue | Status |
|---|---|---|---|
| F35 (ID 35) | HIGH | Stored XSS via post title in list cards | Fixed (`b0b58939`) |
| F36 (ID 36) | HIGH | Body/comment sanitizer stack outdated / bypassable | Fixed (`b50e7bd9`) |
| F47 (ID 47) | MEDIUM | Protocol-relative open redirect | Fixed (`91044659`) |

### F35 — stored XSS via post title

`PostSummary`/`DraftSummary`/`SearchUserList` fed `highlightKeyword()` output straight into `dangerouslySetInnerHTML`. `highlightKeyword` performs no HTML escaping, so an on-chain title such as `<iframe srcdoc='<script src=data:...>'></iframe>` (broadcast directly via RPC, bypassing the editor) executed as markup on every feed/search card. The unescaped search keyword additionally allowed a reflected vector via `?q=`.

- Replaced `highlightKeyword` with `highlightSegments`, which returns inert plain-text segments rendered through normal React children; all four call sites dropped `dangerouslySetInnerHTML`.
- Extended `htmlDecode` (lt/gt/apos/nbsp + numeric entities) so `extractBodySummary` returns true plain text and React rendering displays identically to the old innerHTML path (verified 10/10 on a display-equivalence corpus).
- Note: production CSP (`script-src` without `data:`/`unsafe-inline`, `reportOnly: false`) already blocks script execution for the reported payload, but arbitrary markup/iframe injection (`frameSrc: 'https:'`) was live; this fix removes the injection point entirely.

### F36 — sanitizer stack

`sanitize-html@1.14.1` (2017) and `xmldom@0.1.27` carry known, unpatched bypass primitives; the 1.x line never received the later security fixes (CVE-2019-25225 transformTags output not re-sanitized, CVE-2026-44990 xmp raw-text passthrough, CVE-2026-53606 `javascript:` URIs), and xmldom 0.1.x never got CVE-2021-21366/32796.

- Upgraded to **sanitize-html 2.17.5** + **@xmldom/xmldom 0.8.10** — the newest versions that still run on the production runtime (Docker `node:10`): 2.17.6+ requires the ESM-only htmlparser2 12, and @xmldom/xmldom 0.9+ requires Node >= 14.6. A follow-up runtime upgrade would allow going to the latest.
- Adapted `HtmlReady` to the new parser API: `onError` callback, explicit `text/html` mimeType for fragment parses, and a `parseFragment` helper (a Document node is no longer insertable into another tree). These adapters fix regressions that would otherwise blank out posts containing iframes/standalone images and silently disable linkify.
- Verification: old-vs-new stack diff on a 15-case benign corpus (13 byte-identical, 2 display-equivalent normalizations); full XSS payload battery (xmp/noembed/textarea rawtext incl. CVE-2026-44990, nested code markup, xmldom mXSS, transformTags attribute injection, remarkable CVE-2019-12043) all neutralized with parse5 browser-grade reparse clean.

### F47 — open redirect

The `ch=/cn=/r=` session-param stripping middleware redirected to the stripped URL without validation, so `GET //evil.com?ch=1` returned `302 Location: //evil.com`. The stripped target must now match `/^\/(?!\/)/` (same-origin relative path) or the request falls through to normal handling.

## Test plan

- [x] `npx jest` — 181/181 pass, incl. new `ExtractContent.test.js` (15 cases covering segment inertness, entity decoding, truncation)
- [x] `HtmlReady.test.js` stale parser-quirk assertion updated for @xmldom/xmldom 0.8 behavior
- [x] Prettier clean; eslint introduces no new violations
- [x] Lockfiles updated with minimal diffs — verified no unrelated transitive resolution drift (yarn/npm full regen was rejected because it downgraded ~174 unrelated packages incl. security-relevant ones); `yarn install` round-trip confirms lockfile consistency
- [ ] Full staging deploy + SSR smoke of feed/search/post pages before production rollout