### PR TITLE
feat: server-side SEO metadata for post and user pages

### DIFF
--- a/__tests__/lib/seo.test.ts
+++ b/__tests__/lib/seo.test.ts
@@ -1,0 +1,229 @@
+import { describe, expect, it } from 'vitest';
+import {
+  SITE_ORIGIN,
+  buildAccountMetadata,
+  buildPostMetadata,
+  makeCanonicalLink,
+  type SeoPost,
+} from '@/lib/seo';
+
+const basePost: SeoPost = {
+  author: 'alice',
+  permlink: 'hello-world',
+  category: 'photography',
+  title: 'Hello World',
+  body: 'A short post about cameras.',
+  created: '2024-01-02T03:04:05',
+  depth: 0,
+  json_metadata: { tags: ['photography', 'film'] },
+};
+
+describe('makeCanonicalLink', () => {
+  it('defaults to the steemit scheme', () => {
+    expect(makeCanonicalLink(basePost, null)).toBe(
+      'https://steemit.com/photography/@alice/hello-world'
+    );
+  });
+
+  it('accepts an absolute http(s) canonical_url from json_metadata', () => {
+    expect(
+      makeCanonicalLink(basePost, {
+        canonical_url: 'https://example.com/my-post',
+      })
+    ).toBe('https://example.com/my-post');
+  });
+
+  it.each([
+    'javascript:alert(1)',
+    'ftp://example.com/post',
+    '//example.com/post',
+    'example.com/post',
+  ])('rejects non-http canonical_url %j', (url) => {
+    expect(makeCanonicalLink(basePost, { canonical_url: url })).toBe(
+      'https://steemit.com/photography/@alice/hello-world'
+    );
+  });
+
+  it('uses the whitelisted app scheme (steempeak)', () => {
+    expect(makeCanonicalLink(basePost, { app: 'steempeak/1.0' })).toBe(
+      'https://steempeak.com/photography/@alice/hello-world'
+    );
+  });
+
+  it('uses the whitelisted app scheme (travelfeed, no category slot)', () => {
+    expect(makeCanonicalLink(basePost, { app: 'travelfeed/2.0' })).toBe(
+      'https://travelfeed.io/@alice/hello-world'
+    );
+  });
+
+  it('falls back to the steemit scheme for non-whitelisted apps', () => {
+    expect(makeCanonicalLink(basePost, { app: 'busy/1.0' })).toBe(
+      'https://steemit.com/photography/@alice/hello-world'
+    );
+  });
+
+  it('ignores malformed app strings (no version part)', () => {
+    expect(makeCanonicalLink(basePost, { app: 'steempeak' })).toBe(
+      'https://steemit.com/photography/@alice/hello-world'
+    );
+  });
+
+  it('rewrites hive-* category to the community title slug', () => {
+    const post: SeoPost = {
+      ...basePost,
+      category: 'hive-123456',
+      community_title: 'Photo Lovers!',
+      json_metadata: { tags: ['hive-123456', 'photography'] },
+    };
+    expect(makeCanonicalLink(post, null)).toBe(
+      'https://steemit.com/photo-lovers/@alice/hello-world'
+    );
+  });
+
+  // Legacy quirk (CanonicalLinker.build_scheme): without a community_title,
+  // Option 1 falls back to `#${category}`, and sanitizing `#hive-123456`
+  // strips the dash, yielding `hive123456` — which no longer starts with
+  // `hive-`, so the Option 2 tag fallback never fires for hive categories.
+  it('sanitizes a bare hive-* category to its dash-less slug (legacy parity)', () => {
+    const post: SeoPost = {
+      ...basePost,
+      category: 'hive-123456',
+      json_metadata: { tags: ['hive-123456', 'film'] },
+    };
+    expect(makeCanonicalLink(post, null)).toBe(
+      'https://steemit.com/hive123456/@alice/hello-world'
+    );
+  });
+
+  it('falls back to the first non-community tag when the community title sanitizes to nothing', () => {
+    const post: SeoPost = {
+      ...basePost,
+      category: 'hive-123456',
+      community_title: '!!!',
+      json_metadata: { tags: ['hive-123456', 'film'] },
+    };
+    expect(makeCanonicalLink(post, null)).toBe(
+      'https://steemit.com/film/@alice/hello-world'
+    );
+  });
+
+  it('ignores canonical_url when metadata is null (local URL)', () => {
+    const withCanon = makeCanonicalLink(basePost, basePost.json_metadata!);
+    const local = makeCanonicalLink(basePost, null);
+    expect(withCanon).toBe(local);
+  });
+});
+
+describe('buildPostMetadata', () => {
+  it('maps the legacy addPostMeta fields', () => {
+    const meta = buildPostMetadata(basePost);
+    expect(meta.title).toBe('Hello World — Steemit');
+    expect(meta.description).toBe('A short post about cameras. by alice');
+    expect(meta.alternates?.canonical).toBe(
+      'https://steemit.com/photography/@alice/hello-world'
+    );
+    expect(meta.openGraph).toMatchObject({
+      title: 'Hello World — Steemit',
+      type: 'article',
+      url: 'https://steemit.com/photography/@alice/hello-world',
+      description: 'A short post about cameras. by alice',
+      siteName: 'Steemit',
+      tags: ['photography'],
+      publishedTime: '2024-01-02T03:04:05',
+    });
+    expect(meta.twitter).toMatchObject({ site: '@steemit' });
+  });
+
+  it('strips markdown syntax from the description', () => {
+    const meta = buildPostMetadata({
+      ...basePost,
+      body: 'A **short** post about cameras.',
+    });
+    const desc = String(meta.description);
+    expect(desc).not.toContain('*');
+    expect(desc.replace(/\s+/g, ' ')).toContain('A short post about cameras.');
+  });
+
+  it('never emits raw HTML from the body into the description', () => {
+    const meta = buildPostMetadata({
+      ...basePost,
+      body: 'Hello <script>alert(1)</script><b>world</b> https://spam.example/x',
+    });
+    expect(String(meta.description)).not.toMatch(/<[^>]+>/);
+    expect(String(meta.description)).not.toContain('https://');
+    expect(String(meta.description)).toContain('Hello');
+  });
+
+  it('uses json_metadata.image[0] with a summary_large_image card', () => {
+    const meta = buildPostMetadata({
+      ...basePost,
+      json_metadata: {
+        tags: ['photography'],
+        image: ['https://example.com/pic.jpg'],
+      },
+    });
+    expect(meta.openGraph?.images).toEqual(['https://example.com/pic.jpg']);
+    expect(meta.twitter?.card).toBe('summary_large_image');
+    expect(meta.twitter?.images).toEqual(['https://example.com/pic.jpg']);
+  });
+
+  it('falls back to the author avatar with a summary card when there is no image', () => {
+    const meta = buildPostMetadata({ ...basePost, body: 'no images here' });
+    expect(meta.openGraph?.images).toEqual([`${SITE_ORIGIN}/avatar/alice`]);
+    expect(meta.twitter?.card).toBe('summary');
+  });
+
+  it('strips quotes in the description for replies (depth > 0)', () => {
+    const meta = buildPostMetadata({
+      ...basePost,
+      depth: 1,
+      body: '> quoted text\n\nmy reply',
+    });
+    expect(meta.description).toBe('my reply by alice');
+  });
+
+  it('honours json_metadata.canonical_url as alternates.canonical but keeps og:url local', () => {
+    const meta = buildPostMetadata({
+      ...basePost,
+      json_metadata: {
+        tags: ['photography'],
+        canonical_url: 'https://example.com/original',
+      },
+    });
+    expect(meta.alternates?.canonical).toBe('https://example.com/original');
+    expect(meta.openGraph?.url).toBe(
+      'https://steemit.com/photography/@alice/hello-world'
+    );
+  });
+});
+
+describe('buildAccountMetadata', () => {
+  it('maps the legacy addAccountMeta fields', () => {
+    const meta = buildAccountMetadata('alice', {
+      name: 'Alice A.',
+      about: 'Photographer',
+      profile_image: 'https://example.com/avatar.png',
+    });
+    expect(meta.title).toBe('@alice');
+    expect(meta.description).toBe(
+      'The latest posts from Alice A.. Follow me at @alice. Photographer'
+    );
+    expect(meta.twitter).toMatchObject({
+      card: 'summary',
+      site: '@steemit',
+      title: '@alice',
+      images: ['https://example.com/avatar.png'],
+    });
+  });
+
+  it('falls back to account name and default about/image', () => {
+    const meta = buildAccountMetadata('alice', null);
+    expect(meta.title).toBe('@alice');
+    expect(meta.description).toBe(
+      'The latest posts from alice. Follow me at @alice. Steemit: Communities Without Borders.'
+    );
+    expect(meta.twitter?.images).toEqual([
+      `${SITE_ORIGIN}/images/steemit-twshare-2.png`,
+    ]);
+  });
+});

