### PR TITLE
fix(auth): adapt login signing to steem-js 1.x API

### DIFF
--- a/__tests__/api/auth/login.test.ts
+++ b/__tests__/api/auth/login.test.ts
@@ -11,15 +11,10 @@ vi.mock('@/lib/auth/session', () => ({
   setSessionCookie: vi.fn(),
 }));
 
-const { verifyHashMock } = vi.hoisted(() => ({ verifyHashMock: vi.fn() }));
+const { verifyMock } = vi.hoisted(() => ({ verifyMock: vi.fn() }));
 
 vi.mock('@steemit/steem-js', () => ({
-  Signature: {
-    fromHex: vi.fn(() => ({ verifyHash: verifyHashMock })),
-  },
-  PublicKey: {
-    fromString: vi.fn((value: string) => ({ toString: () => value })),
-  },
+  verify: verifyMock,
 }));
 
 import { POST } from '@/app/api/auth/login/route';
@@ -56,7 +51,7 @@ describe('POST /api/auth/login', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    verifyHashMock.mockReturnValue(true);
+    verifyMock.mockReturnValue(true);
   });
 
   it('rejects bodies missing required fields', async () => {
@@ -105,7 +100,7 @@ describe('POST /api/auth/login', () => {
 
   it('returns 401 when the signature does not verify', async () => {
     getAccountMock.mockResolvedValue(accountWithPostingKey());
-    verifyHashMock.mockReturnValue(false);
+    verifyMock.mockReturnValue(false);
 
     const res = await POST(makePostRequest('/api/auth/login', validBody()));
     expect(res.status).toBe(401);

--- a/__tests__/lib/crypto/client.test.ts
+++ b/__tests__/lib/crypto/client.test.ts
@@ -4,6 +4,7 @@ import { steem } from '@steemit/steem-js';
 import {
   isWifFormat,
   isPublicKeyFormat,
+  signAuthData,
   verifySignature,
 } from '@/lib/crypto/client';
 
@@ -46,5 +47,37 @@ describe('isPublicKeyFormat', () => {
 describe('verifySignature', () => {
   it('returns false for a null-yielding (invalid) public key string', () => {
     expect(verifySignature('00'.repeat(33), 'data', 'not-a-key')).toBe(false);
+  });
+});
+
+describe('signAuthData / verifySignature roundtrip', () => {
+  // Regression: steem-js 1.x removed PrivateKey.sign() (signing is now the
+  // static Signature.sign(string, key)) and verifyHash() requires a 32-byte
+  // digest (raw data must go through verifyBuffer). The old calls made every
+  // login fail with "s.sign is not a function" / a verifyHash length throw.
+  it('signs auth data and verifies it against the derived public key', () => {
+    const result = signAuthData(WIF, 'testuser', 'challenge-123', 1700000000000);
+
+    expect(result.publicKey).toBe(PUB);
+    const authData = JSON.parse(result.data);
+    expect(authData).toEqual({
+      username: 'testuser',
+      challenge: 'challenge-123',
+      timestamp: 1700000000000,
+      action: 'login',
+    });
+    expect(verifySignature(result.signature, result.data, result.publicKey)).toBe(true);
+  });
+
+  it('rejects a signature over tampered data', () => {
+    const result = signAuthData(WIF, 'testuser', 'challenge-123', 1700000000000);
+    const tampered = result.data.replace('challenge-123', 'challenge-456');
+    expect(verifySignature(result.signature, tampered, result.publicKey)).toBe(false);
+  });
+
+  it('rejects verification against a different public key', () => {
+    const other = steem.auth.PrivateKey.fromSeed('condenser-crypto-client-other');
+    const result = signAuthData(WIF, 'testuser', 'challenge-123', 1700000000000);
+    expect(verifySignature(result.signature, result.data, other.toPublicKey().toString())).toBe(false);
   });
 });

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -8,7 +8,12 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAccount } from '@/lib/steem/client';
 import { getSession, loginUser, setSessionCookie } from '@/lib/auth/session';
-import { Signature, PublicKey } from '@steemit/steem-js';
+// NOTE: Signature/PublicKey are NOT exported at the package root at runtime
+// (only under steem.auth.*). The root-level verify() parses the public key
+// and hex signature, then runs verifyBuffer (SHA-256 of the raw data) —
+// matching Signature.sign(dataString, key) on the client. It returns false
+// for malformed input instead of throwing.
+import { verify } from '@steemit/steem-js';
 
 export async function POST(request: NextRequest) {
   try {
@@ -80,28 +85,9 @@ export async function POST(request: NextRequest) {
     }
 
     // Step 5: Verify the signature
-    try {
-      const sig = Signature.fromHex(signature);
-      const pubKey = PublicKey.fromString(publicKey);
-      if (!pubKey) {
-        // steem-js 1.x returns null for invalid public key strings
-        return NextResponse.json(
-          { error: 'Invalid public key' },
-          { status: 400 }
-        );
-      }
-      const isValidSignature = sig.verifyHash(Buffer.from(data, 'utf8'), pubKey);
-      
-      if (!isValidSignature) {
-        return NextResponse.json(
-          { error: 'Invalid signature' },
-          { status: 401 }
-        );
-      }
-    } catch (error: unknown) {
-      console.error('Signature verification error:', error);
+    if (!verify(data, signature, publicKey)) {
       return NextResponse.json(
-        { error: 'Signature verification failed' },
+        { error: 'Invalid signature' },
         { status: 401 }
       );
     }

--- a/lib/crypto/client.ts
+++ b/lib/crypto/client.ts
@@ -93,8 +93,11 @@ export function signAuthData(
     
     const dataString = JSON.stringify(authData);
     
-    // Sign the data
-    const signature = privateKey.sign(Buffer.from(dataString, 'utf8'));
+    // Sign the data. steem-js 1.x removed PrivateKey.sign(); signing is a
+    // static Signature.sign(string, key) which SHA-256 hashes the utf-8
+    // string internally (server verifies with verifyBuffer over the same
+    // bytes).
+    const signature = Signature.sign(dataString, privateKey);
     
     return {
       signature: signature.toHex(),
@@ -162,7 +165,9 @@ export function verifySignature(
       return false;
     }
 
-    return sig.verifyHash(Buffer.from(data, 'utf8'), pubKey);
+    // verifyHash requires a 32-byte digest; verifyBuffer hashes the raw
+    // data with SHA-256 first, matching Signature.sign() on the signer side.
+    return sig.verifyBuffer(Buffer.from(data, 'utf8'), pubKey);
   } catch {
     return false;
   }

--- a/types/steem-js.d.ts
+++ b/types/steem-js.d.ts
@@ -20,15 +20,12 @@ declare module '@steemit/steem-js' {
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   export const steem: any;
 
-  export class PublicKey {
-    static fromString(publicKey: string): PublicKey;
-    toString(): string;
-  }
-
-  export class Signature {
-    static fromHex(hex: string): Signature;
-    verifyHash(hash: Buffer, pubKey: PublicKey): boolean;
-  }
+  // Root-level helpers from dist/crypto (steem-js 1.x).
+  // NOTE: Signature/PublicKey classes are NOT exported at the package root
+  // at runtime — only under steem.auth.*. Do not re-add declarations for
+  // them here; declaring non-existent exports masks runtime failures.
+  export const verify: (message: string | Buffer, signature: string, publicKey: string) => boolean;
+  export const sign: (message: string | Buffer, privateKey: string) => string;
 
   export const api: {
     setOptions(options: {


### PR DESCRIPTION
## Problem

Follow-up to #4002. After the public-key detection fix, login on steemitdev.com still failed with `Failed to sign auth data: s.sign is not a function`, and after fixing that, with server-side 401 `Signature verification failed`.

## Root causes (three more steem-js 1.x incompatibilities)

1. `PrivateKey.sign()` was removed in steem-js 1.x — signing is now the static `Signature.sign(string, key)`, which SHA-256 hashes the utf-8 string internally.
2. Both verify sites passed **raw data** to `verifyHash()`, which requires a 32-byte digest and throws — must use `verifyBuffer()` (hashes first).
3. The login route imported `Signature`/`PublicKey` from the **package root**, but steem-js 1.x does not export them there at runtime (only under `steem.auth.*`). `undefined.fromHex()` threw and surfaced as a 401. Worse, `types/steem-js.d.ts` declared those non-existent root exports, hiding the failure at compile time.

## Fix

- `lib/crypto/client.ts` — `signAuthData` uses static `Signature.sign(dataString, key)`; `verifySignature` uses `verifyBuffer()`
- `app/api/auth/login/route.ts` — uses the root-level `verify()` helper (null-safe end to end; returns false instead of throwing)
- `types/steem-js.d.ts` — removed the false root-level `Signature`/`PublicKey` class declarations (with a comment warning not to re-add), added the real root-level `sign`/`verify` signatures
- Tests: signAuthData/verifySignature roundtrip regression cases (valid, tampered data, wrong key); login route test mocks updated to the `verify()` contract

## Verification

- `pnpm test` — 27 files / 176 cases green
- `pnpm build` — passes; eslint clean on touched files
- **Deployed to steemit-dev-condenser-001 as `login-signfix-test3-20260826124024` and confirmed with a real posting-key login on steemitdev.com**