### PR TITLE
feat: payout options and beneficiaries for post submission

### DIFF
--- a/__tests__/components/PostEditor.test.tsx
+++ b/__tests__/components/PostEditor.test.tsx
@@ -218,4 +218,154 @@ describe('PostEditor', () => {
     ).toBeInTheDocument();
     expect(broadcastCommentMock).not.toHaveBeenCalled();
   });
+
+  it('shows the payout selector and beneficiaries editor only for stories', () => {
+    const store = makeStore();
+    store.dispatch(setUser({ username: 'alice' }));
+
+    const { unmount } = render(
+      <PostEditor
+        type="submit_comment"
+        parentAuthor="bob"
+        parentPermlink="bob-post"
+      />,
+      { wrapper: wrapper(store) }
+    );
+    expect(screen.queryByLabelText('Author rewards')).toBeNull();
+    expect(screen.queryByText('Add account')).toBeNull();
+    unmount();
+
+    render(<PostEditor type="submit_story" />, { wrapper: wrapper(store) });
+    expect(screen.getByLabelText('Author rewards')).toHaveValue('50%');
+    expect(screen.getByText('Add account')).toBeInTheDocument();
+  });
+
+  it('rejects an invalid beneficiary account and does not broadcast', async () => {
+    const store = makeStore();
+    store.dispatch(setUser({ username: 'alice' }));
+    const user = userEvent.setup();
+
+    render(<PostEditor type="submit_story" />, { wrapper: wrapper(store) });
+
+    await user.type(screen.getByPlaceholderText('Title'), 'My Post');
+    await user.type(screen.getByPlaceholderText('Write your story...'), 'body');
+    await user.type(screen.getByPlaceholderText(/Add up to 8 tags/), 'test{Enter}');
+    await user.click(screen.getByText('Add account'));
+    await user.type(screen.getByLabelText('Beneficiary account 1'), '1bad');
+    await user.type(screen.getByLabelText('Beneficiary percent 1'), '10');
+    await user.click(screen.getByRole('button', { name: 'Post' }));
+
+    expect(
+      await screen.findByText('Each account segment should start with a letter.')
+    ).toBeInTheDocument();
+    expect(broadcastCommentMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects beneficiary totals over 100 percent', async () => {
+    const store = makeStore();
+    store.dispatch(setUser({ username: 'alice' }));
+    const user = userEvent.setup();
+
+    render(<PostEditor type="submit_story" />, { wrapper: wrapper(store) });
+
+    await user.type(screen.getByPlaceholderText('Title'), 'My Post');
+    await user.type(screen.getByPlaceholderText('Write your story...'), 'body');
+    await user.type(screen.getByPlaceholderText(/Add up to 8 tags/), 'test{Enter}');
+    await user.click(screen.getByText('Add account'));
+    await user.click(screen.getByText('Add account'));
+    await user.type(screen.getByLabelText('Beneficiary account 1'), 'bob');
+    await user.type(screen.getByLabelText('Beneficiary percent 1'), '60');
+    await user.type(screen.getByLabelText('Beneficiary account 2'), 'carol');
+    await user.type(screen.getByLabelText('Beneficiary percent 2'), '50');
+    await user.click(screen.getByRole('button', { name: 'Post' }));
+
+    expect(
+      await screen.findByText('Beneficiary total percentage must be less than 100')
+    ).toBeInTheDocument();
+    expect(broadcastCommentMock).not.toHaveBeenCalled();
+  });
+
+  it('passes sorted beneficiaries and the payout override to broadcastComment', async () => {
+    const store = makeStore();
+    store.dispatch(setUser({ username: 'alice' }));
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+    broadcastCommentMock.mockResolvedValue({ success: true, result: {} });
+
+    render(<PostEditor type="submit_story" onSuccess={onSuccess} />, {
+      wrapper: wrapper(store),
+    });
+
+    await user.type(screen.getByPlaceholderText('Title'), 'My Post');
+    await user.type(screen.getByPlaceholderText('Write your story...'), 'body');
+    await user.type(screen.getByPlaceholderText(/Add up to 8 tags/), 'test{Enter}');
+    await user.selectOptions(screen.getByLabelText('Author rewards'), '100%');
+    await user.click(screen.getByText('Add account'));
+    await user.click(screen.getByText('Add account'));
+    await user.type(screen.getByLabelText('Beneficiary account 1'), 'charlie');
+    await user.type(screen.getByLabelText('Beneficiary percent 1'), '10');
+    await user.type(screen.getByLabelText('Beneficiary account 2'), 'bob');
+    await user.type(screen.getByLabelText('Beneficiary percent 2'), '5');
+    await user.click(screen.getByRole('button', { name: 'Post' }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+
+    const args = broadcastCommentMock.mock.calls[0][0];
+    expect(args.commentOptions).toEqual({
+      percentSteemDollars: 0,
+      extensions: [
+        [
+          0,
+          {
+            beneficiaries: [
+              { account: 'bob', weight: 500 },
+              { account: 'charlie', weight: 1000 },
+            ],
+          },
+        ],
+      ],
+    });
+  });
+
+  it('omits commentOptions for the default payout without beneficiaries', async () => {
+    const store = makeStore();
+    store.dispatch(setUser({ username: 'alice' }));
+    const user = userEvent.setup();
+    const onSuccess = vi.fn();
+    broadcastCommentMock.mockResolvedValue({ success: true, result: {} });
+
+    render(<PostEditor type="submit_story" onSuccess={onSuccess} />, {
+      wrapper: wrapper(store),
+    });
+
+    await user.type(screen.getByPlaceholderText('Title'), 'My Post');
+    await user.type(screen.getByPlaceholderText('Write your story...'), 'body');
+    await user.type(screen.getByPlaceholderText(/Add up to 8 tags/), 'test{Enter}');
+    await user.click(screen.getByRole('button', { name: 'Post' }));
+
+    await waitFor(() => expect(onSuccess).toHaveBeenCalledTimes(1));
+    expect(broadcastCommentMock.mock.calls[0][0].commentOptions).toBeUndefined();
+  });
+
+  it('persists payoutType and beneficiaries in the localStorage draft', async () => {
+    const store = makeStore();
+    store.dispatch(setUser({ username: 'alice' }));
+    const user = userEvent.setup();
+
+    render(<PostEditor type="submit_story" />, { wrapper: wrapper(store) });
+
+    await user.type(screen.getByPlaceholderText('Title'), 'Draft Post');
+    await user.selectOptions(screen.getByLabelText('Author rewards'), '0%');
+    await user.click(screen.getByText('Add account'));
+    await user.type(screen.getByLabelText('Beneficiary account 1'), 'bob');
+    await user.type(screen.getByLabelText('Beneficiary percent 1'), '10');
+
+    await waitFor(() => {
+      const raw = localStorage.getItem('replyEditorData-submit');
+      expect(raw).toBeTruthy();
+      const draft = JSON.parse(raw as string);
+      expect(draft.payoutType).toBe('0%');
+      expect(draft.beneficiaries).toEqual([{ username: 'bob', percent: '10' }]);
+    });
+  });
 });

--- a/__tests__/lib/crypto/transaction-signer.test.ts
+++ b/__tests__/lib/crypto/transaction-signer.test.ts
@@ -1,0 +1,134 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { signCommentOperation } from '@/lib/crypto/transaction-signer';
+import { steem } from '@steemit/steem-js';
+
+vi.mock('@steemit/steem-js', () => ({
+  steem: {
+    operations: {
+      createComment: vi.fn(
+        (
+          parentAuthor: string,
+          parentPermlink: string,
+          author: string,
+          permlink: string,
+          title: string,
+          body: string,
+          jsonMetadata: string
+        ) => ({
+          0: 'comment',
+          1: {
+            parent_author: parentAuthor,
+            parent_permlink: parentPermlink,
+            author,
+            permlink,
+            title,
+            body,
+            json_metadata: jsonMetadata,
+          },
+        })
+      ),
+      createVote: vi.fn(),
+      createCustomJson: vi.fn(),
+    },
+    auth: {
+      signTransaction: vi.fn((trx: Record<string, unknown>) => ({
+        ...trx,
+        signatures: ['deadbeef'],
+      })),
+    },
+  },
+}));
+
+const signTransactionMock = steem.auth.signTransaction as ReturnType<typeof vi.fn>;
+
+const PARAMS = {
+  parentAuthor: '',
+  parentPermlink: 'test',
+  author: 'alice',
+  permlink: 'my-post',
+  title: 'My Post',
+  body: 'hello',
+  jsonMetadata: '{}',
+};
+
+/** Operations of the transaction handed to steem.auth.signTransaction. */
+function signedOperations(): Array<[string, Record<string, unknown>]> {
+  return signTransactionMock.mock.calls[0][0].operations;
+}
+
+describe('signCommentOperation comment_options', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          head_block_number: 1000,
+          head_block_id:
+            '000003e800000000000000000000000000000000000000000000000000000000',
+        }),
+      })
+    );
+  });
+
+  it('signs a bare comment op when no commentOptions are given', async () => {
+    const signed = await signCommentOperation('wif', PARAMS);
+    expect(signed.signatures).toEqual(['deadbeef']);
+    const ops = signedOperations();
+    expect(ops).toHaveLength(1);
+    expect(ops[0][0]).toBe('comment');
+    expect(ops[0][1]).toMatchObject({ author: 'alice', permlink: 'my-post' });
+  });
+
+  it('appends comment_options immediately after comment with legacy defaults', async () => {
+    await signCommentOperation('wif', PARAMS, {});
+    const ops = signedOperations();
+    expect(ops).toHaveLength(2);
+    expect(ops[0][0]).toBe('comment');
+    expect(ops[1][0]).toBe('comment_options');
+    expect(ops[1][1]).toEqual({
+      author: 'alice',
+      permlink: 'my-post',
+      max_accepted_payout: '1000000.000 SBD',
+      percent_steem_dollars: 10000,
+      allow_votes: true,
+      allow_curation_rewards: true,
+      extensions: [],
+    });
+  });
+
+  it("pins '0%' (decline payout) field values", async () => {
+    await signCommentOperation('wif', PARAMS, {
+      maxAcceptedPayout: '0.000 SBD',
+    });
+    const options = signedOperations()[1][1];
+    expect(options.max_accepted_payout).toBe('0.000 SBD');
+    expect(options.percent_steem_dollars).toBe(10000);
+  });
+
+  it("pins '100%' (power up) field values — 0 must not fall back to the default", async () => {
+    await signCommentOperation('wif', PARAMS, { percentSteemDollars: 0 });
+    const options = signedOperations()[1][1];
+    expect(options.percent_steem_dollars).toBe(0);
+    expect(options.max_accepted_payout).toBe('1000000.000 SBD');
+  });
+
+  it('passes the beneficiaries extension through verbatim', async () => {
+    const extensions: Array<[number, { beneficiaries: Array<{ account: string; weight: number }> }]> = [
+      [
+        0,
+        {
+          beneficiaries: [
+            { account: 'bob', weight: 1000 },
+            { account: 'carol', weight: 500 },
+          ],
+        },
+      ],
+    ];
+    await signCommentOperation('wif', PARAMS, { extensions });
+    const options = signedOperations()[1][1];
+    expect(options.extensions).toEqual(extensions);
+  });
+});