--- a/app/(main)/post-no-category/[username]/[permlink]/PostNoCategoryClient.tsx
+++ b/app/(main)/post-no-category/[username]/[permlink]/PostNoCategoryClient.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { normalizeUsername, formatUsername } from '@/lib/utils/username';
+import { fetchPostByPermlink } from '@/lib/api/steem';
+import { FeedLayout } from '@/components/layout/FeedLayout';
+
+/**
+ * Post page without category — client content.
+ * Rendered by the server page shell in ./page.tsx (which owns
+ * generateMetadata); keeps the original behaviour of redirecting to
+ * /[category]/@[username]/[permlink] after fetching the post's category.
+ */
+export default function PostNoCategoryClient() {
+  const router = useRouter();
+  const params = useParams();
+  const usernameRaw = params.username as string;
+  const username = normalizeUsername(usernameRaw);
+  const permlink = params.permlink as string;
+
+  useEffect(() => {
+    const loadAndRedirect = async () => {
+      try {
+        const post = await fetchPostByPermlink(null, username, permlink);
+        if (post && post.category) {
+          router.replace(`/${post.category}/${formatUsername(username)}/${permlink}`);
+        } else {
+          router.replace(`/general/${formatUsername(username)}/${permlink}`);
+        }
+      } catch (error) {
+        console.error('Error fetching post:', error);
+        router.replace(`/general/${formatUsername(username)}/${permlink}`);
+      }
+    };
+
+    void loadAndRedirect();
+  }, [username, permlink, router]);
+
+  return (
+    <FeedLayout>
+      <div className="flex flex-col items-center justify-center gap-2 py-12">
+        <p className="text-muted-foreground">Loading...</p>
+      </div>
+    </FeedLayout>
+  );
+}

--- a/app/(main)/post-no-category/[username]/[permlink]/page.tsx
+++ b/app/(main)/post-no-category/[username]/[permlink]/page.tsx
@@ -1,49 +1,43 @@
-'use client';
-
-import { useEffect } from 'react';
-import { useParams, useRouter } from 'next/navigation';
-import { normalizeUsername, formatUsername } from '@/lib/utils/username';
-import { fetchPostByPermlink } from '@/lib/api/steem';
-import { FeedLayout } from '@/components/layout/FeedLayout';
+import type { Metadata } from 'next';
+import { getDiscussion } from '@/lib/steem/client';
+import { normalizeUsername } from '@/lib/utils/username';
+import { buildPostMetadata, type SeoPost } from '@/lib/seo';
+import PostNoCategoryClient from './PostNoCategoryClient';
 
 /**
- * Post page without category (redirects to category version)
+ * Post page without category (server shell).
  * Route: /post-no-category/[username]/[permlink]
- * This is rewritten from /@[username]/[permlink] by middleware
- * Equivalent to old route: PostNoCategory with params [@username, permlink]
- * This redirects to /[category]/@[username]/[permlink] after fetching the post's category
+ * This is rewritten from /@[username]/[permlink] by middleware.
+ * The client component redirects to the canonical category URL;
+ * generateMetadata still emits post meta for crawlers that never follow
+ * the client-side redirect. Fetch failures degrade to a bare title.
  */
-export default function PostNoCategoryPage() {
-  const router = useRouter();
-  const params = useParams();
-  const usernameRaw = params.username as string;
-  const username = normalizeUsername(usernameRaw);
-  const permlink = params.permlink as string;
-
-  useEffect(() => {
-    const loadAndRedirect = async () => {
-      try {
-        const post = await fetchPostByPermlink(null, username, permlink);
-        if (post && post.category) {
-          router.replace(`/${post.category}/${formatUsername(username)}/${permlink}`);
-        } else {
-          router.replace(`/general/${formatUsername(username)}/${permlink}`);
-        }
-      } catch (error) {
-        console.error('Error fetching post:', error);
-        router.replace(`/general/${formatUsername(username)}/${permlink}`);
-      }
-    };
-
-    void loadAndRedirect();
-  }, [username, permlink, router]);
-
-  return (
-    <FeedLayout>
-      <div className="flex flex-col items-center justify-center gap-2 py-12">
-        <p className="text-muted-foreground">Loading...</p>
-      </div>
-    </FeedLayout>
-  );
+interface PageParams {
+  username: string;
+  permlink: string;
 }
 
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<PageParams>;
+}): Promise<Metadata> {
+  const { username, permlink } = await params;
+  const author = normalizeUsername(username);
+  try {
+    const discussion = (await getDiscussion({ author, permlink })) as Record<
+      string,
+      SeoPost
+    > | null;
+    const post = discussion?.[`${author}/${permlink}`];
+    if (!post || !post.author) return { title: 'Steemit' };
+    return buildPostMetadata(post);
+  } catch (error) {
+    console.error('generateMetadata: failed to fetch post:', error);
+    return { title: 'Steemit' };
+  }
+}
+
+export default function PostNoCategoryPage() {
+  return <PostNoCategoryClient />;
+}

