### PR TITLE
fix: P1 parity bugs — comments shape, search ES body, feed observer, tuple mapping, auth wiring

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -45,4 +45,7 @@ NEXT_PUBLIC_SIGNUP_URL=https://signup.steemit.com
 # External Steemit wallet (Condenser only links out). Production default: https://steemitwallet.com
 # Unset in production build to use that default; set for test/staging, e.g.:
 # NEXT_PUBLIC_WALLET_URL=https://wallet.steemitdev.com
+# Elasticsearch endpoint for /api/search. Without it the search route returns
+# empty mock results (dev convenience). ELASTICSEARCH_ENDPOINT is accepted as
+# a legacy alias, but ELASTICSEARCH_URL is the documented name.
 # ELASTICSEARCH_URL=http://localhost:9200

--- a/__tests__/api/search.test.ts
+++ b/__tests__/api/search.test.ts
@@ -1,0 +1,157 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { makePostRequest } from '@/__tests__/helpers/request';
+import { POST } from '@/app/api/search/route';
+
+const ES_URL = 'http://es.example:9200';
+
+const ES_RESULT = {
+  hits: { hits: [{ _source: { author: 'alice' } }], total: { value: 1 } },
+  _scroll_id: 'scroll-1',
+};
+
+function mockEsOk(body: unknown = ES_RESULT) {
+  return vi.fn().mockResolvedValue(
+    new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    })
+  );
+}
+
+describe('POST /api/search', () => {
+  beforeEach(() => {
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.stubEnv('ELASTICSEARCH_URL', ES_URL);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('returns 400 when q is empty', async () => {
+    const res = await POST(makePostRequest('/api/search', { q: '  ' }));
+    expect(res.status).toBe(400);
+  });
+
+  it('returns empty mock results when no endpoint is configured', async () => {
+    vi.stubEnv('ELASTICSEARCH_URL', '');
+    vi.stubEnv('ELASTICSEARCH_ENDPOINT', '');
+    const fetchMock = vi.fn();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(makePostRequest('/api/search', { q: 'steem' }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      hits: { hits: [], total: { value: 0 } },
+      _scroll_id: null,
+    });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('sends the query object unwrapped (no { searchQuery } wrapper)', async () => {
+    const fetchMock = mockEsOk();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(makePostRequest('/api/search', { q: 'steem' }));
+    expect(res.status).toBe(200);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [endpoint, init] = fetchMock.mock.calls[0];
+    expect(endpoint).toBe(`${ES_URL}/hive_posts/_search?scroll=1m`);
+    expect(JSON.parse(init.body)).toEqual({
+      size: 30,
+      query: { match_phrase: { searchable: { query: 'steem', slop: 3 } } },
+      sort: { created_at: { order: 'desc' } }, // legacy default sort field
+    });
+    expect(init.signal).toBeDefined();
+    expect(await res.json()).toEqual(ES_RESULT);
+  });
+
+  it('honors the legacy ELASTICSEARCH_ENDPOINT alias', async () => {
+    vi.stubEnv('ELASTICSEARCH_URL', '');
+    vi.stubEnv('ELASTICSEARCH_ENDPOINT', ES_URL);
+    const fetchMock = mockEsOk();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(makePostRequest('/api/search', { q: 'steem' }));
+    expect(res.status).toBe(200);
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      `${ES_URL}/hive_posts/_search?scroll=1m`
+    );
+  });
+
+  it('targets hive_replies / hive_accounts by depth', async () => {
+    const fetchMock = mockEsOk();
+    vi.stubGlobal('fetch', fetchMock);
+
+    await POST(makePostRequest('/api/search', { q: 'steem', depth: 1 }));
+    await POST(makePostRequest('/api/search', { q: 'steem', depth: 2 }));
+
+    expect(fetchMock.mock.calls[0][0]).toBe(
+      `${ES_URL}/hive_replies/_search?scroll=1m`
+    );
+    expect(fetchMock.mock.calls[1][0]).toBe(
+      `${ES_URL}/hive_accounts/_search?scroll=1m`
+    );
+    // Account search uses a wildcard on `name`, no sort.
+    expect(JSON.parse(fetchMock.mock.calls[1][1].body)).toEqual({
+      size: 30,
+      query: { wildcard: { name: { value: 'steem*' } } },
+    });
+  });
+
+  it('posts scroll_id to the scroll endpoint for pagination', async () => {
+    const fetchMock = mockEsOk();
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(
+      makePostRequest('/api/search', { q: 'steem', scroll_id: 'abc123' })
+    );
+    expect(res.status).toBe(200);
+
+    const [endpoint, init] = fetchMock.mock.calls[0];
+    expect(endpoint).toBe(`${ES_URL}/_search/scroll`);
+    expect(JSON.parse(init.body)).toEqual({ scroll: '1m', scroll_id: 'abc123' });
+  });
+
+  it('returns 502 when ES responds non-2xx', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(new Response('bad request', { status: 400 }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(makePostRequest('/api/search', { q: 'steem' }));
+    expect(res.status).toBe(502);
+    expect(await res.json()).toEqual({
+      error: 'Search backend error',
+      code: 'SEARCH_BACKEND_ERROR',
+      es_status: 400,
+    });
+  });
+
+  it('returns 503 when the ES fetch times out', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(new DOMException('The operation timed out', 'TimeoutError'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(makePostRequest('/api/search', { q: 'steem' }));
+    expect(res.status).toBe(503);
+    expect(await res.json()).toEqual({
+      error: 'Search temporarily unavailable',
+      code: 'SEARCH_UNAVAILABLE',
+    });
+  });
+
+  it('returns 503 when ES is unreachable (network error)', async () => {
+    const fetchMock = vi
+      .fn()
+      .mockRejectedValue(new TypeError('fetch failed'));
+    vi.stubGlobal('fetch', fetchMock);
+
+    const res = await POST(makePostRequest('/api/search', { q: 'steem' }));
+    expect(res.status).toBe(503);
+  });
+});

--- a/__tests__/api/steem/comments.test.ts
+++ b/__tests__/api/steem/comments.test.ts
@@ -12,6 +12,44 @@ const getDiscussionMock = vi.mocked(getDiscussion);
 
 const PARAMS = { author: 'alice', permlink: 'my-post' };
 
+/**
+ * Realistic bridge `get_discussion` response: a content map keyed by
+ * "author/permlink". The root post sits at the queried key; each node's
+ * `replies` is an array of child KEYS into the same map (legacy loadThread).
+ */
+const DISCUSSION_MAP = {
+  'alice/my-post': {
+    author: 'alice',
+    permlink: 'my-post',
+    body: 'the root post',
+    replies: ['bob/nice-post', 'carol/first'],
+  },
+  'bob/nice-post': {
+    author: 'bob',
+    permlink: 'nice-post',
+    body: 'nice post',
+    parent_author: 'alice',
+    parent_permlink: 'my-post',
+    replies: ['dave/thanks-bob'],
+  },
+  'carol/first': {
+    author: 'carol',
+    permlink: 'first',
+    body: 'first!',
+    parent_author: 'alice',
+    parent_permlink: 'my-post',
+    replies: [],
+  },
+  'dave/thanks-bob': {
+    author: 'dave',
+    permlink: 'thanks-bob',
+    body: 'thanks bob',
+    parent_author: 'bob',
+    parent_permlink: 'nice-post',
+    replies: [],
+  },
+};
+
 describe('GET /api/steem/comments', () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -36,18 +74,33 @@ describe('GET /api/steem/comments', () => {
     expect(res.status).toBe(404);
   });
 
-  it('returns the replies of the discussion', async () => {
-    const replies = [{ author: 'bob', body: 'nice post' }];
-    getDiscussionMock.mockResolvedValue({ replies });
+  it('flattens the discussion map and excludes the root post', async () => {
+    getDiscussionMock.mockResolvedValue(DISCUSSION_MAP);
 
     const res = await GET(makeGetRequest('/api/steem/comments', PARAMS));
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual(replies);
+
+    const comments = (await res.json()) as Array<{
+      author: string;
+      permlink: string;
+    }>;
+    expect(comments).toHaveLength(3);
+    // The root post is excluded; every other map entry is returned as-is.
+    expect(comments.map((c) => `${c.author}/${c.permlink}`).sort()).toEqual([
+      'bob/nice-post',
+      'carol/first',
+      'dave/thanks-bob',
+    ]);
+    expect(comments).toContainEqual(DISCUSSION_MAP['bob/nice-post']);
+    expect(comments).toContainEqual(DISCUSSION_MAP['carol/first']);
+    expect(comments).toContainEqual(DISCUSSION_MAP['dave/thanks-bob']);
     expect(getDiscussionMock).toHaveBeenCalledWith(PARAMS);
   });
 
-  it('returns an empty list when the discussion has no replies', async () => {
-    getDiscussionMock.mockResolvedValue({});
+  it('returns an empty list when the root post has no comments', async () => {
+    getDiscussionMock.mockResolvedValue({
+      'alice/my-post': DISCUSSION_MAP['alice/my-post'],
+    });
 
     const res = await GET(makeGetRequest('/api/steem/comments', PARAMS));
     expect(res.status).toBe(200);

--- a/__tests__/api/steem/communities.test.ts
+++ b/__tests__/api/steem/communities.test.ts
@@ -29,8 +29,11 @@ describe('GET /api/steem/communities', () => {
     expect(getUserSubscriptionsMock).not.toHaveBeenCalled();
   });
 
-  it('returns subscriptions for an account', async () => {
-    getUserSubscriptionsMock.mockResolvedValue([['hive-1', 'Steem']]);
+  it('returns subscriptions for an account, mapping tuples to objects', async () => {
+    // bridge.list_all_subscriptions tuples: [community, title, role, affiliation]
+    getUserSubscriptionsMock.mockResolvedValue([
+      ['hive-1', 'Steem', 'mod', 'founder'],
+    ]);
 
     const res = await GET(
       makeGetRequest('/api/steem/communities', {
@@ -39,8 +42,29 @@ describe('GET /api/steem/communities', () => {
       })
     );
     expect(res.status).toBe(200);
-    expect(await res.json()).toEqual([['hive-1', 'Steem']]);
+    expect(await res.json()).toEqual([
+      {
+        name: 'hive-1',
+        title: 'Steem',
+        context: { role: 'mod', title: 'founder' },
+      },
+    ]);
     expect(getUserSubscriptionsMock).toHaveBeenCalledWith({ account: 'alice' });
+  });
+
+  it('falls back to the community id when the tuple title is empty', async () => {
+    getUserSubscriptionsMock.mockResolvedValue([['hive-2', '', 'guest', '']]);
+
+    const res = await GET(
+      makeGetRequest('/api/steem/communities', {
+        type: 'subscriptions',
+        account: 'alice',
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      { name: 'hive-2', title: 'hive-2', context: { role: 'guest', title: '' } },
+    ]);
   });
 
   it('lists communities with defaults and forwards the observer', async () => {

--- a/__tests__/api/steem/community-roles.test.ts
+++ b/__tests__/api/steem/community-roles.test.ts
@@ -1,0 +1,106 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { makeGetRequest } from '@/__tests__/helpers/request';
+
+vi.mock('@/lib/steem/client', () => ({
+  getCommunityRoles: vi.fn(),
+  getCommunitySubscribers: vi.fn(),
+}));
+
+import { GET } from '@/app/api/steem/community-roles/route';
+import { getCommunityRoles, getCommunitySubscribers } from '@/lib/steem/client';
+
+const getCommunityRolesMock = vi.mocked(getCommunityRoles);
+const getCommunitySubscribersMock = vi.mocked(getCommunitySubscribers);
+
+describe('GET /api/steem/community-roles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  it('returns 400 without a community', async () => {
+    const res = await GET(makeGetRequest('/api/steem/community-roles'));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Community is required' });
+    expect(getCommunityRolesMock).not.toHaveBeenCalled();
+    expect(getCommunitySubscribersMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 for an unknown type', async () => {
+    const res = await GET(
+      makeGetRequest('/api/steem/community-roles', {
+        community: 'hive-1',
+        type: 'bogus',
+      })
+    );
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({
+      error: 'Type must be "roles" or "subscribers"',
+    });
+  });
+
+  it('maps list_community_roles [name, role, title] tuples to objects', async () => {
+    // Tuple order per legacy pages/CommunityRoles.jsx (tuple[0]=name,
+    // tuple[1]=role, tuple[2]=title).
+    getCommunityRolesMock.mockResolvedValue([
+      ['alice', 'admin', 'founder'],
+      ['bob', 'mod', ''],
+    ]);
+
+    const res = await GET(
+      makeGetRequest('/api/steem/community-roles', { community: 'hive-1' })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      { name: 'alice', role: 'admin', title: 'founder' },
+      { name: 'bob', role: 'mod', title: '' },
+    ]);
+    expect(getCommunityRolesMock).toHaveBeenCalledWith({ community: 'hive-1' });
+  });
+
+  it('maps list_subscribers [name, role, title, created_at] tuples to objects', async () => {
+    // Tuple order per legacy modules/CommunitySubscriberList.jsx (s[0]=name,
+    // s[1]=role, s[2]=title); hivemind appends created_at at index 3.
+    getCommunitySubscribersMock.mockResolvedValue([
+      ['carol', 'guest', '', '2024-01-01T00:00:00'],
+    ]);
+
+    const res = await GET(
+      makeGetRequest('/api/steem/community-roles', {
+        community: 'hive-1',
+        type: 'subscribers',
+      })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      { name: 'carol', role: 'guest', title: '', created_at: '2024-01-01T00:00:00' },
+    ]);
+    expect(getCommunitySubscribersMock).toHaveBeenCalledWith({
+      community: 'hive-1',
+    });
+  });
+
+  it('passes through already-object rows unchanged', async () => {
+    getCommunityRolesMock.mockResolvedValue([
+      { name: 'alice', role: 'admin', title: 'founder' },
+    ]);
+
+    const res = await GET(
+      makeGetRequest('/api/steem/community-roles', { community: 'hive-1' })
+    );
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual([
+      { name: 'alice', role: 'admin', title: 'founder' },
+    ]);
+  });
+
+  it('propagates RPC failures as 500', async () => {
+    getCommunityRolesMock.mockRejectedValue(new Error('boom'));
+
+    const res = await GET(
+      makeGetRequest('/api/steem/community-roles', { community: 'hive-1' })
+    );
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: 'boom' });
+  });
+});

--- a/__tests__/components/Header.test.tsx
+++ b/__tests__/components/Header.test.tsx
@@ -1,0 +1,88 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+import userReducer, { setUser } from '@/store/slices/userSlice';
+
+const routerPush = vi.fn();
+const routerRefresh = vi.fn();
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: routerPush, refresh: routerRefresh }),
+  usePathname: () => '/trending',
+}));
+
+// Render the dropdown inline (no portal) so menu items are directly clickable.
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuGroup: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => (
+    <button type="button" onClick={onClick}>
+      {children}
+    </button>
+  ),
+  DropdownMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => null,
+}));
+
+vi.mock('@/components/layout/SidePanel', () => ({
+  SidePanel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/layout/SteemitLogo', () => ({
+  SteemitLogo: () => <div>logo</div>,
+}));
+vi.mock('@/components/elements/Userpic', () => ({
+  default: () => <div>userpic</div>,
+}));
+vi.mock('@/components/elements/NotificationBadge', () => ({
+  default: () => null,
+}));
+
+import { Header } from '@/components/layout/Header';
+
+function makeStore() {
+  return configureStore({ reducer: { user: userReducer } });
+}
+
+describe('Header logout', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    vi.clearAllMocks();
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it('dispatches logoutThunk and refreshes without navigating away', async () => {
+    const store = makeStore();
+    store.dispatch(setUser({ username: 'alice', posting_authority: true }));
+    window.localStorage.setItem('autopost2', JSON.stringify({ username: 'alice' }));
+
+    render(
+      <Provider store={store}>
+        <Header />
+      </Provider>
+    );
+
+    fireEvent.click(screen.getByText('Logout'));
+
+    await waitFor(() => {
+      expect(store.getState().user.current).toEqual({});
+    });
+    expect(store.getState().user.logged_out).toBe(true);
+    expect(window.localStorage.getItem('autopost2')).toBeNull();
+    expect(fetch).toHaveBeenCalledWith('/api/auth/logout', { method: 'POST' });
+    expect(routerRefresh).toHaveBeenCalled();
+    // Legacy does not navigate on logout
+    expect(routerPush).not.toHaveBeenCalled();
+  });
+});

--- a/__tests__/hooks/use-session-hydration.test.tsx
+++ b/__tests__/hooks/use-session-hydration.test.tsx
@@ -1,0 +1,93 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { renderHook, waitFor } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+import type { ReactNode } from 'react';
+
+import {
+  resetSessionHydrationForTests,
+  useSessionHydration,
+} from '@/hooks/use-session-hydration';
+import userReducer from '@/store/slices/userSlice';
+
+function makeStore() {
+  return configureStore({ reducer: { user: userReducer } });
+}
+
+function wrapper(store: ReturnType<typeof makeStore>) {
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <Provider store={store}>{children}</Provider>;
+  };
+}
+
+function mockSessionResponse(body: unknown, ok = true) {
+  (fetch as Mock).mockResolvedValue({ ok, json: async () => body });
+}
+
+describe('useSessionHydration', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn());
+    resetSessionHydrationForTests();
+  });
+
+  it('restores user identity into Redux when the session is authenticated', async () => {
+    mockSessionResponse({
+      authenticated: true,
+      session: { username: 'alice', uid: 'uid-1' },
+    });
+    const store = makeStore();
+
+    renderHook(() => useSessionHydration(), { wrapper: wrapper(store) });
+
+    await waitFor(() => {
+      expect(store.getState().user.current.username).toBe('alice');
+    });
+    // Same action shape loginThunk dispatches on success
+    expect(store.getState().user.current).toMatchObject({
+      username: 'alice',
+      posting_authority: true,
+      pass_auth: true,
+    });
+  });
+
+  it('leaves the user logged out when the session is unauthenticated', async () => {
+    mockSessionResponse({ authenticated: false, session: null });
+    const store = makeStore();
+
+    renderHook(() => useSessionHydration(), { wrapper: wrapper(store) });
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledWith('/api/auth/session', {
+        credentials: 'same-origin',
+      });
+    });
+    expect(store.getState().user.current).toEqual({});
+  });
+
+  it('leaves the user logged out when the fetch fails', async () => {
+    (fetch as Mock).mockRejectedValue(new Error('network down'));
+    const store = makeStore();
+
+    renderHook(() => useSessionHydration(), { wrapper: wrapper(store) });
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalled();
+    });
+    expect(store.getState().user.current).toEqual({});
+  });
+
+  it('hydrates only once per page load, even across remounts', async () => {
+    mockSessionResponse({ authenticated: false, session: null });
+    const store = makeStore();
+
+    const first = renderHook(() => useSessionHydration(), {
+      wrapper: wrapper(store),
+    });
+    first.unmount();
+    renderHook(() => useSessionHydration(), { wrapper: wrapper(store) });
+
+    await waitFor(() => {
+      expect(fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/__tests__/store/authThunks.test.ts
+++ b/__tests__/store/authThunks.test.ts
@@ -1,0 +1,44 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+import userReducer, { setUser } from '@/store/slices/userSlice';
+import { logoutThunk } from '@/store/thunks/authThunks';
+
+function makeStore() {
+  return configureStore({ reducer: { user: userReducer } });
+}
+
+describe('logoutThunk', () => {
+  beforeEach(() => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({ ok: true }));
+    window.localStorage.clear();
+    window.sessionStorage.clear();
+  });
+
+  it('clears Redux user state, stored credentials and the server session', async () => {
+    const store = makeStore();
+    store.dispatch(setUser({ username: 'alice', posting_authority: true }));
+    window.localStorage.setItem('autopost2', JSON.stringify({ username: 'alice' }));
+    window.sessionStorage.setItem('steem_encrypted_key', '{"encrypted":"x"}');
+
+    await store.dispatch(logoutThunk());
+
+    const state = store.getState().user;
+    expect(state.current).toEqual({});
+    expect(state.logged_out).toBe(true);
+    expect(window.localStorage.getItem('autopost2')).toBeNull();
+    expect(window.sessionStorage.getItem('steem_encrypted_key')).toBeNull();
+    expect(fetch).toHaveBeenCalledWith('/api/auth/logout', { method: 'POST' });
+  });
+
+  it('still clears local state when the server logout call fails', async () => {
+    (fetch as Mock).mockRejectedValue(new Error('network down'));
+    const store = makeStore();
+    store.dispatch(setUser({ username: 'alice' }));
+
+    await store.dispatch(logoutThunk());
+
+    expect(store.getState().user.current).toEqual({});
+    expect(store.getState().user.logged_out).toBe(true);
+  });
+});

--- a/app/(main)/[sort]/[tag]/page.tsx
+++ b/app/(main)/[sort]/[tag]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams } from "next/navigation";
-import { useAppDispatch } from "@/store/hooks";
+import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { setPathname } from "@/store/slices/globalSlice";
 import {
   fetchRankedPosts,
@@ -27,6 +27,7 @@ const VALID_SORTS = [
 export default function SortTagPage() {
   const dispatch = useAppDispatch();
   const { sort, tag } = useParams();
+  const observer = useAppSelector((s) => s.user.current?.username);
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
   const [hasMore, setHasMore] = useState(true);
@@ -42,15 +43,23 @@ export default function SortTagPage() {
     dispatch(setPathname(`/${sortString}/${tagString}`));
   }, [dispatch, sortString, tagString, isValidSort]);
 
+  // Normalize sort/tag for API calls: proxy.ts lowercases only for validation
+  // and passes the raw-cased segments through, so `/Trending/My` would query a
+  // bogus sort/tag. Legacy lowercases the tag before querying
+  // (PostsIndex.jsx mapStateToProps). Display values stay as-is.
+  const order = sortString.toLowerCase() as FetchPostsParams["order"];
+  const fetchCategory = tagString.toLowerCase();
+
   const loadInitial = useCallback(async () => {
     if (!isValidSort) return;
     setLoading(true);
     setHasMore(true);
     try {
       const newPosts = await fetchRankedPosts({
-        order: sortString as FetchPostsParams["order"],
-        category: tagString,
+        order,
+        category: fetchCategory,
         limit: 20,
+        observer,
       });
       setPosts(newPosts);
       setHasMore(newPosts.length >= 20);
@@ -63,7 +72,7 @@ export default function SortTagPage() {
     } finally {
       setLoading(false);
     }
-  }, [sortString, tagString, isValidSort]);
+  }, [order, fetchCategory, sortString, tagString, isValidSort, observer]);
 
   useEffect(() => {
     if (!isValidSort) {
@@ -81,11 +90,12 @@ export default function SortTagPage() {
     try {
       const last = posts[posts.length - 1];
       const morePosts = await fetchRankedPosts({
-        order: sortString as FetchPostsParams["order"],
-        category: tagString,
+        order,
+        category: fetchCategory,
         start_author: last.author,
         start_permlink: last.permlink,
         limit: 20,
+        observer,
       });
       const slice =
         morePosts[0]?.author === last.author &&
@@ -105,7 +115,7 @@ export default function SortTagPage() {
       setLoading(false);
       loadingMoreRef.current = false;
     }
-  }, [isValidSort, loading, hasMore, posts, sortString, tagString]);
+  }, [isValidSort, loading, hasMore, posts, order, fetchCategory, observer]);
 
   const isHiveCommunity = tagString.startsWith("hive-");
 

--- a/app/(main)/[sort]/page.tsx
+++ b/app/(main)/[sort]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect, useState, useCallback, useRef } from "react";
 import { useParams } from "next/navigation";
-import { useAppDispatch } from "@/store/hooks";
+import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { setPathname } from "@/store/slices/globalSlice";
 import {
   fetchRankedPosts,
@@ -27,6 +27,7 @@ const VALID_SORTS = [
 export default function SortPage() {
   const dispatch = useAppDispatch();
   const { sort } = useParams();
+  const observer = useAppSelector((s) => s.user.current?.username);
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
   const [hasMore, setHasMore] = useState(true);
@@ -42,14 +43,20 @@ export default function SortPage() {
     dispatch(setPathname(`/${sortString}`));
   }, [dispatch, sortString, isValidSort]);
 
+  // Normalize the sort for API calls; proxy.ts lowercases only for validation
+  // and passes the raw-cased segment through, so `/Trending` must still query
+  // `trending`. Display values stay as-is.
+  const order = sortString.toLowerCase() as FetchPostsParams["order"];
+
   const loadInitial = useCallback(async () => {
     if (!isValidSort) return;
     setLoading(true);
     setHasMore(true);
     try {
       const newPosts = await fetchRankedPosts({
-        order: sortString as FetchPostsParams["order"],
+        order,
         limit: 20,
+        observer,
       });
       setPosts(newPosts);
       setHasMore(newPosts.length >= 20);
@@ -59,7 +66,7 @@ export default function SortPage() {
     } finally {
       setLoading(false);
     }
-  }, [sortString, isValidSort]);
+  }, [order, sortString, isValidSort, observer]);
 
   useEffect(() => {
     if (!isValidSort) {
@@ -77,10 +84,11 @@ export default function SortPage() {
     try {
       const last = posts[posts.length - 1];
       const morePosts = await fetchRankedPosts({
-        order: sortString as FetchPostsParams["order"],
+        order,
         start_author: last.author,
         start_permlink: last.permlink,
         limit: 20,
+        observer,
       });
       const slice =
         morePosts[0]?.author === last.author &&
@@ -100,7 +108,7 @@ export default function SortPage() {
       setLoading(false);
       loadingMoreRef.current = false;
     }
-  }, [isValidSort, loading, hasMore, posts, sortString]);
+  }, [isValidSort, loading, hasMore, posts, order, sortString, observer]);
 
   if (showNotFound) {
     return <NotFound />;

--- a/app/(main)/trending/page.tsx
+++ b/app/(main)/trending/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState, useCallback, useRef } from "react";
-import { useAppDispatch } from "@/store/hooks";
+import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { setPathname } from "@/store/slices/globalSlice";
 import { fetchRankedPosts, Post } from "@/lib/api/steem";
 import PostsList from "@/components/cards/PostsList";
@@ -13,6 +13,7 @@ import { FeedListHeader } from "@/components/layout/FeedListHeader";
  */
 export default function TrendingPage() {
   const dispatch = useAppDispatch();
+  const observer = useAppSelector((s) => s.user.current?.username);
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
   const [hasMore, setHasMore] = useState(true);
@@ -29,6 +30,7 @@ export default function TrendingPage() {
         const fetchedPosts = await fetchRankedPosts({
           order: "trending",
           limit: 20,
+          observer,
         });
         setPosts(fetchedPosts);
         setHasMore(fetchedPosts.length >= 20);
@@ -39,7 +41,7 @@ export default function TrendingPage() {
       }
     };
     void loadPosts();
-  }, []);
+  }, [observer]);
 
   const handleLoadMore = useCallback(async () => {
     if (loading || !hasMore || posts.length === 0) return;
@@ -53,6 +55,7 @@ export default function TrendingPage() {
         start_author: lastPost.author,
         start_permlink: lastPost.permlink,
         limit: 20,
+        observer,
       });
       const newPosts =
         morePosts[0]?.author === lastPost.author &&
@@ -72,7 +75,7 @@ export default function TrendingPage() {
       setLoading(false);
       loadingMoreRef.current = false;
     }
-  }, [loading, hasMore, posts]);
+  }, [loading, hasMore, posts, observer]);
 
   return (
     <FeedLayout>

--- a/app/api/search/route.ts
+++ b/app/api/search/route.ts
@@ -14,14 +14,19 @@ interface SearchParams {
 
 interface ElasticsearchQuery {
   size: number;
-  query?: any;
-  sort?: any;
+  query?: Record<string, unknown>;
+  sort?: Record<string, unknown>;
 }
+
+// Legacy parity (src/server/api/general.js): abortable ES fetch with a short
+// timeout to avoid socket exhaustion when ES DNS breaks or ES is down.
+const ES_FETCH_TIMEOUT_MS = 1200;
 
 export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
-    const { q, s = 'created', depth = 0, scroll_id } = body as SearchParams;
+    // Legacy default sort field is `created_at` (the ES field name).
+    const { q, s = 'created_at', depth = 0, scroll_id } = body as SearchParams;
 
     if (!q || q.trim().length === 0) {
       return NextResponse.json(
@@ -30,11 +35,14 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Get Elasticsearch endpoint from environment
-    const elasticSearchEndpoint = process.env.ELASTICSEARCH_ENDPOINT;
-    
+    // `ELASTICSEARCH_URL` is the documented name (.env.example,
+    // docs/CONFIGURATION.md); `ELASTICSEARCH_ENDPOINT` is kept as a legacy
+    // alias for existing deployments.
+    const elasticSearchEndpoint =
+      process.env.ELASTICSEARCH_URL || process.env.ELASTICSEARCH_ENDPOINT;
+
     if (!elasticSearchEndpoint) {
-      // Return mock data for development
+      // Return mock data for development (intentional dev convenience)
       return NextResponse.json({
         hits: {
           hits: [],
@@ -88,7 +96,9 @@ export async function POST(request: NextRequest) {
       };
     }
 
-    let requestBody: any = { searchQuery };
+    // ES expects the query object itself ({size, query, sort}), NOT a
+    // { searchQuery: {...} } wrapper — the wrapper made ES return 400.
+    let requestBody: unknown = searchQuery;
     let endpoint = searchEndpoint;
 
     // Handle scroll pagination
@@ -107,26 +117,49 @@ export async function POST(request: NextRequest) {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(requestBody),
+      signal: AbortSignal.timeout(ES_FETCH_TIMEOUT_MS),
     });
 
     if (!response.ok) {
-      throw new Error(`Elasticsearch request failed: ${response.statusText}`);
+      // Pass through non-2xx from ES as 502 to make the failure explicit
+      // (legacy behavior).
+      return NextResponse.json(
+        {
+          error: 'Search backend error',
+          code: 'SEARCH_BACKEND_ERROR',
+          es_status: response.status,
+        },
+        { status: 502 }
+      );
     }
 
     const result = await response.json();
     return NextResponse.json(result);
 
-  } catch (error: any) {
+  } catch (error: unknown) {
+    // ES connectivity failure or timeout: search is unavailable (503),
+    // never a silent 200 with empty hits.
+    const errName = (error as { name?: string } | null)?.name;
+    const isConnectivityError =
+      error instanceof DOMException ||
+      error instanceof TypeError ||
+      errName === 'TimeoutError' ||
+      errName === 'AbortError';
+    if (isConnectivityError) {
+      console.error('Search unavailable (ES connectivity/timeout):', error);
+      return NextResponse.json(
+        {
+          error: 'Search temporarily unavailable',
+          code: 'SEARCH_UNAVAILABLE',
+        },
+        { status: 503 }
+      );
+    }
+
     console.error('Search error:', error);
-    
-    // Return empty results on error (for development)
-    return NextResponse.json({
-      hits: {
-        hits: [],
-        total: { value: 0 },
-      },
-      _scroll_id: null,
-      error: error.message,
-    });
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Search failed' },
+      { status: 500 }
+    );
   }
 }

--- a/app/api/steem/comments/route.ts
+++ b/app/api/steem/comments/route.ts
@@ -19,8 +19,14 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Get discussion which includes the post and all comments
-    const discussion = (await getDiscussion({ author, permlink })) as { replies?: unknown[] } | null;
+    // Bridge `get_discussion` returns a content MAP keyed by "author/permlink"
+    // (legacy loadThread): the root post lives at the `${author}/${permlink}`
+    // key, every other entry is a comment. There is no top-level `replies`
+    // field — each node's `replies` is an array of child map keys.
+    const discussion = (await getDiscussion({ author, permlink })) as Record<
+      string,
+      unknown
+    > | null;
 
     if (!discussion) {
       return NextResponse.json(
@@ -29,9 +35,12 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // Extract comments from discussion
-    // The discussion structure may vary, adjust based on actual API response
-    const comments = discussion.replies || [];
+    // Flatten the map, excluding the root post itself; CommentsList rebuilds
+    // the tree client-side from parent_author/parent_permlink.
+    const rootKey = `${author}/${permlink}`;
+    const comments = Object.entries(discussion)
+      .filter(([key]) => key !== rootKey)
+      .map(([, content]) => content);
 
     return NextResponse.json(comments);
   } catch (error: unknown) {

--- a/app/api/steem/communities/route.ts
+++ b/app/api/steem/communities/route.ts
@@ -28,6 +28,19 @@ export async function GET(request: NextRequest) {
         );
       }
       result = await getUserSubscriptions({ account });
+      // bridge.list_all_subscriptions returns tuples, not objects:
+      // [community, community_title, role, affiliation_title]
+      // (legacy cards/SubscriptionsList.jsx renderItem). Map to typed objects
+      // so the client contract stays object-shaped.
+      result = (result || []).map((item: unknown) => {
+        if (!Array.isArray(item)) return item;
+        const [community, communityTitle, role, affiliationTitle] = item;
+        return {
+          name: community,
+          title: communityTitle || community,
+          context: { role, title: affiliationTitle },
+        };
+      });
     } else {
       // List communities
       result = await listCommunities({

--- a/app/api/steem/community-roles/route.ts
+++ b/app/api/steem/community-roles/route.ts
@@ -29,9 +29,23 @@ export async function GET(request: NextRequest) {
 
     let result;
     if (type === 'roles') {
-      result = await getCommunityRoles({ community });
+      // bridge.list_community_roles returns [name, role, title] tuples
+      // (legacy pages/CommunityRoles.jsx destructures tuple[0..2]).
+      const roles = await getCommunityRoles({ community });
+      result = (roles || []).map((item: unknown) => {
+        if (!Array.isArray(item)) return item;
+        const [name, role, title] = item;
+        return { name, role, title };
+      });
     } else {
-      result = await getCommunitySubscribers({ community });
+      // bridge.list_subscribers returns [name, role, title, created_at] tuples
+      // (legacy modules/CommunitySubscriberList.jsx uses s[0..2]).
+      const subscribers = await getCommunitySubscribers({ community });
+      result = (subscribers || []).map((item: unknown) => {
+        if (!Array.isArray(item)) return item;
+        const [name, role, title, created_at] = item;
+        return { name, role, title, created_at };
+      });
     }
 
     return NextResponse.json(result || []);

--- a/app/api/steem/followers/route.ts
+++ b/app/api/steem/followers/route.ts
@@ -1,6 +1,9 @@
 /**
  * Steem API Route: Get Followers/Following Lists
- * GET /api/steem/followers?account=username&type=followers&page=1&limit=20
+ * GET /api/steem/followers?account=username&type=followers&page=0&limit=20
+ *
+ * `page` is 0-based: condenser_api.get_followers_by_page expects a 0-based
+ * page and legacy passes its 0-based currentPage straight through.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -11,7 +14,7 @@ export async function GET(request: NextRequest) {
     const searchParams = request.nextUrl.searchParams;
     const account = searchParams.get('account');
     const type = searchParams.get('type') || 'followers'; // 'followers' or 'following'
-    const page = parseInt(searchParams.get('page') || '1');
+    const page = parseInt(searchParams.get('page') || '0');
     const limit = parseInt(searchParams.get('limit') || '20');
 
     if (!account) {

--- a/components/cards/FollowList.tsx
+++ b/components/cards/FollowList.tsx
@@ -25,7 +25,10 @@ export default function FollowList({ accountname, type, total }: FollowListProps
   const currentUser = useAppSelector((s) => s.user.current?.username);
   const [items, setItems] = useState<FollowItem[]>([]);
   const [loading, setLoading] = useState(true);
-  const [page, setPage] = useState(1);
+  // 0-based page: condenser_api.get_followers_by_page expects a 0-based page
+  // and legacy passes its 0-based currentPage straight through
+  // (elements/UserList.jsx + FetchDataSaga.js getFollowers).
+  const [page, setPage] = useState(0);
 
   const loadPage = useCallback(
     async (p: number) => {
@@ -46,15 +49,15 @@ export default function FollowList({ accountname, type, total }: FollowListProps
   );
 
   useEffect(() => {
-    void loadPage(1);
+    void loadPage(0);
   }, [loadPage]);
 
   const totalPages =
     typeof total === 'number' && total > 0
       ? Math.ceil(total / PAGE_SIZE)
       : items.length >= PAGE_SIZE
-        ? page + 1 // unknown total; at least one more page
-        : page;
+        ? page + 2 // unknown total; at least one more page
+        : page + 1;
 
   if (loading && items.length === 0) {
     return (
@@ -75,9 +78,10 @@ export default function FollowList({ accountname, type, total }: FollowListProps
   }
 
   // Page number window (ReactPaginate-like: prev/next + numbered pages).
+  // Internal pages are 0-based; the UI displays 1-based labels.
   const pageNumbers: number[] = [];
-  const start = Math.max(1, Math.min(page - 2, totalPages - 4));
-  for (let p = start; p <= Math.min(totalPages, start + 4); p++) {
+  const start = Math.max(0, Math.min(page - 2, totalPages - 5));
+  for (let p = start; p <= Math.min(totalPages - 1, start + 4); p++) {
     pageNumbers.push(p);
   }
 
@@ -116,13 +120,13 @@ export default function FollowList({ accountname, type, total }: FollowListProps
         >
           <button
             type="button"
-            disabled={page <= 1 || loading}
+            disabled={page <= 0 || loading}
             onClick={() => void loadPage(page - 1)}
             className="rounded px-2 py-1 text-foreground hover:bg-accent disabled:opacity-40"
           >
             previous
           </button>
-          {start > 1 && <span className="px-1 text-muted-foreground">…</span>}
+          {start > 0 && <span className="px-1 text-muted-foreground">…</span>}
           {pageNumbers.map((p) => (
             <button
               key={p}
@@ -135,15 +139,15 @@ export default function FollowList({ accountname, type, total }: FollowListProps
                   : 'text-foreground hover:bg-accent'
               } disabled:opacity-40`}
             >
-              {p}
+              {p + 1}
             </button>
           ))}
-          {pageNumbers[pageNumbers.length - 1] < totalPages && (
+          {pageNumbers[pageNumbers.length - 1] < totalPages - 1 && (
             <span className="px-1 text-muted-foreground">…</span>
           )}
           <button
             type="button"
-            disabled={page >= totalPages || loading}
+            disabled={page >= totalPages - 1 || loading}
             onClick={() => void loadPage(page + 1)}
             className="rounded px-2 py-1 text-foreground hover:bg-accent disabled:opacity-40"
           >

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -19,6 +19,7 @@ import { getSteemitWalletBaseUrl } from "@/lib/steemitWallet";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { toggleNightmode } from "@/store/slices/appSlice";
 import { showLogin } from "@/store/slices/userSlice";
+import { logoutThunk } from "@/store/thunks/authThunks";
 import { SteemitLogo } from "@/components/layout/SteemitLogo";
 import { SidePanel } from "@/components/layout/SidePanel";
 import Userpic from "@/components/elements/Userpic";
@@ -139,13 +140,12 @@ export function Header() {
     if (win) win.opener = null;
   };
 
-  const logout = async () => {
-    await fetch("/api/auth/logout", {
-      method: "POST",
-      credentials: "same-origin",
-    });
+  const handleLogout = async () => {
+    // Full logout: clears the stored key, Redux state and the server session.
+    // Legacy does not navigate away on logout (UserSaga.js logout), so we
+    // stay on the current page and just refresh server components.
+    await dispatch(logoutThunk());
     router.refresh();
-    router.push("/");
   };
 
   return (
@@ -276,7 +276,7 @@ export function Header() {
                   >
                     Wallet
                   </DropdownMenuItem>
-                  <DropdownMenuItem onClick={() => void logout()}>
+                  <DropdownMenuItem onClick={() => void handleLogout()}>
                     Logout
                   </DropdownMenuItem>
                 </DropdownMenuGroup>

--- a/components/modules/LoginForm.tsx
+++ b/components/modules/LoginForm.tsx
@@ -185,7 +185,16 @@ export default function LoginForm({ embedded = false }: { embedded?: boolean }) 
       ).unwrap();
 
       dispatch(hideLogin());
-      router.refresh();
+
+      // Legacy (UserSaga.js:495-500) navigates to the user's feed after
+      // logging in from the login page or the home page; modal logins from
+      // other pages stay put and just refresh.
+      const path = window.location.pathname;
+      if (path === '/login' || path === '/') {
+        router.push('/trending/my');
+      } else {
+        router.refresh();
+      }
     } catch (err: unknown) {
       console.error('Login error:', err);
       const errorMessage = err instanceof Error ? err.message : 'Login failed. Please try again.';

--- a/hooks/use-session-hydration.ts
+++ b/hooks/use-session-hydration.ts
@@ -1,0 +1,60 @@
+'use client';
+
+/**
+ * Session hydration hook
+ * Restores user identity into Redux on app mount when a valid server-side
+ * session cookie exists (legacy App.jsx auto-login equivalent).
+ *
+ * Note: this only restores identity/UI state. The encrypted private key in
+ * sessionStorage does not survive a page reload by design, so posting
+ * actions will prompt for the key again — that is intentional.
+ */
+
+import { useEffect } from 'react';
+import { useAppDispatch } from '@/store/hooks';
+import { setUser } from '@/store/slices/userSlice';
+
+// One hydration attempt per page load is enough: the session cookie lives
+// for 30 days, and on failure the UI simply stays logged out until the next
+// load. The guard also absorbs React strict-mode double effects.
+let hydrationStarted = false;
+
+/** Reset the hydration guard (test-only). */
+export function resetSessionHydrationForTests() {
+  hydrationStarted = false;
+}
+
+export function useSessionHydration() {
+  const dispatch = useAppDispatch();
+
+  useEffect(() => {
+    if (hydrationStarted) return;
+    hydrationStarted = true;
+
+    let cancelled = false;
+
+    fetch('/api/auth/session', { credentials: 'same-origin' })
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (cancelled || !data?.authenticated) return;
+        const username = data.session?.username;
+        if (!username) return;
+        // Same action shape loginThunk dispatches on success so downstream
+        // selectors behave identically.
+        dispatch(
+          setUser({
+            username,
+            posting_authority: true, // Session implies a verified posting key
+            pass_auth: true,
+          })
+        );
+      })
+      .catch(() => {
+        // Network/session errors leave the UI logged out.
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [dispatch]);
+}

--- a/lib/api/steem.ts
+++ b/lib/api/steem.ts
@@ -263,11 +263,11 @@ export interface FollowItem {
 }
 
 /**
- * Fetch followers list
+ * Fetch followers list. `page` is 0-based (see app/api/steem/followers/route.ts).
  */
 export async function fetchFollowers(
   account: string,
-  page: number = 1,
+  page: number = 0,
   limit: number = 20
 ): Promise<FollowItem[]> {
   const searchParams = new URLSearchParams({
@@ -288,11 +288,11 @@ export async function fetchFollowers(
 }
 
 /**
- * Fetch following list
+ * Fetch following list. `page` is 0-based (see app/api/steem/followers/route.ts).
  */
 export async function fetchFollowing(
   account: string,
-  page: number = 1,
+  page: number = 0,
   limit: number = 20
 ): Promise<FollowItem[]> {
   const searchParams = new URLSearchParams({
@@ -435,6 +435,7 @@ export interface CommunitySubscriber {
   name: string;
   role?: string;
   title?: string;
+  created_at?: string;
   [key: string]: any;
 }
 

--- a/next.config.ts
+++ b/next.config.ts
@@ -31,6 +31,19 @@ const nextConfig: NextConfig = {
   
   // Transpile packages if needed
   transpilePackages: [],
+
+  // Legacy URL aliases (legacy ResolveRoute.js mapped /login.html to the
+  // login page). Declared here rather than in proxy.ts so the redirect is
+  // evaluated before the route-resolution proxy.
+  async redirects() {
+    return [
+      {
+        source: '/login.html',
+        destination: '/login',
+        permanent: true,
+      },
+    ];
+  },
 };
 
 export default nextConfig;

--- a/store/Provider.tsx
+++ b/store/Provider.tsx
@@ -2,8 +2,19 @@
 
 import { Provider } from 'react-redux';
 import { store } from './index';
+import { useSessionHydration } from '@/hooks/use-session-hydration';
 
-export function ReduxProvider({ children }: { children: React.ReactNode }) {
-  return <Provider store={store}>{children}</Provider>;
+// Hydrates Redux from the server session cookie on first mount. Must live
+// inside <Provider> to access the dispatch context.
+function SessionHydration({ children }: { children: React.ReactNode }) {
+  useSessionHydration();
+  return <>{children}</>;
 }
 
+export function ReduxProvider({ children }: { children: React.ReactNode }) {
+  return (
+    <Provider store={store}>
+      <SessionHydration>{children}</SessionHydration>
+    </Provider>
+  );
+}


### PR DESCRIPTION
## Summary

Fixes for the high/medium-severity findings from a legacy behavioral-parity audit of the high-traffic pages (audit compared the new app against `condenser-legacy` page by page). Several of these were live bugs, not just parity gaps:

**API layer**
- **Comments route** (`app/api/steem/comments/route.ts`): `get_discussion` returns a content **map** keyed by `author/permlink`, but the route read a nonexistent `discussion.replies` — **comments never loaded on post pages** (masked by an incorrect test mock). Now flattens the map minus the root, matching what `CommentsList.buildCommentTree` consumes.
- **Search route** (`app/api/search/route.ts`): the ES request body was wrapped one level too deep (`{"searchQuery":{…}}` → ES 400, swallowed into empty results — **search was broken whenever ES was configured**); unified the env var to the documented `ELASTICSEARCH_URL` (old name kept as alias); added 1200ms timeout + 502 (ES non-2xx) / 503 (unavailable) instead of catch-all 200; default sort fixed to `created_at`.

**Feeds / profile / roles**
- Feed pages (`[sort]`, `[sort]/[tag]`, `trending`) now pass `observer` when logged in — **restores `/trending/my`** (my-communities feed). Cache observer-bypass gating already existed server-side.
- Tag lowercased for fetch (legacy behavior); sort normalized to lowercase at the fetch layer.
- **Tuple parsing bugs**: `list_all_subscriptions`, `list_community_roles`, `list_subscribers` return tuple arrays but were read as objects — communities section and roles page rendered `undefined`/`@undefined`. Tuples are now mapped to typed objects at the route boundary (index order verified against legacy).
- Followers/following pagination was 1-based; legacy and the RPC are 0-based — the first page of 20 was skipped.

**Auth wiring** (infrastructure existed but was never connected)
- Header logout now dispatches the existing `logoutThunk` (clears Redux + stored key + server session); stays on the current page like legacy.
- New `useSessionHydration` hook restores identity into Redux from the session cookie on mount (refresh no longer "logs you out" in the UI). Private keys are intentionally NOT restored (sessionStorage design).
- Login from `/login` or `/` now redirects to `/trending/my` (legacy behavior).
- `/login.html` → `/login` permanent redirect in `next.config.ts`.

## Deliberately left for follow-up PRs (found by the audit, not addressed here)

- PostEditor rewrite (currently WIP: hardcoded author + `prompt()` for the key) — posting/commenting
- Post page `generateMetadata` SEO, gray-post hiding gate, comment `?sort=` URL sync
- Community role editing, Settings `account_update2` broadcast, notifications mark-as-read on chain
- Muted-author client-side filtering in feeds

## Test plan

- `pnpm test` — 19 files / 92 tests, all green (new: search route, community-roles tuple mapping, session hydration, authThunks, Header)
- `pnpm build` — passes
- `npx eslint` on touched files — clean

🤖 Generated with Kimi Code