### PR TITLE
fix(htmlready): do not treat synthetic html wrapper as a forbidden tag

### DIFF
--- a/src/shared/HtmlReady.js
+++ b/src/shared/HtmlReady.js
@@ -108,7 +108,13 @@ export default function(
         const hadWrapper = /^\s*<html[\s>]/i.test(prepared);
         const source = hadWrapper ? prepared : `<html>${prepared}</html>`;
         const doc = DOMParser.parseFromString(source, 'text/html');
-        traverse(doc, state);
+        // Synthetic <html> is parse scaffolding only. Walking from `doc`
+        // would record `html` in htmltags and fail Markdown-mode post
+        // validation ("Please remove ... <html>"). A real user-supplied
+        // <html> root still matches hadWrapper, so it is collected.
+        const traverseRoot =
+            hadWrapper || !doc.documentElement ? doc : doc.documentElement;
+        traverse(traverseRoot, state);
         if (mutate) {
             if (hideImages) {
                 for (const image of Array.from(

--- a/src/shared/HtmlReady.test.js
+++ b/src/shared/HtmlReady.test.js
@@ -18,6 +18,28 @@ describe('htmlready', () => {
         expect(res.html).toBeUndefined();
     });
 
+    it('should not report a synthetic html wrapper in htmltags', () => {
+        // Markdown-mode ReplyEditor rejects leftover htmltags after
+        // subtracting allowedTags; a parse-only <html> root must not
+        // block plain posts as "Please remove ... <html>".
+        const res = HtmlReady('<p>hello world</p>', { mutate: false });
+        expect(Array.from(res.htmltags)).toContain('p');
+        expect(Array.from(res.htmltags)).not.toContain('html');
+    });
+
+    it('should still report a real html root in htmltags', () => {
+        const res = HtmlReady('<html><p>hello world</p></html>', {
+            mutate: false,
+        });
+        expect(Array.from(res.htmltags)).toContain('html');
+        expect(Array.from(res.htmltags)).toContain('p');
+    });
+
+    it('should still report nested html inside a fragment', () => {
+        const res = HtmlReady('<p>hello</p><html>x</html>', { mutate: false });
+        expect(Array.from(res.htmltags)).toContain('html');
+    });
+
     it('should keep state collections on the error path', () => {
         const res = HtmlReady('teststring lol', { mutate: false });
         expect(res.images instanceof Set).toBe(true);


### PR DESCRIPTION
## Summary
- `#3993` wrapped fragment HTML in a synthetic `<html>` root so `@xmldom/xmldom` 0.8 can parse multi-root markdown. `traverse()` started at the document node and recorded that wrapper in `htmltags`.
- Markdown-mode `ReplyEditor` / `ReplyEditorNew` then rejected every post with `Please remove the following HTML elements from your post: <html>` (reported on `eec447b`).
- Skip the synthetic root when collecting tags (walk `documentElement` unless the input already had an `<html>` wrapper). Real user-supplied `<html>` (root or nested) is still reported. F35/F36/F47 sanitizer and redirect fixes are unchanged.

## Test plan
- [x] `npx jest src/shared/HtmlReady.test.js src/app/utils/ExtractContent.test.js` — 51/51 pass, including new cases for synthetic wrapper, real html root, and nested html in a fragment
- [x] Markdown-mode compose/comment on staging: a plain-text post publishes without the `<html>` validation error
- [x] HTML-mode post that actually starts with `<html>` is still accepted; markdown containing a nested `<html>` is still rejected