--- a/app/(main)/post/[category]/[username]/[permlink]/PostPageClient.tsx
+++ b/app/(main)/post/[category]/[username]/[permlink]/PostPageClient.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import { useAppDispatch } from '@/store/hooks';
+import { setPathname } from '@/store/slices/globalSlice';
+import { normalizeUsername, formatUsername } from '@/lib/utils/username';
+import PostFull from '@/components/cards/PostFull';
+import CommentsList from '@/components/cards/CommentsList';
+import { PostEditorResult } from '@/components/elements/PostEditor';
+import { Post, fetchPostByPermlink, fetchCommentsByPermlink } from '@/lib/api/steem';
+import { FeedLayout } from '@/components/layout/FeedLayout';
+
+/**
+ * Post page client content (with category).
+ * Rendered by the server page shell in ./page.tsx, which owns
+ * generateMetadata; this component keeps the original client-side
+ * fetch/render behaviour.
+ */
+export default function PostPageClient() {
+  const params = useParams();
+  const dispatch = useAppDispatch();
+  const category = params.category as string;
+  const usernameRaw = params.username as string;
+  const username = normalizeUsername(usernameRaw);
+  const permlink = params.permlink as string;
+  const [post, setPost] = useState<Post | null>(null);
+  const [comments, setComments] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  // Set pathname in global state
+  useEffect(() => {
+    const pathname = `/${category}/${formatUsername(username)}/${permlink}`;
+    dispatch(setPathname(pathname));
+  }, [category, username, permlink, dispatch]);
+
+  // Fetch post data and comments
+  useEffect(() => {
+    const loadData = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const fetchedPost = await fetchPostByPermlink(category, username, permlink);
+        if (fetchedPost) {
+          setPost(fetchedPost);
+          const fetchedComments = await fetchCommentsByPermlink(username, permlink);
+          setComments(fetchedComments);
+        } else {
+          setError('Post not found');
+        }
+      } catch (err) {
+        console.error('Error fetching post or comments:', err);
+        setError('Failed to load post or comments');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadData();
+  }, [category, username, permlink]);
+
+  // PostEditor already broadcast the reply; optimistically append a
+  // synthesized comment built from the known author/permlink/body instead of
+  // refetching (the chain API may not have indexed the comment yet).
+  const handleNewComment = (result: PostEditorResult) => {
+    if (!post) return;
+    const newComment: Post = {
+      author: result.author,
+      permlink: result.permlink,
+      category: post.category,
+      title: '',
+      body: result.body,
+      created: new Date().toISOString(),
+      net_rshares: '0',
+      children: 0,
+      parent_author: result.parentAuthor,
+      parent_permlink: result.parentPermlink,
+      depth: 1,
+      active_votes: [],
+      pending_payout_value: '0.000 SBD',
+    };
+    setComments((prevComments) => [...prevComments, newComment]);
+  };
+
+  // PostEditor already broadcast the edit; update the comment body in place.
+  const handleEditComment = (author: string, commentPermlink: string, body: string) => {
+    setComments((prevComments) =>
+      prevComments.map((c) =>
+        c.author === author && c.permlink === commentPermlink ? { ...c, body } : c
+      )
+    );
+  };
+
+  if (loading) {
+    return (
+      <FeedLayout centerClassName="md:max-w-4xl">
+        <div className="flex flex-col items-center justify-center gap-2 py-12">
+          <p className="text-muted-foreground">Loading post...</p>
+        </div>
+      </FeedLayout>
+    );
+  }
+
+  if (error || !post) {
+    return (
+      <FeedLayout centerClassName="md:max-w-4xl">
+        <div className="flex flex-col items-center justify-center gap-2 py-12">
+          <p className="text-destructive">{error || "Post not found"}</p>
+        </div>
+      </FeedLayout>
+    );
+  }
+
+  return (
+    <FeedLayout centerClassName="md:max-w-4xl">
+      <PostFull post={post} />
+      <CommentsList
+        comments={comments}
+        postAuthor={post.author}
+        postPermlink={post.permlink}
+        postCategory={post.category}
+        onReply={handleNewComment}
+        onEdit={handleEditComment}
+      />
+    </FeedLayout>
+  );
+}

--- a/app/(main)/post/[category]/[username]/[permlink]/page.tsx
+++ b/app/(main)/post/[category]/[username]/[permlink]/page.tsx
@@ -1,129 +1,48 @@
-'use client';
-
-import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
-import { useAppDispatch } from '@/store/hooks';
-import { setPathname } from '@/store/slices/globalSlice';
-import { normalizeUsername, formatUsername } from '@/lib/utils/username';
-import PostFull from '@/components/cards/PostFull';
-import CommentsList from '@/components/cards/CommentsList';
-import { PostEditorResult } from '@/components/elements/PostEditor';
-import { Post, fetchPostByPermlink, fetchCommentsByPermlink } from '@/lib/api/steem';
-import { FeedLayout } from '@/components/layout/FeedLayout';
+import type { Metadata } from 'next';
+import { getDiscussion } from '@/lib/steem/client';
+import { normalizeUsername } from '@/lib/utils/username';
+import { buildPostMetadata, type SeoPost } from '@/lib/seo';
+import PostPageClient from './PostPageClient';
 
 /**
- * Post page with category
+ * Post page with category (server shell).
  * Route: /post/[category]/[username]/[permlink]
  * This is rewritten from /[category]/@[username]/[permlink] by middleware
  * Equivalent to old route: Post with params [category, @username, permlink]
+ *
+ * generateMetadata ports legacy ExtractMeta.addPostMeta so crawlers and link
+ * unfurlers get post-level meta in the SSR HTML. Fetch failures degrade to a
+ * bare title — metadata must never 500 the page.
  */
