### PR TITLE
fix(auth): correct public key detection in isPublicKeyFormat

### DIFF
--- a/__tests__/lib/crypto/client.test.ts
+++ b/__tests__/lib/crypto/client.test.ts
@@ -1,0 +1,50 @@
+// @vitest-environment node
+import { describe, it, expect } from 'vitest';
+import { steem } from '@steemit/steem-js';
+import {
+  isWifFormat,
+  isPublicKeyFormat,
+  verifySignature,
+} from '@/lib/crypto/client';
+
+// Deterministic key pair generated from a seed (never used on-chain)
+const key = steem.auth.PrivateKey.fromSeed('condenser-crypto-client-test');
+const WIF = key.toWif();
+const PUB = key.toPublicKey().toString();
+
+describe('isWifFormat', () => {
+  it('accepts a valid WIF private key', () => {
+    expect(isWifFormat(WIF)).toBe(true);
+  });
+
+  it('rejects a public key', () => {
+    expect(isWifFormat(PUB)).toBe(false);
+  });
+
+  it('rejects garbage', () => {
+    expect(isWifFormat('not-a-key')).toBe(false);
+  });
+});
+
+describe('isPublicKeyFormat', () => {
+  // Regression: steem-js 1.x PublicKey.fromString returns null instead of
+  // throwing for non-public-key input, so a bare try/catch misclassified
+  // every valid WIF as a public key and blocked all logins.
+  it('rejects a valid WIF private key (must not be seen as public key)', () => {
+    expect(isPublicKeyFormat(WIF)).toBe(false);
+  });
+
+  it('accepts a valid STM public key', () => {
+    expect(isPublicKeyFormat(PUB)).toBe(true);
+  });
+
+  it('rejects garbage', () => {
+    expect(isPublicKeyFormat('not-a-key')).toBe(false);
+  });
+});
+
+describe('verifySignature', () => {
+  it('returns false for a null-yielding (invalid) public key string', () => {
+    expect(verifySignature('00'.repeat(33), 'data', 'not-a-key')).toBe(false);
+  });
+});

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -83,6 +83,13 @@ export async function POST(request: NextRequest) {
     try {
       const sig = Signature.fromHex(signature);
       const pubKey = PublicKey.fromString(publicKey);
+      if (!pubKey) {
+        // steem-js 1.x returns null for invalid public key strings
+        return NextResponse.json(
+          { error: 'Invalid public key' },
+          { status: 400 }
+        );
+      }
       const isValidSignature = sig.verifyHash(Buffer.from(data, 'utf8'), pubKey);
       
       if (!isValidSignature) {

--- a/components/modules/LoginForm.tsx
+++ b/components/modules/LoginForm.tsx
@@ -74,14 +74,15 @@ export default function LoginForm({ embedded = false }: { embedded?: boolean }) 
       return t('loginform_jsx.wif_required');
     }
 
+    // Check for a public key first so users pasting one get the specific
+    // message (legacy behavior); isPublicKeyFormat runs before the WIF check.
+    if (isPublicKeyFormat(password.trim())) {
+      return t('loginform_jsx.you_need_a_private_password_or_key');
+    }
+
     // Only accept WIF format private keys
     if (!isWifFormat(password.trim())) {
       return t('loginform_jsx.invalid_wif_format');
-    }
-
-    // Check if password is a public key (should not be)
-    if (isPublicKeyFormat(password.trim())) {
-      return t('loginform_jsx.you_need_a_private_password_or_key');
     }
 
     return null;

--- a/lib/crypto/client.ts
+++ b/lib/crypto/client.ts
@@ -138,8 +138,9 @@ export function isWifFormat(key: string): boolean {
  */
 export function isPublicKeyFormat(key: string): boolean {
   try {
-    PublicKey.fromString(key);
-    return true;
+    // steem-js 1.x returns null instead of throwing for non-public-key
+    // input (e.g. a WIF), so a bare try/catch misclassifies every key.
+    return PublicKey.fromString(key) != null;
   } catch {
     return false;
   }
@@ -156,7 +157,11 @@ export function verifySignature(
   try {
     const sig = Signature.fromHex(signature);
     const pubKey = PublicKey.fromString(publicKey);
-    
+    if (!pubKey) {
+      // steem-js 1.x returns null for invalid public key strings
+      return false;
+    }
+
     return sig.verifyHash(Buffer.from(data, 'utf8'), pubKey);
   } catch {
     return false;


### PR DESCRIPTION
## Problem

Login was completely broken on the dev environment (steemitdev.com): every attempt failed with "You need a private password or key (not a public key)", even with a valid WIF private key.

## Root cause

`lib/crypto/client.ts` `isPublicKeyFormat()` wrapped `PublicKey.fromString()` in try/catch, assuming it throws on invalid input. In steem-js 1.x, `PublicKey.fromString()\**returns `null`*** instead of throwing — so the function returned `true` for **every** string, misclassifying all valid WIF private keys as public keys and rejecting them.

This slipped through because existing login tests mocked this layer.

## Fix

- `lib/crypto/client.ts` — `isPublicKeyFormat` now checks for a `null` return instead of relying on an exception; `verifySignature` guards against a null `PublicKey`
- `app/api/auth/login/route.ts` — return 400 `Invalid public key` if the account public key fails to parse before server-side signature verification
- `components/modules/LoginForm.tsx` — moved the public-key check before the WIF check in form validation so users pasting a public key see the dedicated error message (previously dead code)
- `__tests__/lib/crypto/client.test.ts` — new regression tests (7 cases) covering WIF vs public key classification, using a deterministic keypair from `PrivateKey.fromSeed()`

## Verification

- `pnpm test` — 27 files / 173 cases all green
- `pnpm lint` — touched files clean
- `pnpm build` — passes