### PR TITLE
fix: user home feed section and GDPR user list 404 guard

### DIFF
--- a/__tests__/api/steem/posts.test.ts
+++ b/__tests__/api/steem/posts.test.ts
@@ -53,6 +53,26 @@ describe('GET /api/steem/posts', () => {
     expect(getRankedPostsMock).not.toHaveBeenCalled();
   });
 
+  it('forwards sort=feed to getAccountPosts (user home feed)', async () => {
+    getAccountPostsMock.mockResolvedValue([{ post_id: 3 }]);
+
+    const res = await GET(
+      makeGetRequest('/api/steem/posts', { account: 'alice', sort: 'feed' })
+    );
+    expect(res.status).toBe(200);
+    // Legacy PostsIndex ['home', user] calls bridge get_account_posts with
+    // sort 'feed'; the client forwards `sort` verbatim to that bridge call.
+    expect(getAccountPostsMock).toHaveBeenCalledWith({
+      sort: 'feed',
+      account: 'alice',
+      start_author: undefined,
+      start_permlink: undefined,
+      limit: 20,
+      observer: undefined,
+    });
+    expect(getRankedPostsMock).not.toHaveBeenCalled();
+  });
+
   it('forwards pagination params and observer (observer gates the server cache)', async () => {
     getRankedPostsMock.mockResolvedValue([]);
 

--- a/__tests__/lib/gdpr-user-list.test.ts
+++ b/__tests__/lib/gdpr-user-list.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest';
+import gdprUserList, { isGdprUser } from '@/lib/gdpr-user-list';
+
+describe('gdpr-user-list', () => {
+  it('contains the 25 accounts ported from legacy GDPRUserList.js', () => {
+    expect(gdprUserList).toHaveLength(25);
+    expect(gdprUserList).toContain('thedarkoverlord');
+    expect(gdprUserList).toContain('mateja.klaric');
+    expect(gdprUserList).toContain('nikapelex');
+  });
+
+  it('matches listed usernames', () => {
+    expect(isGdprUser('thedarkoverlord')).toBe(true);
+    expect(isGdprUser('mateja.klaric')).toBe(true);
+    expect(isGdprUser('m4r1a')).toBe(true);
+  });
+
+  it('is case-insensitive and trims whitespace', () => {
+    expect(isGdprUser('TheDarkOverlord')).toBe(true);
+    expect(isGdprUser('  nikapelex  ')).toBe(true);
+  });
+
+  it('rejects non-listed usernames', () => {
+    expect(isGdprUser('alice')).toBe(false);
+    expect(isGdprUser('steemit')).toBe(false);
+    expect(isGdprUser('')).toBe(false);
+  });
+
+  it('does not do substring matching', () => {
+    expect(isGdprUser('thedarkoverlord2')).toBe(false);
+    expect(isGdprUser('m4r1')).toBe(false);
+  });
+});

--- a/app/(main)/user/[username]/[section]/page.tsx
+++ b/app/(main)/user/[username]/[section]/page.tsx
@@ -24,9 +24,10 @@ import UserSettings from '@/components/modules/UserSettings';
 /**
  * User profile page with section
  * Route: /@[username]/[section]
- * Sections: blog, posts, comments, replies, payout, followers, followed, settings, notifications, communities
+ * Sections: blog, posts, comments, replies, payout, feed, followers, followed, settings, notifications, communities
  * Note: proxy.ts ensures only @username format reaches here
- * Equivalent to old route: UserProfile with params [@username, section]
+ * Equivalent to old route: UserProfile with params [@username, section];
+ * `feed` is legacy PostsIndex ['home', user] (bridge get_account_posts, sort 'feed')
  */
 export default function UserProfileSectionPage() {
   const params = useParams();
@@ -55,6 +56,7 @@ export default function UserProfileSectionPage() {
     'comments',
     'replies',
     'payout',
+    'feed',
   ].includes(section)
     ? (section as AccountPostsOrder)
     : 'blog';
@@ -95,7 +97,7 @@ export default function UserProfileSectionPage() {
       }
     };
 
-    if (['blog', 'posts', 'comments', 'replies', 'payout'].includes(section)) {
+    if (['blog', 'posts', 'comments', 'replies', 'payout', 'feed'].includes(section)) {
       loadPosts();
     } else {
       setLoading(false);
@@ -284,6 +286,26 @@ function emptySectionText(
       return `@${accountname} hasn't made any comments yet.`;
     case 'posts':
       return `@${accountname} hasn't made any posts yet.`;
+    case 'feed':
+      // Legacy PostsIndex noFriendsText (empty home feed).
+      return (
+        <span className="flex flex-col items-center gap-2">
+          <span>You haven&apos;t followed anyone yet!</span>
+          <span className="flex flex-wrap justify-center gap-3">
+            <Link href="/trending" className="text-accent-foreground underline">
+              Explore Trending
+            </Link>
+            <a
+              href="https://steemit.com/welcome"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent-foreground underline"
+            >
+              New users guide
+            </a>
+          </span>
+        </span>
+      );
     default:
       break;
   }

--- a/docs/ROUTE_MAP.md
+++ b/docs/ROUTE_MAP.md
@@ -18,31 +18,45 @@ All `proxy.ts` line references below are to the file at the repo root.
 | Legacy URL pattern | Legacy page | proxy.ts branch | Next.js route | Status |
 |---|---|---|---|---|
 | `/` | `PostsIndex ['trending']` | none (no rewrite; matcher allows it) | `app/page.tsx` (client redirect to `/trending`) | Implemented |
-| `/category/@username/permlink` | `Post` | Rewrite → `/post/<category>/<username>/<permlink>` (proxy.ts:74-83); skipped when `category` is reserved | `app/(main)/post/[category]/[username]/[permlink]/page.tsx` | Implemented |
-| `/@username/feed` | `PostsIndex ['home', user]` | Rewrite → `/user/<username>/feed` (proxy.ts:85-95) | `app/(main)/user/[username]/[section]/page.tsx` | **Gap** — see "Known gaps" |
-| `/@username/<section>` | `UserProfile` | Rewrite → `/user/<username>/<section>` (proxy.ts:97-108); `section` must be in `SECTIONS` (proxy.ts:21-24) | `app/(main)/user/[username]/[section]/page.tsx` | Implemented |
-| `/@username/<permlink>` | `PostNoCategory` | Rewrite → `/post-no-category/<username>/<permlink>` (proxy.ts:110-120); only when second segment is not a section | `app/(main)/post-no-category/[username]/[permlink]/page.tsx` (fetches category, redirects to `/<category>/@user/permlink`) | Implemented |
-| `/@username` | `UserProfile` (blog tab) | Rewrite → `/user/<username>` (proxy.ts:122-134); reserved usernames rewrite to `/404` | `app/(main)/user/[username]/page.tsx` (client redirect to `/@<username>/blog`) | Implemented |
-| `/<sort>/<tag>` | `PostsIndex [sort, tag]` | Pass-through when `sort` ∈ `SORT_TYPES` and `tag` doesn't start with `@` (proxy.ts:136-145) | `app/(main)/[sort]/[tag]/page.tsx` | Implemented |
-| `/<sort>` | `PostsIndex [sort]` | Pass-through when `sort` ∈ `SORT_TYPES` (proxy.ts:147-160); literal `/404` rewrites to `/404` | `app/(main)/[sort]/page.tsx` (renders `NotFound` for invalid sorts) | Implemented |
+| `/category/@username/permlink` | `Post` | Rewrite → `/post/<category>/<username>/<permlink>` (proxy.ts:87-96); skipped when `category` is reserved | `app/(main)/post/[category]/[username]/[permlink]/page.tsx` | Implemented |
+| `/@username/feed` | `PostsIndex ['home', user]` | Rewrite → `/user/<username>/feed` (proxy.ts:98-108) | `app/(main)/user/[username]/[section]/page.tsx` (fetches `bridge.get_account_posts` with sort `feed`, like legacy `PostsIndex ['home', user]`) | Implemented |
+| `/@username/<section>` | `UserProfile` | Rewrite → `/user/<username>/<section>` (proxy.ts:110-121); `section` must be in `SECTIONS` (proxy.ts:22-25) | `app/(main)/user/[username]/[section]/page.tsx` | Implemented |
+| `/@username/<permlink>` | `PostNoCategory` | Rewrite → `/post-no-category/<username>/<permlink>` (proxy.ts:123-133); only when second segment is not a section | `app/(main)/post-no-category/[username]/[permlink]/page.tsx` (fetches category, redirects to `/<category>/@user/permlink`) | Implemented |
+| `/@username` | `UserProfile` (blog tab) | Rewrite → `/user/<username>` (proxy.ts:135-147); reserved usernames rewrite to `/404` | `app/(main)/user/[username]/page.tsx` (client redirect to `/@<username>/blog`) | Implemented |
+| `/<sort>/<tag>` | `PostsIndex [sort, tag]` | Pass-through when `sort` ∈ `SORT_TYPES` and `tag` doesn't start with `@` (proxy.ts:149-158) | `app/(main)/[sort]/[tag]/page.tsx` | Implemented |
+| `/<sort>` | `PostsIndex [sort]` | Pass-through when `sort` ∈ `SORT_TYPES` (proxy.ts:160-173); literal `/404` rewrites to `/404` | `app/(main)/[sort]/page.tsx` (renders `NotFound` for invalid sorts) | Implemented |
 | `/trending` | `PostsIndex ['trending']` | Pass-through (also matched by the `/<sort>` branch) | `app/(main)/trending/page.tsx` (static route shadows `[sort]`) | Implemented |
-| `/roles/<tag>` (e.g. `/roles/hive-123456`) | `CommunityRoles` | Pass-through (proxy.ts:67-72) | `app/(main)/roles/[tag]/page.tsx` | Implemented |
-| `/<a>/<b>/<c>` without `@` (e.g. `/bitcoin/alice/my-post`) | `NotFound` | Rewrite → `/404` (proxy.ts:164-171), unless first segment is reserved or second starts with `@` | `app/(main)/404/page.tsx` | Implemented |
-| `/<a>/<b>` without `@`, non-sort (e.g. `/alice/my-post`) | `NotFound` | Rewrite → `/404` (proxy.ts:173-180) | `app/(main)/404/page.tsx` | Implemented |
-| `/<segment>` without `@`, non-sort, non-reserved (e.g. `/alice`) | `NotFound` | Rewrite → `/404` (proxy.ts:182-189) | `app/(main)/404/page.tsx` | Implemented |
+| `/roles/<tag>` (e.g. `/roles/hive-123456`) | `CommunityRoles` | Pass-through (proxy.ts:80-85) | `app/(main)/roles/[tag]/page.tsx` | Implemented |
+| `/<a>/<b>/<c>` without `@` (e.g. `/bitcoin/alice/my-post`) | `NotFound` | Rewrite → `/404` (proxy.ts:177-184), unless first segment is reserved or second starts with `@` | `app/(main)/404/page.tsx` | Implemented |
+| `/<a>/<b>` without `@`, non-sort (e.g. `/alice/my-post`) | `NotFound` | Rewrite → `/404` (proxy.ts:186-193) | `app/(main)/404/page.tsx` | Implemented |
+| `/<segment>` without `@`, non-sort, non-reserved (e.g. `/alice`) | `NotFound` | Rewrite → `/404` (proxy.ts:195-202) | `app/(main)/404/page.tsx` | Implemented |
 | `/%40username/...` | (same as `@` variants) | `%40` is decoded to `@` before matching (proxy.ts:38-44) | same as the corresponding `@` routes | Implemented |
 
-`SORT_TYPES` (proxy.ts:27-29): `hot`, `trending`, `promoted`, `payout`,
+`SORT_TYPES` (proxy.ts:28-30): `hot`, `trending`, `promoted`, `payout`,
 `payout_comments`, `muted`, `created` — identical to the legacy `<sort>`
 regex alternation.
 
-`SECTIONS` (proxy.ts:21-24): `blog`, `posts`, `comments`, `replies`,
+`SECTIONS` (proxy.ts:22-25): `blog`, `posts`, `comments`, `replies`,
 `payout`, `feed`, `followers`, `followed`, `settings`, `notifications`,
 `communities` — identical to the legacy `<account-tab>` alternation.
 
+## GDPR-blocked accounts
+
+`lib/gdpr-user-list.ts` ports legacy `src/app/utils/GDPRUserList.js`
+verbatim. Mirroring legacy `ResolveRoute.js`, any route family that exposes
+a GDPR-listed account returns `NotFound`: `/@user/feed` (UserFeed),
+`/@user` + all sections (UserProfile), `/@user/permlink` (PostNoCategory),
+and `/category/@user/permlink` (Post).
+
+A single guard in `proxy.ts` (proxy.ts:58-68) covers all four families —
+the `@`-segment is always the first or second path segment — by rewriting
+to `/404`. Usernames containing a dot (e.g. `mateja.klaric`) never reach
+the guard: the `.` skip (proxy.ts:48-56) passes them through and they 404
+via `not-found.tsx`, which is the same net effect.
+
 ## Static and reserved routes
 
-`RESERVED_ROUTES` (proxy.ts:14-18) guards against reserved words being
+`RESERVED_ROUTES` (proxy.ts:15-19) guards against reserved words being
 treated as categories or usernames. Whether a page actually exists for them:
 
 | Path | proxy.ts handling | Next.js route | Status |
@@ -53,8 +67,8 @@ treated as categories or usernames. Whether a page actually exists for them:
 | `/communities` | Pass-through | `app/(main)/communities/page.tsx` | Implemented |
 | `/trending`, `/hot`, `/created`, `/payout`, `/payout_comments`, `/muted` | Pass-through (`/<sort>` branch) | `app/(main)/[sort]/page.tsx` / `app/(main)/trending/page.tsx` | Implemented |
 | `/promoted` | Pass-through (`/<sort>` branch; note: in `SORT_TYPES` but **not** in `RESERVED_ROUTES`) | `app/(main)/[sort]/page.tsx` | Implemented |
-| `/404` | Explicitly skipped (proxy.ts:47-55) | `app/(main)/404/page.tsx` | Implemented (proxy 404 target) |
-| `/api/*`, `/_next/*`, `/static/*`, any path containing `.` | Skipped by proxy (proxy.ts:47-55); also excluded by the `matcher` (proxy.ts:194-205) | `app/api/**`, `app/.well-known/**`, `public/**` | Implemented |
+| `/404` | Explicitly skipped (proxy.ts:48-56) | `app/(main)/404/page.tsx` | Implemented (proxy 404 target) |
+| `/api/*`, `/_next/*`, `/static/*`, any path containing `.` | Skipped by proxy (proxy.ts:48-56); also excluded by the `matcher` (proxy.ts:208-219) | `app/api/**`, `app/.well-known/**`, `public/**` | Implemented |
 | `/tags` | Pass-through (reserved) | — | **Not migrated** (legacy `TagsIndex`); falls through to `not-found.tsx` |
 | `/rewards` | Pass-through (reserved) | — | **Not migrated** (legacy `Rewards`); falls through to `not-found.tsx` |
 | `/welcome`, `/about`, `/faq`, `/privacy`, `/support`, `/tos` | Pass-through (reserved) | — | **Not migrated** (marketing/static pages; legacy served them at `/about.html` etc. plus `/welcome`) |
@@ -78,14 +92,6 @@ Verified against `condenser-legacy/src/app/ResolveRoute.js` and
 
 ## Known gaps and behavioral differences
 
-- **`/@username/feed`**: legacy renders the user's home feed
-  (`PostsIndex ['home', user]`). The proxy rewrites it to the
-  `user/[username]/[section]` page, but that page has no `feed` branch —
-  `feed` is not in its post-fetching section list, so it renders the profile
-  header with the generic empty state instead of a feed. Tracked as a gap.
-- **GDPR user list**: legacy `ResolveRoute.js` returns `NotFound` for any
-  account in `GDPRUserList`. The new app has no equivalent check; those
-  profiles render normally.
 - **`/@<reserved>/<section>`** (e.g. `/@trending/blog`): both the section and
   post-no-category branches skip reserved usernames, and the 404 guards only
   fire for non-`@` paths, so the proxy passes it through and it 404s at

--- a/lib/api/steem.ts
+++ b/lib/api/steem.ts
@@ -73,7 +73,8 @@ export type AccountPostsOrder =
   | "posts"
   | "comments"
   | "replies"
-  | "payout";
+  | "payout"
+  | "feed";
 
 export interface FetchAccountPostsParams {
   account: string;

--- a/lib/gdpr-user-list.ts
+++ b/lib/gdpr-user-list.ts
@@ -1,0 +1,43 @@
+/**
+ * GDPR-blocked account names: these users exercised their right to be
+ * forgotten, so every route family that exposes them must 404
+ * (see proxy.ts). Ported verbatim from master's
+ * src/app/utils/GDPRUserList.js.
+ */
+const gdprUserList: string[] = [
+  'mateja.klaric',
+  'xondra',
+  'tgylhn',
+  'vichkovski',
+  'wizzymt',
+  'thedarkoverlord',
+  'twoblokestrading',
+  'ruttydm',
+  'mlcuk',
+  'm4r1a',
+  'bridgenit',
+  'bitchminer',
+  'bisade',
+  'boy666',
+  'casually',
+  'nayardu92',
+  'djdarkstorm',
+  'cristinaluchi',
+  'dennis.spiedt',
+  'sebtarnowski',
+  'mihailm',
+  'ardaia',
+  'jemand',
+  'chiefadu',
+  'nikapelex',
+];
+
+/**
+ * Membership check; defensive against case and surrounding whitespace
+ * (legacy compared verbatim against path segments).
+ */
+export function isGdprUser(name: string): boolean {
+  return gdprUserList.includes(name.trim().toLowerCase());
+}
+
+export default gdprUserList;

--- a/proxy.ts
+++ b/proxy.ts
@@ -9,6 +9,7 @@
 
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
+import { isGdprUser } from './lib/gdpr-user-list';
 
 // Reserved routes that should not be treated as categories
 const RESERVED_ROUTES = [
@@ -52,6 +53,18 @@ export function proxy(request: NextRequest) {
     pathname.includes('.')
   ) {
     return NextResponse.next();
+  }
+
+  // GDPR-listed accounts 404 on every route family that exposes them
+  // (mirrors legacy ResolveRoute.js GDPRUserList checks): /@user,
+  // /@user/<section|permlink|feed> and /category/@user/permlink.
+  // A single guard covers all four families because the @-segment is always
+  // the first or second path segment in each of them. Note: usernames
+  // containing a dot (e.g. mateja.klaric) are skipped by the '.' guard above
+  // and 404 naturally via not-found — same net effect.
+  const gdprMatch = pathname.match(/^\/(?:[^\/]+\/)?@([^\/]+)/);
+  if (gdprMatch && isGdprUser(gdprMatch[1])) {
+    return NextResponse.rewrite(new URL('/404', request.url));
   }
 
   // Follow legacy route matching order (ResolveRoute.js):

--- a/scripts/test-proxy-routes.ts
+++ b/scripts/test-proxy-routes.ts
@@ -63,6 +63,18 @@ const testCases = [
   // Community routes
   { path: '/roles/hive-123456', expected: 'next', description: 'Community roles page' },
   
+  // GDPR-listed accounts (legacy GDPRUserList → NotFound on all four route families)
+  { path: '/@thedarkoverlord', expected: '404', description: 'GDPR user: profile root' },
+  { path: '/@thedarkoverlord/blog', expected: '404', description: 'GDPR user: profile section' },
+  { path: '/@thedarkoverlord/feed', expected: '404', description: 'GDPR user: feed' },
+  { path: '/@thedarkoverlord/my-post', expected: '404', description: 'GDPR user: post without category' },
+  { path: '/steem/@thedarkoverlord/my-post', expected: '404', description: 'GDPR user: post with category' },
+  { path: '/@TheDarkOverlord', expected: '404', description: 'GDPR user: match is case-insensitive' },
+  { path: '/@xondra/settings', expected: '404', description: 'GDPR user: settings section' },
+  { path: '/@mateja.klaric', expected: 'next', description: 'GDPR user with dot: skipped by "." guard (404s via not-found)' },
+  { path: '/@alice', expected: 'rewrite:/user/alice', description: 'Non-GDPR user unaffected' },
+  { path: '/steem/@alice/my-post', expected: 'rewrite:/post/steem/alice/my-post', description: 'Non-GDPR user post unaffected' },
+  
   // Sort feeds (pass through to [sort] / [sort]/[tag] routes)
   { path: '/hot', expected: 'next', description: 'Hot posts page' },
   { path: '/created', expected: 'next', description: 'Created posts page' },


### PR DESCRIPTION
## Summary

Closes the two functional gaps found while building `docs/ROUTE_MAP.md`:

**1. `/@username/feed` rendered an empty shell**

Legacy resolves `/@user/feed` to `PostsIndex ['home', user]` → bridge `get_account_posts` with `sort: 'feed'`. The rewrite in `proxy.ts` worked, but the section page never fetched feed data.

- Add `'feed'` to `AccountPostsOrder` (`lib/api/steem.ts`); the client forwards `sort` verbatim to `callBridge('get_account_posts', …)`, so no route-handler change was needed
- Wire `feed` into `app/(main)/user/[username]/[section]/page.tsx` (order mapping + fetch-enabled sections + load-more reuse)
- Empty-state copy mirrors legacy PostsIndex `noFriendsText` (`/welcome` is not migrated, so the guide link points to `https://steemit.com/welcome`, matching the existing blog empty-state)

**2. GDPRUserList not ported**

Legacy `ResolveRoute.js` returns NotFound for GDPR-listed users on all four route families (`/@user`, `/@user/<section|permlink|feed>`, `/category/@user/permlink`).

- Port the 25-name list verbatim to `lib/gdpr-user-list.ts` with a defensive `isGdprUser()` (trim + lowercase)
- Single guard in `proxy.ts` captures the `@`-segment in first or second position and rewrites to `/404` — one place covers all four families, mirroring legacy's route-resolution-level enforcement
- Usernames containing a dot are skipped by the existing `.` guard and 404 naturally via `not-found` — same net effect (noted in code comment + ROUTE_MAP)

## Tests

- `pnpm test` — 69 passed (new: 5 gdpr-list unit tests, 1 feed route case)
- `pnpm test:proxy` — 50 passed (new: 10 GDPR cases; profile/feed/section/post with & without category → 404, case-insensitive, dot-name skip, non-GDPR unaffected)
- `pnpm build` — passes
- `docs/ROUTE_MAP.md` — both known-gap entries resolved, line refs re-synced

🤖 Generated with Kimi Code