-export default function PostPage() {
-  const params = useParams();
-  const dispatch = useAppDispatch();
-  const category = params.category as string;
-  const usernameRaw = params.username as string;
-  const username = normalizeUsername(usernameRaw);
-  const permlink = params.permlink as string;
-  const [post, setPost] = useState<Post | null>(null);
-  const [comments, setComments] = useState<Post[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [error, setError] = useState<string | null>(null);
-
-  // Set pathname in global state
-  useEffect(() => {
-    const pathname = `/${category}/${formatUsername(username)}/${permlink}`;
-    dispatch(setPathname(pathname));
-  }, [category, username, permlink, dispatch]);
-
-  // Fetch post data and comments
-  useEffect(() => {
-    const loadData = async () => {
-      setLoading(true);
-      setError(null);
-      try {
-        const fetchedPost = await fetchPostByPermlink(category, username, permlink);
-        if (fetchedPost) {
-          setPost(fetchedPost);
-          const fetchedComments = await fetchCommentsByPermlink(username, permlink);
-          setComments(fetchedComments);
-        } else {
-          setError('Post not found');
-        }
-      } catch (err) {
-        console.error('Error fetching post or comments:', err);
-        setError('Failed to load post or comments');
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    loadData();
-  }, [category, username, permlink]);
-
-  // PostEditor already broadcast the reply; optimistically append a
-  // synthesized comment built from the known author/permlink/body instead of
-  // refetching (the chain API may not have indexed the comment yet).
-  const handleNewComment = (result: PostEditorResult) => {
-    if (!post) return;
-    const newComment: Post = {
-      author: result.author,
-      permlink: result.permlink,
-      category: post.category,
-      title: '',
-      body: result.body,
-      created: new Date().toISOString(),
-      net_rshares: '0',
-      children: 0,
-      parent_author: result.parentAuthor,
-      parent_permlink: result.parentPermlink,
-      depth: 1,
-      active_votes: [],
-      pending_payout_value: '0.000 SBD',
-    };
-    setComments((prevComments) => [...prevComments, newComment]);
-  };
-
-  // PostEditor already broadcast the edit; update the comment body in place.
-  const handleEditComment = (author: string, commentPermlink: string, body: string) => {
-    setComments((prevComments) =>
-      prevComments.map((c) =>
-        c.author === author && c.permlink === commentPermlink ? { ...c, body } : c
-      )
-    );
-  };
-
-  if (loading) {
-    return (
-      <FeedLayout centerClassName="md:max-w-4xl">
-        <div className="flex flex-col items-center justify-center gap-2 py-12">
-          <p className="text-muted-foreground">Loading post...</p>
-        </div>
-      </FeedLayout>
-    );
-  }
-
-  if (error || !post) {
-    return (
-      <FeedLayout centerClassName="md:max-w-4xl">
-        <div className="flex flex-col items-center justify-center gap-2 py-12">
-          <p className="text-destructive">{error || "Post not found"}</p>
-        </div>
-      </FeedLayout>
-    );
-  }
-
-  return (
-    <FeedLayout centerClassName="md:max-w-4xl">
-      <PostFull post={post} />
-      <CommentsList
-        comments={comments}
-        postAuthor={post.author}
-        postPermlink={post.permlink}
-        postCategory={post.category}
-        onReply={handleNewComment}
-        onEdit={handleEditComment}
-      />
-    </FeedLayout>
-  );
+interface PageParams {
+  category: string;
+  username: string;
+  permlink: string;
 }
 
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<PageParams>;
+}): Promise<Metadata> {
+  const { username, permlink } = await params;
+  const author = normalizeUsername(username);
+  try {
+    // Same cached path as /api/steem/post: bridge get_discussion returns a
+    // content map keyed "author/permlink".
+    const discussion = (await getDiscussion({ author, permlink })) as Record<
+      string,
+      SeoPost
+    > | null;
+    const post = discussion?.[`${author}/${permlink}`];
+    if (!post || !post.author) return { title: 'Steemit' };
+    return buildPostMetadata(post);
+  } catch (error) {
+    console.error('generateMetadata: failed to fetch post:', error);
+    return { title: 'Steemit' };
+  }
+}
+
+export default function PostPage() {
+  return <PostPageClient />;
+}

--- a/app/(main)/user/[username]/UserRedirectClient.tsx
+++ b/app/(main)/user/[username]/UserRedirectClient.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import { normalizeUsername } from '@/lib/utils/username';
+import { FeedLayout } from '@/components/layout/FeedLayout';
+
+/**
+ * User profile root — client content (redirects to the blog section).
+ * Rendered by the server page shell in ./page.tsx, which owns
+ * generateMetadata.
+ */
+export default function UserRedirectClient() {
+  const params = useParams();
+  const router = useRouter();
+  const usernameRaw = params.username as string;
+  const username = normalizeUsername(usernameRaw);
+
+  useEffect(() => {
+    // Use @username format in URL
+    router.replace(`/@${username}/blog`);
+  }, [username, router]);
+
+  return (
+    <FeedLayout>
+      <div className="flex flex-col items-center justify-center gap-2 py-12">
+        <p className="text-muted-foreground">Loading...</p>
+      </div>
+    </FeedLayout>
+  );
+}

--- a/app/(main)/user/[username]/[section]/UserSectionClient.tsx
+++ b/app/(main)/user/[username]/[section]/UserSectionClient.tsx
@@ -1,0 +1,342 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import Link from 'next/link';
+import { useAppDispatch, useAppSelector } from '@/store/hooks';
+import { setPathname } from '@/store/slices/globalSlice';
+import {
+  fetchAccountPosts,
+  fetchUserProfile,
+  type AccountPostsOrder,
+  type Post,
+  type UserProfile,
+} from '@/lib/api/steem';
+import { normalizeUsername } from '@/lib/utils/username';
+import PostsList from '@/components/cards/PostsList';
+import { FeedLayout } from '@/components/layout/FeedLayout';
+import UserProfileHeader from '@/components/cards/UserProfileHeader';
+import NotificationsList from '@/components/cards/NotificationsList';
+import FollowList from '@/components/cards/FollowList';
+import CommunitiesList from '@/components/cards/CommunitiesList';
+import UserSettings from '@/components/modules/UserSettings';
+
+/**
+ * User profile page with section — client content.
+ * Rendered by the server page shell in ./page.tsx, which owns
+ * generateMetadata; this component keeps the original client-side
+ * fetch/render behaviour.
+ * Sections: blog, posts, comments, replies, payout, feed, followers, followed, settings, notifications, communities
+ * Note: proxy.ts ensures only @username format reaches here
+ * Equivalent to old route: UserProfile with params [@username, section];
+ * `feed` is legacy PostsIndex ['home', user] (bridge get_account_posts, sort 'feed')
+ */
+export default function UserSectionClient() {
+  const params = useParams();
+  const dispatch = useAppDispatch();
+  const username = useAppSelector((state) => state.user.current?.username);
+  
+  const usernameRaw = params.username as string;
+  const accountname = normalizeUsername(usernameRaw).toLowerCase();
+  const section = (params.section as string) || 'blog';
+  
+  const [posts, setPosts] = useState<Post[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [hasMore, setHasMore] = useState(true);
+  const [profile, setProfile] = useState<UserProfile | null>(null);
+  const [profileLoading, setProfileLoading] = useState(true);
+
+  // Set pathname in global state (use @username format)
+  useEffect(() => {
+    const pathname = `/@${accountname}${section !== 'blog' ? `/${section}` : ''}`;
+    dispatch(setPathname(pathname));
+  }, [accountname, section, dispatch]);
+
+  const order: AccountPostsOrder = [
+    'blog',
+    'posts',
+    'comments',
+    'replies',
+    'payout',
+    'feed',
+  ].includes(section)
+    ? (section as AccountPostsOrder)
+    : 'blog';
+
+  // Fetch user profile
+  useEffect(() => {
+    const loadProfile = async () => {
+      setProfileLoading(true);
+      try {
+        const fetchedProfile = await fetchUserProfile(accountname, username);
+        setProfile(fetchedProfile);
+      } catch (error) {
+        console.error('Error fetching profile:', error);
+      } finally {
+        setProfileLoading(false);
+      }
+    };
+
+    loadProfile();
+  }, [accountname, username]);
+
+  // Fetch posts
+  useEffect(() => {
+    const loadPosts = async () => {
+      setLoading(true);
+      try {
+        const fetchedPosts = await fetchAccountPosts({
+          account: accountname,
+          order,
+          limit: 20,
+        });
+        setPosts(fetchedPosts);
+        setHasMore(fetchedPosts.length >= 20);
+      } catch (error) {
+        console.error('Error fetching posts:', error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    if (['blog', 'posts', 'comments', 'replies', 'payout', 'feed'].includes(section)) {
+      loadPosts();
+    } else {
+      setLoading(false);
+    }
+  }, [accountname, order, section]);
+
+  const handleLoadMore = async () => {
+    if (loading || !hasMore || posts.length === 0) return;
+
+    const lastPost = posts[posts.length - 1];
+    setLoading(true);
+    try {
+      const fetchedPosts = await fetchAccountPosts({
+        account: accountname,
+        order,
+        start_author: lastPost.author,
+        start_permlink: lastPost.permlink,
+        limit: 20,
+      });
+
+      if (fetchedPosts.length > 0) {
+        setPosts((prev) => [...prev, ...fetchedPosts]);
+        setHasMore(fetchedPosts.length >= 20);
+      } else {
+        setHasMore(false);
+      }
+    } catch (error) {
+      console.error('Error loading more posts:', error);
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const isMyAccount = username === accountname;
+
+  const profileHeader = (
+    <UserProfileHeader
+      accountname={accountname}
+      profile={profile?.metadata?.profile || null}
+      currentUser={username}
+      stats={profile?.stats}
+      reputation={profile?.reputation}
+      postCount={profile?.post_count}
+      created={profile?.created}
+      active={profile?.active}
+      blacklists={profile?.blacklists}
+    />
+  );
+
+  // Show loading state if profile is still loading
+  if (profileLoading) {
+    return (
+      <FeedLayout>
+        <div className="flex flex-col items-center justify-center gap-2 py-12">
+          <p className="text-muted-foreground">Loading profile...</p>
+        </div>
+      </FeedLayout>
+    );
+  }
+
+  if (!profile) {
+    return (
+      <FeedLayout>
+        <div className="flex flex-col items-center justify-center gap-2 py-12">
+          <p className="text-destructive">User not found</p>
+        </div>
+      </FeedLayout>
+    );
+  }
+
+  // Handle different sections
+  if (section === 'settings') {
+    if (!isMyAccount) {
+      return (
+        <FeedLayout centerClassName="md:max-w-4xl">
+          <div className="rounded-lg border border-border bg-muted/50 p-4">
+            <p className="text-foreground">
+              You can only view your own settings.
+            </p>
+          </div>
+        </FeedLayout>
+      );
+    }
+
+    return (
+      <FeedLayout centerClassName="md:max-w-4xl">
+        {profileHeader}
+        <div className="mt-8">
+          <UserSettings 
+            accountname={accountname} 
+            profile={profile?.metadata?.profile || null}
+            onProfileUpdate={(updatedProfile) => {
+              // Update local profile state
+              if (profile) {
+                setProfile({
+                  ...profile,
+                  metadata: {
+                    ...profile.metadata,
+                    profile: updatedProfile,
+                  },
+                });
+              }
+            }}
+          />
+        </div>
+      </FeedLayout>
+    );
+  }
+
+  if (section === 'followers' || section === 'followed') {
+    const followType = section === 'followers' ? 'followers' : 'following';
+    return (
+      <FeedLayout centerClassName="md:max-w-4xl">
+        {profileHeader}
+        <h3 className="mt-6 mb-4 text-lg font-bold text-foreground">
+          {section === 'followers' ? 'Followers' : 'Following'}
+        </h3>
+        <FollowList
+          accountname={accountname}
+          type={followType}
+          total={
+            section === 'followers'
+              ? profile?.stats?.followers
+              : profile?.stats?.following
+          }
+        />
+      </FeedLayout>
+    );
+  }
+
+  if (section === 'notifications') {
+    return (
+      <FeedLayout centerClassName="md:max-w-4xl lg:max-w-6xl">
+        {profileHeader}
+        <NotificationsList username={accountname} />
+      </FeedLayout>
+    );
+  }
+
+  if (section === 'communities') {
+    return (
+      <FeedLayout centerClassName="md:max-w-4xl lg:max-w-6xl">
+        {profileHeader}
+        <CommunitiesList accountname={accountname} />
+      </FeedLayout>
+    );
+  }
+
+  return (
+    <FeedLayout>
+      {profileHeader}
+
+      {loading && posts.length === 0 ? (
+        <div className="flex flex-col items-center justify-center gap-2 py-12">
+          <p className="text-muted-foreground">Loading posts...</p>
+        </div>
+      ) : posts.length === 0 ? (
+        <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
+          {emptySectionText(section, accountname, isMyAccount)}
+        </div>
+      ) : (
+        <PostsList
+          posts={posts}
+          loading={loading}
+          onLoadMore={hasMore ? handleLoadMore : undefined}
+          category={`@${accountname}`}
+          order={order}
+        />
+      )}
+    </FeedLayout>
+  );
+}
+
+/** Legacy UserProfile empty-state copy per section (UserProfile.jsx:23-69). */
+function emptySectionText(
+  section: string,
+  accountname: string,
+  isMyAccount: boolean
+): React.ReactNode {
+  switch (section) {
+    case 'replies':
+      return `@${accountname} hasn't had any replies yet.`;
+    case 'payout':
+      return 'No pending payouts.';
+    case 'comments':
+      return `@${accountname} hasn't made any comments yet.`;
+    case 'posts':
+      return `@${accountname} hasn't made any posts yet.`;
+    case 'feed':
+      // Legacy PostsIndex noFriendsText (empty home feed).
+      return (
+        <span className="flex flex-col items-center gap-2">
+          <span>You haven&apos;t followed anyone yet!</span>
+          <span className="flex flex-wrap justify-center gap-3">
+            <Link href="/trending" className="text-accent-foreground underline">
+              Explore Trending
+            </Link>
+            <a
+              href="https://steemit.com/welcome"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-accent-foreground underline"
+            >
+              New users guide
+            </a>
+          </span>
+        </span>
+      );
+    default:
+      break;
+  }
+  if (isMyAccount) {
+    return (
+      <span className="flex flex-col items-center gap-2">
+        <span>You haven&apos;t posted anything yet.</span>
+        <span className="flex flex-wrap justify-center gap-3">
+          <Link href="/communities" className="text-accent-foreground underline">
+            Explore Communities
+          </Link>
+          <Link href="/submit" className="text-accent-foreground underline">
+            Create a post
+          </Link>
+          <Link href="/trending" className="text-accent-foreground underline">
+            Trending Articles
+          </Link>
+          <a
+            href="https://steemit.com/welcome"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-accent-foreground underline"
+          >
+            Welcome Guide
+          </a>
+        </span>
+      </span>
+    );
+  }
+  return `@${accountname} hasn't posted anything yet.`;
+}
+

--- a/app/(main)/user/[username]/[section]/page.tsx
+++ b/app/(main)/user/[username]/[section]/page.tsx
@@ -1,340 +1,44 @@
-'use client';
-
-import { useEffect, useState } from 'react';
-import { useParams } from 'next/navigation';
-import Link from 'next/link';
-import { useAppDispatch, useAppSelector } from '@/store/hooks';
-import { setPathname } from '@/store/slices/globalSlice';
-import {
-  fetchAccountPosts,
-  fetchUserProfile,
-  type AccountPostsOrder,
-  type Post,
-  type UserProfile,
-} from '@/lib/api/steem';
+import type { Metadata } from 'next';
+import { getProfile } from '@/lib/steem/client';
 import { normalizeUsername } from '@/lib/utils/username';
-import PostsList from '@/components/cards/PostsList';
-import { FeedLayout } from '@/components/layout/FeedLayout';
-import UserProfileHeader from '@/components/cards/UserProfileHeader';
-import NotificationsList from '@/components/cards/NotificationsList';
-import FollowList from '@/components/cards/FollowList';
-import CommunitiesList from '@/components/cards/CommunitiesList';
-import UserSettings from '@/components/modules/UserSettings';
+import { buildAccountMetadata, type SeoProfile } from '@/lib/seo';
+import UserSectionClient from './UserSectionClient';
 
 /**
- * User profile page with section
+ * User profile page with section (server shell).
  * Route: /@[username]/[section]
  * Sections: blog, posts, comments, replies, payout, feed, followers, followed, settings, notifications, communities
  * Note: proxy.ts ensures only @username format reaches here
- * Equivalent to old route: UserProfile with params [@username, section];
- * `feed` is legacy PostsIndex ['home', user] (bridge get_account_posts, sort 'feed')
+ *
+ * generateMetadata ports legacy ExtractMeta.addAccountMeta. Profile fetch
+ * failures degrade to account-name defaults; hard errors to a bare title —
+ * metadata must never 500 the page.
  */
+interface PageParams {
+  username: string;
+  section: string;
+}
+
+interface BridgeProfile {
+  metadata?: { profile?: SeoProfile };
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<PageParams>;
+}): Promise<Metadata> {
+  const { username } = await params;
+  const accountname = normalizeUsername(username).toLowerCase();
+  try {
+    const profile = (await getProfile({ account: accountname })) as BridgeProfile | null;
+    return buildAccountMetadata(accountname, profile?.metadata?.profile ?? null);
+  } catch (error) {
+    console.error('generateMetadata: failed to fetch profile:', error);
+    return { title: 'Steemit' };
+  }
+}
+
 export default function UserProfileSectionPage() {
-  const params = useParams();
-  const dispatch = useAppDispatch();
-  const username = useAppSelector((state) => state.user.current?.username);
-  
-  const usernameRaw = params.username as string;
-  const accountname = normalizeUsername(usernameRaw).toLowerCase();
-  const section = (params.section as string) || 'blog';
-  
-  const [posts, setPosts] = useState<Post[]>([]);
-  const [loading, setLoading] = useState(true);
-  const [hasMore, setHasMore] = useState(true);
-  const [profile, setProfile] = useState<UserProfile | null>(null);
-  const [profileLoading, setProfileLoading] = useState(true);
-
-  // Set pathname in global state (use @username format)
-  useEffect(() => {
-    const pathname = `/@${accountname}${section !== 'blog' ? `/${section}` : ''}`;
-    dispatch(setPathname(pathname));
-  }, [accountname, section, dispatch]);
-
-  const order: AccountPostsOrder = [
-    'blog',
-    'posts',
-    'comments',
-    'replies',
-    'payout',
-    'feed',
-  ].includes(section)
-    ? (section as AccountPostsOrder)
-    : 'blog';
-
-  // Fetch user profile
-  useEffect(() => {
-    const loadProfile = async () => {
-      setProfileLoading(true);
-      try {
-        const fetchedProfile = await fetchUserProfile(accountname, username);
-        setProfile(fetchedProfile);
-      } catch (error) {
-        console.error('Error fetching profile:', error);
-      } finally {
-        setProfileLoading(false);
-      }
-    };
-
-    loadProfile();
-  }, [accountname, username]);
-
-  // Fetch posts
-  useEffect(() => {
-    const loadPosts = async () => {
-      setLoading(true);
-      try {
-        const fetchedPosts = await fetchAccountPosts({
-          account: accountname,
-          order,
-          limit: 20,
-        });
-        setPosts(fetchedPosts);
-        setHasMore(fetchedPosts.length >= 20);
-      } catch (error) {
-        console.error('Error fetching posts:', error);
-      } finally {
-        setLoading(false);
-      }
-    };
-
-    if (['blog', 'posts', 'comments', 'replies', 'payout', 'feed'].includes(section)) {
-      loadPosts();
-    } else {
-      setLoading(false);
-    }
-  }, [accountname, order, section]);
-
-  const handleLoadMore = async () => {
-    if (loading || !hasMore || posts.length === 0) return;
-
-    const lastPost = posts[posts.length - 1];
-    setLoading(true);
-    try {
-      const fetchedPosts = await fetchAccountPosts({
-        account: accountname,
-        order,
-        start_author: lastPost.author,
-        start_permlink: lastPost.permlink,
-        limit: 20,
-      });
-
-      if (fetchedPosts.length > 0) {
-        setPosts((prev) => [...prev, ...fetchedPosts]);
-        setHasMore(fetchedPosts.length >= 20);
-      } else {
-        setHasMore(false);
-      }
-    } catch (error) {
-      console.error('Error loading more posts:', error);
-    } finally {
-      setLoading(false);
-    }
-  };
-
-  const isMyAccount = username === accountname;
-
-  const profileHeader = (
-    <UserProfileHeader
-      accountname={accountname}
-      profile={profile?.metadata?.profile || null}
-      currentUser={username}
-      stats={profile?.stats}
-      reputation={profile?.reputation}
-      postCount={profile?.post_count}
-      created={profile?.created}
-      active={profile?.active}
-      blacklists={profile?.blacklists}
-    />
-  );
-
-  // Show loading state if profile is still loading
-  if (profileLoading) {
-    return (
-      <FeedLayout>
-        <div className="flex flex-col items-center justify-center gap-2 py-12">
-          <p className="text-muted-foreground">Loading profile...</p>
-        </div>
-      </FeedLayout>
-    );
-  }
-
-  if (!profile) {
-    return (
-      <FeedLayout>
-        <div className="flex flex-col items-center justify-center gap-2 py-12">
-          <p className="text-destructive">User not found</p>
-        </div>
-      </FeedLayout>
-    );
-  }
-
-  // Handle different sections
-  if (section === 'settings') {
-    if (!isMyAccount) {
-      return (
-        <FeedLayout centerClassName="md:max-w-4xl">
-          <div className="rounded-lg border border-border bg-muted/50 p-4">
-            <p className="text-foreground">
-              You can only view your own settings.
-            </p>
-          </div>
-        </FeedLayout>
-      );
-    }
-
-    return (
-      <FeedLayout centerClassName="md:max-w-4xl">
-        {profileHeader}
-        <div className="mt-8">
-          <UserSettings 
-            accountname={accountname} 
-            profile={profile?.metadata?.profile || null}
-            onProfileUpdate={(updatedProfile) => {
-              // Update local profile state
-              if (profile) {
-                setProfile({
-                  ...profile,
-                  metadata: {
-                    ...profile.metadata,
-                    profile: updatedProfile,
-                  },
-                });
-              }
-            }}
-          />
-        </div>
-      </FeedLayout>
-    );
-  }
-
-  if (section === 'followers' || section === 'followed') {
-    const followType = section === 'followers' ? 'followers' : 'following';
-    return (
-      <FeedLayout centerClassName="md:max-w-4xl">
-        {profileHeader}
-        <h3 className="mt-6 mb-4 text-lg font-bold text-foreground">
-          {section === 'followers' ? 'Followers' : 'Following'}
-        </h3>
-        <FollowList
-          accountname={accountname}
-          type={followType}
-          total={
-            section === 'followers'
-              ? profile?.stats?.followers
-              : profile?.stats?.following
-          }
-        />
-      </FeedLayout>
-    );
-  }
-
-  if (section === 'notifications') {
-    return (
-      <FeedLayout centerClassName="md:max-w-4xl lg:max-w-6xl">
-        {profileHeader}
-        <NotificationsList username={accountname} />
-      </FeedLayout>
-    );
-  }
-
-  if (section === 'communities') {
-    return (
-      <FeedLayout centerClassName="md:max-w-4xl lg:max-w-6xl">
-        {profileHeader}
-        <CommunitiesList accountname={accountname} />
-      </FeedLayout>
-    );
-  }
-
-  return (
-    <FeedLayout>
-      {profileHeader}
-
-      {loading && posts.length === 0 ? (
-        <div className="flex flex-col items-center justify-center gap-2 py-12">
-          <p className="text-muted-foreground">Loading posts...</p>
-        </div>
-      ) : posts.length === 0 ? (
-        <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
-          {emptySectionText(section, accountname, isMyAccount)}
-        </div>
-      ) : (
-        <PostsList
-          posts={posts}
-          loading={loading}
-          onLoadMore={hasMore ? handleLoadMore : undefined}
-          category={`@${accountname}`}
-          order={order}
-        />
-      )}
-    </FeedLayout>
-  );
+  return <UserSectionClient />;
 }
-
-/** Legacy UserProfile empty-state copy per section (UserProfile.jsx:23-69). */
-function emptySectionText(
-  section: string,
-  accountname: string,
-  isMyAccount: boolean
-): React.ReactNode {
-  switch (section) {
-    case 'replies':
-      return `@${accountname} hasn't had any replies yet.`;
-    case 'payout':
-      return 'No pending payouts.';
-    case 'comments':
-      return `@${accountname} hasn't made any comments yet.`;
-    case 'posts':
-      return `@${accountname} hasn't made any posts yet.`;
-    case 'feed':
-      // Legacy PostsIndex noFriendsText (empty home feed).
-      return (
-        <span className="flex flex-col items-center gap-2">
-          <span>You haven&apos;t followed anyone yet!</span>
-          <span className="flex flex-wrap justify-center gap-3">
-            <Link href="/trending" className="text-accent-foreground underline">
-              Explore Trending
-            </Link>
-            <a
-              href="https://steemit.com/welcome"
-              target="_blank"
-              rel="noopener noreferrer"
-              className="text-accent-foreground underline"
-            >
-              New users guide
-            </a>
-          </span>
-        </span>
-      );
-    default:
-      break;
-  }
-  if (isMyAccount) {
-    return (
-      <span className="flex flex-col items-center gap-2">
-        <span>You haven&apos;t posted anything yet.</span>
-        <span className="flex flex-wrap justify-center gap-3">
-          <Link href="/communities" className="text-accent-foreground underline">
-            Explore Communities
-          </Link>
-          <Link href="/submit" className="text-accent-foreground underline">
-            Create a post
-          </Link>
-          <Link href="/trending" className="text-accent-foreground underline">
-            Trending Articles
-          </Link>
-          <a
-            href="https://steemit.com/welcome"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-accent-foreground underline"
-          >
-            Welcome Guide
-          </a>
-        </span>
-      </span>
-    );
-  }
-  return `@${accountname} hasn't posted anything yet.`;
-}
-

--- a/app/(main)/user/[username]/page.tsx
+++ b/app/(main)/user/[username]/page.tsx
@@ -1,33 +1,42 @@
-'use client';
-
-import { useEffect } from 'react';
-import { useParams, useRouter } from 'next/navigation';
+import type { Metadata } from 'next';
+import { getProfile } from '@/lib/steem/client';
 import { normalizeUsername } from '@/lib/utils/username';
-import { FeedLayout } from '@/components/layout/FeedLayout';
+import { buildAccountMetadata, type SeoProfile } from '@/lib/seo';
+import UserRedirectClient from './UserRedirectClient';
 
 /**
- * User profile page (default to blog section)
+ * User profile page root (server shell; redirects to /@username/blog).
  * Route: /@[username]
- * Redirects to /@[username]/blog
- * Note: proxy.ts ensures only @username format reaches here
+ * Note: proxy.ts ensures only @username format reaches here.
+ *
+ * generateMetadata ports legacy ExtractMeta.addAccountMeta. Profile fetch
+ * failures degrade to account-name defaults; hard errors to a bare title —
+ * metadata must never 500 the page.
  */
-export default function UserProfilePage() {
-  const params = useParams();
-  const router = useRouter();
-  const usernameRaw = params.username as string;
-  const username = normalizeUsername(usernameRaw);
-
-  useEffect(() => {
-    // Use @username format in URL
-    router.replace(`/@${username}/blog`);
-  }, [username, router]);
-
-  return (
-    <FeedLayout>
-      <div className="flex flex-col items-center justify-center gap-2 py-12">
-        <p className="text-muted-foreground">Loading...</p>
-      </div>
-    </FeedLayout>
-  );
+interface PageParams {
+  username: string;
 }
 
+interface BridgeProfile {
+  metadata?: { profile?: SeoProfile };
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<PageParams>;
+}): Promise<Metadata> {
+  const { username } = await params;
+  const accountname = normalizeUsername(username).toLowerCase();
+  try {
+    const profile = (await getProfile({ account: accountname })) as BridgeProfile | null;
+    return buildAccountMetadata(accountname, profile?.metadata?.profile ?? null);
+  } catch (error) {
+    console.error('generateMetadata: failed to fetch profile:', error);
+    return { title: 'Steemit' };
+  }
+}
+
+export default function UserProfilePage() {
+  return <UserRedirectClient />;
+}

--- a/components/cards/PostFull.tsx
+++ b/components/cards/PostFull.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { useEffect } from 'react';
 import Link from 'next/link';
 import { Clock, Link2, MessageSquare } from 'lucide-react';
 
@@ -26,29 +25,6 @@ interface PostFullProps {
  * | share icons | link).
  */
 export default function PostFull({ post }: PostFullProps) {
-  // Set document title
-  useEffect(() => {
-    if (typeof window !== 'undefined' && post.title) {
-      document.title = `${post.title} — Steemit`;
-    }
-  }, [post.title]);
-
-  // Set canonical URL
-  useEffect(() => {
-    if (typeof window === 'undefined') return;
-
-    let canonicalLink = document.getElementById('canonicalUrlID') as HTMLLinkElement;
-    if (!canonicalLink) {
-      canonicalLink = document.createElement('link');
-      canonicalLink.rel = 'canonical';
-      canonicalLink.id = 'canonicalUrlID';
-      document.head.appendChild(canonicalLink);
-    }
-
-    const canonicalURL = `/${post.category}/@${post.author}/${post.permlink}`;
-    canonicalLink.href = `${window.location.origin}${canonicalURL}`;
-  }, [post]);
-
   const tags = post.json_metadata?.tags || [];
   const postUrl = `/${post.category}/@${post.author}/${post.permlink}`;
   const rep = reputation(post.author_reputation);

--- a/lib/seo.ts
+++ b/lib/seo.ts
@@ -1,0 +1,213 @@
+/**
+ * Server-side SEO metadata builders for post and user pages.
+ *
+ * Ported from legacy src/app/utils/ExtractMeta.js (addPostMeta /
+ * addAccountMeta) and src/app/utils/CanonicalLinker.js, mapped onto the
+ * Next.js Metadata API. Used by generateMetadata() in the post and user
+ * page server shells.
+ *
+ * Post bodies are untrusted: the description goes through
+ * extractBodySummary (markdown rendered to plain text, all HTML stripped,
+ * URLs removed) before it ever reaches a meta tag.
+ */
+
+import type { Metadata } from 'next';
+import { extractBodySummary, extractImageLink } from '@/lib/extract-content';
+
+/**
+ * Origin of this site, used for absolute URLs in metadata (avatar fallback
+ * image, og:url base). Legacy read state.app.site_domain (default
+ * steemit.com); this app has no site-domain env var, so default to the
+ * production origin.
+ */
+export const SITE_ORIGIN = 'https://steemit.com';
+
+/**
+ * URL schemes from steemscript apps.json, restricted to the apps legacy
+ * whitelisted as canonical-reciprocating (CanonicalLinker.allowed_app):
+ * a post whose json_metadata.app is one of these keeps its canonical URL
+ * on that app's scheme instead of ours.
+ */
+const APP_URL_SCHEMES: Record<string, string> = {
+  steemit: 'https://steemit.com/{category}/@{username}/{permlink}',
+  steempeak: 'https://steempeak.com/{category}/@{username}/{permlink}',
+  travelfeed: 'https://travelfeed.io/@{username}/{permlink}',
+};
+
+/** Subset of a bridge content object that SEO metadata needs. */
+export interface SeoPost {
+  author: string;
+  permlink: string;
+  category: string;
+  title?: string;
+  body?: string;
+  created?: string;
+  depth?: number;
+  community_title?: string;
+  json_metadata?: {
+    tags?: unknown;
+    image?: unknown;
+    app?: unknown;
+    canonical_url?: unknown;
+    [key: string]: unknown;
+  } | null;
+}
+
+type JsonMetadata = NonNullable<SeoPost['json_metadata']>;
+
+/** Legacy read_md_app: "appname/version" -> "appname". */
+function readMdApp(metadata: JsonMetadata | null): string | null {
+  const app = metadata?.app;
+  if (typeof app !== 'string') return null;
+  const parts = app.split('/');
+  return parts.length === 2 ? parts[0] : null;
+}
+
+/** Legacy read_md_canonical: accept only absolute http(s) canonical_url. */
+function readMdCanonical(metadata: JsonMetadata | null): string | null {
+  const url = metadata?.canonical_url;
+  if (typeof url !== 'string') return null;
+  return /^https?:\/\//.test(url) ? url : null;
+}
+
+/**
+ * Legacy build_scheme: fill {category}/{username}/{permlink}, with the
+ * community slug rewrite from legacy PostFull.jsx:313-343 —
+ * Option 1: replace hive-xxxxxx with the sanitized community title;
+ * Option 2: if still hive-*, fall back to the first non-community tag.
+ */
+function buildScheme(scheme: string, post: SeoPost): string {
+  let tempCategory = post.category || '';
+
+  const tags = Array.isArray(post.json_metadata?.tags)
+    ? (post.json_metadata.tags as unknown[]).filter(
+        (t): t is string => typeof t === 'string'
+      )
+    : [];
+
+  // Option 1: community title slug (no-op for non-community posts).
+  const communityTitle = post.community_title || `#${tempCategory}` || '';
+  const urlFriendlyTitle = communityTitle
+    .replace(/[^a-zA-Z0-9 ]/g, '')
+    .trim()
+    .replace(/\s+/g, '-')
+    .toLowerCase();
+  if (urlFriendlyTitle) {
+    tempCategory = urlFriendlyTitle;
+  }
+
+  // Option 2: first tag of the post (sometimes the first tag is still the
+  // community, so check the second tag in that case).
+  if (tempCategory.startsWith('hive-') && tags.length > 0) {
+    const firstTag = tags[0].startsWith('#') ? tags[0].substring(1) : tags[0];
+    tempCategory =
+      firstTag.startsWith('hive-') && tags.length > 1 ? tags[1] : firstTag;
+    tempCategory = tempCategory.startsWith('#')
+      ? tempCategory.substring(1)
+      : tempCategory;
+  }
+
+  return scheme
+    .split('{category}')
+    .join(tempCategory)
+    .split('{username}')
+    .join(post.author)
+    .split('{permlink}')
+    .join(post.permlink);
+}
+
+/**
+ * Legacy makeCanonicalLink. Pass `metadata = null` to get the local URL
+ * (ignores canonical_url/app from json_metadata) — legacy used that for
+ * og:url.
+ */
+export function makeCanonicalLink(
+  post: SeoPost,
+  metadata: JsonMetadata | null
+): string {
+  let scheme: string | null = null;
+
+  if (metadata) {
+    const canonUrl = readMdCanonical(metadata);
+    if (canonUrl) return canonUrl;
+
+    const app = readMdApp(metadata);
+    if (app && app in APP_URL_SCHEMES) {
+      scheme = APP_URL_SCHEMES[app];
+    }
+  }
+  if (!scheme) scheme = APP_URL_SCHEMES.steemit;
+  return buildScheme(scheme, post);
+}
+
+/** Legacy addPostMeta mapped to the Next.js Metadata API. */
+export function buildPostMetadata(post: SeoPost): Metadata {
+  const isReply = (post.depth ?? 0) > 0;
+  const jsonMetadata = post.json_metadata ?? null;
+
+  const title = `${post.title} — Steemit`;
+  const description = `${extractBodySummary(post.body ?? '', isReply)} by ${post.author}`;
+  const imageLink = extractImageLink(jsonMetadata ?? undefined, post.body ?? null);
+  const profileImage = `${SITE_ORIGIN}/avatar/${post.author}`;
+
+  const canonical = makeCanonicalLink(post, jsonMetadata);
+  const localUrl = makeCanonicalLink(post, null);
+  const image = imageLink || profileImage;
+  const card = imageLink ? 'summary_large_image' : 'summary';
+
+  return {
+    title,
+    description,
+    alternates: { canonical },
+    openGraph: {
+      title,
+      type: 'article',
+      url: localUrl,
+      images: [image],
+      description,
+      siteName: 'Steemit',
+      tags: post.category ? [post.category] : undefined,
+      publishedTime: post.created,
+    },
+    twitter: {
+      card,
+      site: '@steemit',
+      title,
+      description,
+      images: [image],
+    },
+  };
+}
+
+/** Profile subset legacy addAccountMeta consumed. */
+export interface SeoProfile {
+  name?: string;
+  about?: string;
+  profile_image?: string;
+}
+
+/** Legacy addAccountMeta mapped to the Next.js Metadata API. */
+export function buildAccountMetadata(
+  accountname: string,
+  profile: SeoProfile | null
+): Metadata {
+  const name = profile?.name || accountname;
+  const about = profile?.about || 'Steemit: Communities Without Borders.';
+  const profileImage =
+    profile?.profile_image || `${SITE_ORIGIN}/images/steemit-twshare-2.png`;
+
+  const title = `@${accountname}`;
+  const description = `The latest posts from ${name}. Follow me at @${accountname}. ${about}`;
+
+  return {
+    title,
+    description,
+    twitter: {
+      card: 'summary',
+      site: '@steemit',
+      title,
+      description,
+      images: [profileImage],
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Post pages were pure client components, so SSR HTML contained no post-level meta — crawlers and link unfurlers (Twitter/Telegram/Facebook, Google) only saw the root-layout defaults. This PR ports legacy's server-side metadata behavior.

**New `lib/seo.ts`** — faithful port of legacy `ExtractMeta.js` (`addPostMeta`/`addAccountMeta`) + `CanonicalLinker.js`:
- Post meta: `{title} — Steemit`, description from body summary + author, `og:type=article`, `article:tag`/`published_time`, first body image (else author avatar), twitter card `summary_large_image`/`summary`
- Canonical: respects author-specified `json_metadata.canonical_url` against the scheme + app whitelists, and rewrites `hive-*` categories to community slugs
- User pages: legacy `addAccountMeta` equivalent

**Server shells + `generateMetadata`** for `post/[category]/[username]/[permlink]`, `post-no-category/[username]/[permlink]`, `user/[username]`, `user/[username]/[section]` — existing client logic moved verbatim into sibling `*Client.tsx` components. Post data reuses the `getDiscussion` Redis-cached path; fetch failures degrade to a minimal title rather than 500.

**Removed** the client-side `document.title`/canonical effects in `PostFull.tsx` (server meta covers SSR; client navigations get metadata from the new route automatically).

Notes: site origin defaults to `https://steemit.com` (no config var exists, matching legacy's default); `fb:app_id` skipped (no such config here); `lib/extract-content.ts` verified line-by-line equivalent to legacy `ExtractContent.js`.

## Test plan

- `pnpm test` — 22 files / 131 tests green (23 new SEO cases: canonical whitelist accept/reject, hive-* rewrites, metadata mapping, no-HTML-leak in descriptions)
- `pnpm build` — passes; all 4 routes server-rendered on demand
- Verified live: `pnpm dev` + curl shows full `og:title/og:image/article:*/twitter:card/rel=canonical` in SSR HTML for a real post and user page; nonexistent post returns 200 with degraded title

🤖 Generated with Kimi Code