--- a/__tests__/lib/utils/comment-options.test.ts
+++ b/__tests__/lib/utils/comment-options.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  buildCommentOptionsConfig,
+  validateBeneficiaries,
+  MAX_BENEFICIARIES,
+  type BeneficiaryEntry,
+} from '@/lib/utils/comment-options';
+
+describe('buildCommentOptionsConfig', () => {
+  it("returns undefined for the default '50%' payout without beneficiaries", () => {
+    expect(buildCommentOptionsConfig('50%', [])).toBeUndefined();
+  });
+
+  it("maps '100%' (power up) to percentSteemDollars 0 with default max payout", () => {
+    // Legacy ReplyEditor.jsx: '100%' branch sets only percent_steem_dollars: 0.
+    const config = buildCommentOptionsConfig('100%', []);
+    expect(config).toEqual({ percentSteemDollars: 0 });
+    expect(config?.maxAcceptedPayout).toBeUndefined();
+  });
+
+  it("maps '0%' (decline payout) to maxAcceptedPayout '0.000 SBD'", () => {
+    // Legacy ReplyEditor.jsx: '0%' branch sets only max_accepted_payout.
+    const config = buildCommentOptionsConfig('0%', []);
+    expect(config).toEqual({ maxAcceptedPayout: '0.000 SBD' });
+    expect(config?.percentSteemDollars).toBeUndefined();
+  });
+
+  it('converts beneficiaries to weight = percent * 100', () => {
+    const config = buildCommentOptionsConfig('50%', [
+      { username: 'bob', percent: '10' },
+      { username: 'carol', percent: '100' },
+    ]);
+    expect(config?.extensions).toEqual([
+      [
+        0,
+        {
+          beneficiaries: [
+            { account: 'bob', weight: 1000 },
+            { account: 'carol', weight: 10000 },
+          ],
+        },
+      ],
+    ]);
+  });
+
+  it('sorts beneficiaries by account name ascending (serialization requirement)', () => {
+    const config = buildCommentOptionsConfig('50%', [
+      { username: 'charlie', percent: '10' },
+      { username: 'alice', percent: '5' },
+      { username: 'bob', percent: '1' },
+    ]);
+    const routes = config?.extensions?.[0]?.[1].beneficiaries;
+    expect(routes?.map((r) => r.account)).toEqual(['alice', 'bob', 'charlie']);
+  });
+
+  it('combines payout overrides with beneficiaries', () => {
+    const config = buildCommentOptionsConfig('0%', [
+      { username: 'bob', percent: '25' },
+    ]);
+    expect(config?.maxAcceptedPayout).toBe('0.000 SBD');
+    expect(config?.extensions?.[0]?.[1].beneficiaries).toEqual([
+      { account: 'bob', weight: 2500 },
+    ]);
+  });
+});
+
+describe('validateBeneficiaries', () => {
+  const valid = (rows: BeneficiaryEntry[]) =>
+    validateBeneficiaries('alice', rows, true);
+
+  it('accepts an empty list', () => {
+    expect(valid([])).toBeNull();
+  });
+
+  it('rejects more than 8 beneficiaries', () => {
+    const rows = Array.from({ length: MAX_BENEFICIARIES + 1 }, (_, i) => ({
+      username: `user${i}abc`.slice(0, 16),
+      percent: '1',
+    }));
+    expect(valid(rows)).toBe('Can have at most 8 beneficiaries');
+  });
+
+  it('rejects invalid account names', () => {
+    expect(valid([{ username: 'ab', percent: '10' }])).toBe(
+      'Account name should be longer.'
+    );
+    expect(valid([{ username: '1abc', percent: '10' }])).toBe(
+      'Each account segment should start with a letter.'
+    );
+    expect(valid([{ username: 'ABc', percent: '10' }])).toBe(
+      'Each account segment should start with a letter.'
+    );
+  });
+
+  it('rejects the author as their own beneficiary', () => {
+    expect(valid([{ username: 'alice', percent: '10' }])).toBe(
+      'Cannot specify self as beneficiary'
+    );
+  });
+
+  it('rejects duplicate beneficiaries', () => {
+    expect(
+      valid([
+        { username: 'bob', percent: '10' },
+        { username: 'bob', percent: '5' },
+      ])
+    ).toBe('Beneficiary cannot be duplicate');
+  });
+
+  it('rejects invalid percents', () => {
+    expect(valid([{ username: 'bob', percent: '0' }])).toBe(
+      'Beneficiary percentage must be from 1-100'
+    );
+    expect(valid([{ username: 'bob', percent: 'abc' }])).toBe(
+      'Beneficiary percentage must be from 1-100'
+    );
+    expect(valid([{ username: 'bob', percent: '' }])).toBe(
+      'Beneficiary percentage must be from 1-100'
+    );
+  });
+
+  it('rejects a total percent over 100', () => {
+    expect(valid([{ username: 'bob', percent: '101' }])).toBe(
+      'Beneficiary total percentage must be less than 100'
+    );
+    expect(
+      valid([
+        { username: 'bob', percent: '60' },
+        { username: 'carol', percent: '50' },
+      ])
+    ).toBe('Beneficiary total percentage must be less than 100');
+  });
+
+  it('accepts a valid list totaling exactly 100', () => {
+    expect(
+      valid([
+        { username: 'bob', percent: '60' },
+        { username: 'carol', percent: '40' },
+      ])
+    ).toBeNull();
+  });
+});

--- a/components/elements/PostEditor.tsx
+++ b/components/elements/PostEditor.tsx
@@ -10,6 +10,14 @@ import {
   generateCommentPermlink,
   generateStoryPermlink,
 } from '@/lib/utils/permlink';
+import {
+  buildCommentOptionsConfig,
+  validateBeneficiaries,
+  DEFAULT_PAYOUT_TYPE,
+  MAX_BENEFICIARIES,
+  type BeneficiaryEntry,
+  type PayoutType,
+} from '@/lib/utils/comment-options';
 
 /** Result passed to onSuccess after a successful broadcast. */
 export interface PostEditorResult {
@@ -137,6 +145,11 @@ export default function PostEditor({
   const [body, setBody] = useState(initialBody || '');
   const [tags, setTags] = useState<string[]>(initialTags || []);
   const [category, setCategory] = useState(initialCategory || '');
+  // Payout options + beneficiaries apply to root posts only (legacy
+  // ReplyEditor gates them behind PostAdvancedSettings, shown for stories,
+  // and skips them entirely on edits — #735).
+  const [payoutType, setPayoutType] = useState<PayoutType>(DEFAULT_PAYOUT_TYPE);
+  const [beneficiaries, setBeneficiaries] = useState<BeneficiaryEntry[]>([]);
   const [submitting, setSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   // Per-editor draft key so story/comment/edit drafts never clobber each
@@ -163,6 +176,10 @@ export default function PostEditor({
         if (draft.body) setBody(draft.body);
         if (draft.tags) setTags(draft.tags);
         if (draft.category) setCategory(draft.category);
+        // Legacy persists payoutType/beneficiaries in the same draft
+        // (ReplyEditor.jsx:203-245).
+        if (draft.payoutType) setPayoutType(draft.payoutType);
+        if (draft.beneficiaries) setBeneficiaries(draft.beneficiaries);
       } catch (e) {
         console.error('Error loading draft:', e);
       }
@@ -174,9 +191,9 @@ export default function PostEditor({
     if (typeof window === 'undefined') return;
     if (!title && !body) return;
 
-    const draftData = JSON.stringify({ title, body, tags, category });
+    const draftData = JSON.stringify({ title, body, tags, category, payoutType, beneficiaries });
     localStorage.setItem(`replyEditorData-${formId}`, draftData);
-  }, [title, body, tags, category, formId]);
+  }, [title, body, tags, category, payoutType, beneficiaries, formId]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -212,6 +229,15 @@ export default function PostEditor({
     if (isStory && !cat) {
       setError('At least one tag is required (the first tag is the category)');
       return;
+    }
+    // Beneficiaries are validated with legacy required=true semantics
+    // (PostAdvancedSettings.jsx submit handler).
+    if (isStory) {
+      const beneficiaryError = validateBeneficiaries(username, beneficiaries, true);
+      if (beneficiaryError) {
+        setError(beneficiaryError);
+        return;
+      }
     }
 
     setSubmitting(true);
@@ -250,6 +276,11 @@ export default function PostEditor({
         title: trimmedTitle,
         body: trimmedBody,
         jsonMetadata,
+        // Root posts only: legacy never attaches comment_options to comments
+        // or edits.
+        commentOptions: isStory
+          ? buildCommentOptionsConfig(payoutType, beneficiaries)
+          : undefined,
       });
 
       // Clear draft
@@ -300,6 +331,27 @@ export default function PostEditor({
 
   const removeTag = (tagToRemove: string) => {
     setTags(tags.filter((tag) => tag !== tagToRemove));
+  };
+
+  // Beneficiary row editing, mirroring legacy BeneficiarySelector handlers.
+  const addBeneficiary = () => {
+    if (beneficiaries.length < MAX_BENEFICIARIES) {
+      setBeneficiaries([...beneficiaries, { username: '', percent: '' }]);
+    }
+  };
+
+  const removeBeneficiary = (idx: number) => {
+    setBeneficiaries(beneficiaries.filter((_, bidx) => idx !== bidx));
+  };
+
+  const updateBeneficiary = (
+    idx: number,
+    field: keyof BeneficiaryEntry,
+    value: string
+  ) => {
+    setBeneficiaries(
+      beneficiaries.map((b, bidx) => (idx === bidx ? { ...b, [field]: value } : b))
+    );
   };
 
   return (
@@ -370,6 +422,74 @@ export default function PostEditor({
         </div>
       )}
 
+      {isStory && (
+        <div className="space-y-4 border-t border-gray-200 pt-4">
+          <div>
+            <label
+              htmlFor="payout-type"
+              className="block text-sm font-medium text-gray-700 mb-1"
+            >
+              Author rewards
+            </label>
+            {/* Labels from legacy locales/en.json reply_editor.* */}
+            <select
+              id="payout-type"
+              value={payoutType}
+              onChange={(e) => setPayoutType(e.target.value as PayoutType)}
+              className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+            >
+              <option value="50%">50% SBD / 50% SP</option>
+              <option value="100%">Power Up 100%</option>
+              <option value="0%">Decline Payout</option>
+            </select>
+          </div>
+
+          <div>
+            <span className="block text-sm font-medium text-gray-700 mb-1">
+              Who should receive any rewards?
+            </span>
+            {beneficiaries.map((beneficiary, idx) => (
+              <div key={idx} className="flex items-center gap-2 mb-2">
+                <input
+                  type="text"
+                  value={beneficiary.username}
+                  onChange={(e) => updateBeneficiary(idx, 'username', e.target.value)}
+                  className="flex-1 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="Account"
+                  aria-label={`Beneficiary account ${idx + 1}`}
+                />
+                <input
+                  type="text"
+                  inputMode="numeric"
+                  value={beneficiary.percent}
+                  onChange={(e) => updateBeneficiary(idx, 'percent', e.target.value)}
+                  className="w-24 px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+                  placeholder="Percent"
+                  aria-label={`Beneficiary percent ${idx + 1}`}
+                />
+                <button
+                  type="button"
+                  onClick={() => removeBeneficiary(idx)}
+                  className="px-2 text-gray-500 hover:text-red-600"
+                  aria-label={`Remove beneficiary ${idx + 1}`}
+                >
+                  ×
+                </button>
+              </div>
+            ))}
+            {beneficiaries.length < MAX_BENEFICIARIES && (
+              <button
+                type="button"
+                onClick={addBeneficiary}
+                className="text-sm text-blue-600 hover:text-blue-800"
+              >
+                Add account
+              </button>
+            )}
+          </div>
+        </div>
+      )}
+
       <div className="flex items-center gap-4 pt-4 border-t border-gray-200">
         <button
           type="submit"
@@ -395,6 +515,8 @@ export default function PostEditor({
             setTitle('');
             setBody('');
             setTags([]);
+            setPayoutType(DEFAULT_PAYOUT_TYPE);
+            setBeneficiaries([]);
             if (typeof window !== 'undefined') {
               localStorage.removeItem(`replyEditorData-${formId}`);
             }

--- a/lib/api/broadcast.ts
+++ b/lib/api/broadcast.ts
@@ -10,6 +10,7 @@ import {
   SignedTransaction 
 } from '@/lib/crypto/transaction-signer';
 import { getCachedKey, decryptAndRetrieveKey } from '@/lib/crypto/key-storage';
+import type { CommentOptionsConfig } from '@/lib/utils/comment-options';
 
 /**
  * Get private key for signing
@@ -65,6 +66,9 @@ export async function broadcastComment(
     title: string;
     body: string;
     jsonMetadata: string;
+    /** Payout/beneficiary options (root posts only); appended as a
+     * comment_options op right after the comment op. */
+    commentOptions?: CommentOptionsConfig;
   }
 ): Promise<{ success: boolean; result: unknown; transactionId?: string; permlink?: string }> {
   const privateKey = await getPrivateKeyForSigning();
@@ -77,7 +81,7 @@ export async function broadcastComment(
     title: params.title,
     body: params.body,
     jsonMetadata: params.jsonMetadata,
-  });
+  }, params.commentOptions);
 
   return broadcastSignedTransaction(signedTransaction);
 }

--- a/lib/crypto/transaction-signer.ts
+++ b/lib/crypto/transaction-signer.ts
@@ -6,6 +6,8 @@
 // Import steem object directly as a named export
 import { steem } from '@steemit/steem-js';
 
+import type { CommentOptionsConfig } from '@/lib/utils/comment-options';
+
 // Import types directly from dist (these are TypeScript definition files)
 // @ts-expect-error - TypeScript can't resolve these paths, but they exist at runtime
 import type { Transaction } from '@steemit/steem-js/dist/types';
@@ -78,7 +80,8 @@ export async function signCommentOperation(
     title: string;
     body: string;
     jsonMetadata: string;
-  }
+  },
+  commentOptions?: CommentOptionsConfig
 ): Promise<SignedTransaction> {
   try {
     // Get dynamic global properties for transaction header
@@ -109,12 +112,36 @@ export async function signCommentOperation(
       params.jsonMetadata
     ));
 
+    const operations: Array<[string, Record<string, unknown>]> = [operation];
+
+    // comment_options must come directly after comment (legacy
+    // TransactionSaga.js preBroadcast_comment stresses this ordering).
+    // @steemit/steem-js 1.x has no createCommentOptions factory, but its
+    // serializer supports the op, so the tuple is constructed manually with
+    // the same defaults legacy applies.
+    if (commentOptions) {
+      operations.push([
+        'comment_options',
+        {
+          author: params.author,
+          permlink: params.permlink,
+          max_accepted_payout:
+            commentOptions.maxAcceptedPayout ?? '1000000.000 SBD',
+          percent_steem_dollars:
+            commentOptions.percentSteemDollars ?? 10000, // 10000 === 100%
+          allow_votes: true,
+          allow_curation_rewards: true,
+          extensions: commentOptions.extensions ?? [],
+        },
+      ]);
+    }
+
     // Create transaction
     const transaction: Omit<SignedTransaction, 'signatures'> = {
       ref_block_num: refBlockNum,
       ref_block_prefix: refBlockPrefix,
       expiration: expirationStr,
-      operations: [operation],
+      operations,
       extensions: [],
     };
 

--- a/lib/utils/comment-options.ts
+++ b/lib/utils/comment-options.ts
@@ -1,0 +1,125 @@
+/**
+ * Payout (comment_options) helpers for root posts.
+ * Ported from legacy:
+ * - src/app/components/elements/ReplyEditor.jsx (~1458-1495):
+ *   payoutType -> __config.comment_options config
+ * - src/app/components/cards/BeneficiarySelector.jsx (validateBeneficiaries)
+ * The final op assembly (author/permlink fill-in + defaults) happens in
+ * lib/crypto/transaction-signer.ts, mirroring legacy TransactionSaga.js
+ * preBroadcast_comment.
+ */
+
+import { validateAccountName } from '@/lib/chain-validation';
+
+/** Legacy payoutType values (ReplyEditor.jsx switch). */
+export type PayoutType = '50%' | '100%' | '0%';
+export const DEFAULT_PAYOUT_TYPE: PayoutType = '50%';
+
+/** One beneficiary row as edited in the UI (legacy {username, percent}). */
+export interface BeneficiaryEntry {
+  username: string;
+  percent: string;
+}
+
+/** Serialized beneficiary route inside the comment_options extension. */
+export interface BeneficiaryRoute {
+  account: string;
+  /** percent * 100 (10000 === 100%). */
+  weight: number;
+}
+
+/**
+ * Partial comment_options payload, like legacy __config.comment_options:
+ * only the fields that differ from the chain defaults are set.
+ */
+export interface CommentOptionsConfig {
+  maxAcceptedPayout?: string;
+  percentSteemDollars?: number;
+  extensions?: Array<[number, { beneficiaries: BeneficiaryRoute[] }]>;
+}
+
+// Legacy BeneficiarySelector handleAddBeneficiary caps the list at 8.
+export const MAX_BENEFICIARIES = 8;
+
+/**
+ * Ported from legacy BeneficiarySelector.jsx validateBeneficiaries, with
+ * counterpart i18n messages inlined as English (locales/en.json
+ * beneficiary_selector_jsx.*). Returns an error message or null when valid.
+ */
+export function validateBeneficiaries(
+  username: string,
+  beneficiaries: BeneficiaryEntry[],
+  required = true
+): string | null {
+  if (beneficiaries.length > MAX_BENEFICIARIES) {
+    return 'Can have at most 8 beneficiaries';
+  }
+  let totalPercent = 0;
+  const beneficiaryNames = new Set<string>();
+  for (const beneficiary of beneficiaries) {
+    const accountError = validateAccountName(beneficiary.username);
+    if ((required || beneficiary.username) && accountError) {
+      return accountError;
+    }
+    if (beneficiary.username === username) {
+      return 'Cannot specify self as beneficiary';
+    }
+    if (beneficiaryNames.has(beneficiary.username)) {
+      return 'Beneficiary cannot be duplicate';
+    }
+    beneficiaryNames.add(beneficiary.username);
+    if (
+      (required || beneficiary.percent) &&
+      !/^[1-9]\d{0,2}$/.test(beneficiary.percent)
+    ) {
+      return 'Beneficiary percentage must be from 1-100';
+    }
+    totalPercent += parseInt(beneficiary.percent);
+  }
+  if (totalPercent > 100) {
+    return 'Beneficiary total percentage must be less than 100';
+  }
+  return null;
+}
+
+/**
+ * Build the comment_options config for a new root post, mirroring legacy
+ * ReplyEditor.jsx:1458-1495. Returns undefined when the defaults apply
+ * (50% payout, no beneficiaries), in which case no comment_options op is
+ * appended at all.
+ */
+export function buildCommentOptionsConfig(
+  payoutType: PayoutType,
+  beneficiaries: BeneficiaryEntry[]
+): CommentOptionsConfig | undefined {
+  let config: CommentOptionsConfig | undefined;
+  switch (payoutType) {
+    case '0%': // decline payout
+      config = { maxAcceptedPayout: '0.000 SBD' };
+      break;
+    case '100%': // 100% steem power payout
+      config = { percentSteemDollars: 0 }; // 10000 === 100% (of 50%)
+      break;
+    default: // 50% steem power, 50% SBD
+  }
+  if (beneficiaries.length > 0) {
+    if (!config) config = {};
+    // Serialization requires beneficiaries sorted by account name ascending;
+    // weight is percent * 100 (10000 === 100%).
+    const sorted = [...beneficiaries].sort((a, b) =>
+      a.username < b.username ? -1 : a.username > b.username ? 1 : 0
+    );
+    config.extensions = [
+      [
+        0,
+        {
+          beneficiaries: sorted.map((elt) => ({
+            account: elt.username,
+            weight: parseInt(elt.percent) * 100,
+          })),
+        },
+      ],
+    ];
+  }
+  return config;
+}


### PR DESCRIPTION
## Summary

Posts were broadcast with only a `comment` op and no `comment_options`, so authors couldn't choose a payout mode (50/50, Power Up 100%, Decline) or set beneficiaries. This ports the legacy feature end-to-end.

**New `lib/utils/comment-options.ts`**
- `buildCommentOptionsConfig(payoutType, beneficiaries)` — exact legacy field mapping (verified at `ReplyEditor.jsx:1458-1495` + `TransactionSaga.js:481-497`):
  - `50%` (default): defaults `max_accepted_payout: '1000000.000 SBD'`, `percent_steem_dollars: 10000`; with no beneficiaries **no op is emitted at all** (legacy behavior)
  - `100%` (Power Up): `percent_steem_dollars: 0`
  - `0%` (Decline): `max_accepted_payout: '0.000 SBD'`
  - Beneficiaries: `extensions: [[0, { beneficiaries: [{account, weight}] }]]`, `weight = percent × 100`, sorted by account ascending (serialization requirement)
- `validateBeneficiaries()` — ported rules: max 8, valid account names (via existing `lib/chain-validation.ts`), no self, no duplicates, 1-100 per entry, ≤100 total

**Signing** — `signCommentOperation` accepts an optional `commentOptions` and appends the `comment_options` tuple **immediately after** `comment` (legacy ordering requirement). steem-js 1.x has no `createCommentOptions` factory, but its serializer fully supports the op (incl. the beneficiaries extension), so the tuple is constructed manually with a comment noting this.

**UI** (`PostEditor`) — story-only "Author rewards" selector + beneficiaries editor; both persist in the localStorage draft. Comment replies are unaffected, matching legacy.

## Test plan

- `pnpm test` — 24 files / **156 tests green** (25 new: exact op field values per payout type incl. the `percent_steem_dollars: 0` non-fallback case, weight math, account sort order, comment→comment_options op ordering, validation messages, draft persistence, selector hidden for comments)
- `npx eslint` on touched files — clean
- `pnpm build` — passes

Not ported (deliberately): beneficiary account autocomplete (would need a new dep), per-account default payout setting.

🤖 Generated with Kimi Code