### PR TITLE
refactor(auth): use steem-js SDK high-level auth helpers

### DIFF
--- a/__tests__/api/auth/login.test.ts
+++ b/__tests__/api/auth/login.test.ts
@@ -11,10 +11,14 @@ vi.mock('@/lib/auth/session', () => ({
   setSessionCookie: vi.fn(),
 }));
 
-const { verifyMock } = vi.hoisted(() => ({ verifyMock: vi.fn() }));
+const { verifySignatureMock } = vi.hoisted(() => ({ verifySignatureMock: vi.fn() }));
 
 vi.mock('@steemit/steem-js', () => ({
-  verify: verifyMock,
+  steem: {
+    auth: {
+      verifySignature: verifySignatureMock,
+    },
+  },
 }));
 
 import { POST } from '@/app/api/auth/login/route';
@@ -51,7 +55,7 @@ describe('POST /api/auth/login', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'error').mockImplementation(() => {});
-    verifyMock.mockReturnValue(true);
+    verifySignatureMock.mockReturnValue(true);
   });
 
   it('rejects bodies missing required fields', async () => {
@@ -100,7 +104,7 @@ describe('POST /api/auth/login', () => {
 
   it('returns 401 when the signature does not verify', async () => {
     getAccountMock.mockResolvedValue(accountWithPostingKey());
-    verifyMock.mockReturnValue(false);
+    verifySignatureMock.mockReturnValue(false);
 
     const res = await POST(makePostRequest('/api/auth/login', validBody()));
     expect(res.status).toBe(401);

--- a/app/api/auth/check-authority/route.ts
+++ b/app/api/auth/check-authority/route.ts
@@ -4,8 +4,8 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
+import { steem } from '@steemit/steem-js';
 import { getAccount } from '@/lib/steem/client';
-import { PrivateKey } from '@/lib/steem/client';
 
 export async function POST(request: NextRequest) {
   try {
@@ -28,44 +28,40 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Derive private keys
-    const isRole = (r: string, fn: () => InstanceType<typeof PrivateKey>) => (!role || role === r ? fn() : undefined);
+    // Derive public keys via the steem-js SDK auth helpers.
+    const isRole = (r: string, fn: () => string) => (!role || role === r ? fn() : undefined);
 
-    let privateKeys: {
-      posting_private?: InstanceType<typeof PrivateKey>;
-      active_private?: InstanceType<typeof PrivateKey>;
-      owner_private?: InstanceType<typeof PrivateKey>;
-      memo_private: InstanceType<typeof PrivateKey>;
+    let publicKeys: {
+      posting_pub?: string;
+      active_pub?: string;
+      owner_pub?: string;
+      memo_pub: string;
     };
 
-    try {
-      // Try to parse as WIF (private key)
-      const privateKey = PrivateKey.fromWif(password);
-      privateKeys = {
-        owner_private: isRole('owner', () => privateKey),
-        posting_private: isRole('posting', () => privateKey),
-        active_private: isRole('active', () => privateKey),
-        memo_private: privateKey,
+    if (steem.auth.isWif(password)) {
+      // A WIF: check the same key against every role
+      const pub = steem.auth.wifToPublic(password);
+      publicKeys = {
+        owner_pub: isRole('owner', () => pub),
+        posting_pub: isRole('posting', () => pub),
+        active_pub: isRole('active', () => pub),
+        memo_pub: pub,
       };
-    } catch {
-      // Not a WIF, treat as password and derive keys
-      privateKeys = {
-        posting_private: isRole('posting', () =>
-          PrivateKey.fromSeed(username + 'posting' + password)
-        ),
-        active_private: isRole('active', () =>
-          PrivateKey.fromSeed(username + 'active' + password)
-        ),
-        memo_private: PrivateKey.fromSeed(username + 'memo' + password),
+    } else {
+      // A master password: derive per-role keys
+      const derivePub = (r: string) => steem.auth.wifToPublic(steem.auth.toWif(username, password, r));
+      publicKeys = {
+        posting_pub: isRole('posting', () => derivePub('posting')),
+        active_pub: isRole('active', () => derivePub('active')),
+        memo_pub: derivePub('memo'),
       };
     }
 
     // Check authority (simplified version)
-    const toPub = (k?: InstanceType<typeof PrivateKey>) => (k ? k.toPublicKey().toString() : '-');
-    const postingPub = toPub(privateKeys.posting_private);
-    const activePub = toPub(privateKeys.active_private);
-    const ownerPub = toPub(privateKeys.owner_private);
-    const memoPub = toPub(privateKeys.memo_private);
+    const postingPub = publicKeys.posting_pub ?? '-';
+    const activePub = publicKeys.active_pub ?? '-';
+    const ownerPub = publicKeys.owner_pub ?? '-';
+    const memoPub = publicKeys.memo_pub;
 
     // Simplified authority check
     /**
@@ -104,13 +100,13 @@ export async function POST(request: NextRequest) {
     };
 
     const auth = {
-      posting: privateKeys.posting_private
+      posting: publicKeys.posting_pub
         ? checkKeyAuth(postingPub, accountData.posting)
         : 'none',
-      active: privateKeys.active_private
+      active: publicKeys.active_pub
         ? checkKeyAuth(activePub, accountData.active)
         : 'none',
-      owner: privateKeys.owner_private
+      owner: publicKeys.owner_pub
         ? checkKeyAuth(ownerPub, accountData.owner)
         : 'none',
       memo: accountData.memo_key === memoPub ? 'full' : 'none',

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -8,12 +8,11 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { getAccount } from '@/lib/steem/client';
 import { getSession, loginUser, setSessionCookie } from '@/lib/auth/session';
-// NOTE: Signature/PublicKey are NOT exported at the package root at runtime
-// (only under steem.auth.*). The root-level verify() parses the public key
-// and hex signature, then runs verifyBuffer (SHA-256 of the raw data) —
-// matching Signature.sign(dataString, key) on the client. It returns false
-// for malformed input instead of throwing.
-import { verify } from '@steemit/steem-js';
+// steem.auth.verifySignature() parses the public key and hex signature,
+// then runs verifyBuffer (SHA-256 of the raw message) — matching
+// steem.auth.sign() on the client. It returns false for malformed input
+// instead of throwing.
+import { steem } from '@steemit/steem-js';
 
 export async function POST(request: NextRequest) {
   try {
@@ -85,7 +84,7 @@ export async function POST(request: NextRequest) {
     }
 
     // Step 5: Verify the signature
-    if (!verify(data, signature, publicKey)) {
+    if (!steem.auth.verifySignature(data, signature, publicKey)) {
       return NextResponse.json(
         { error: 'Invalid signature' },
         { status: 401 }

--- a/lib/crypto/client.ts
+++ b/lib/crypto/client.ts
@@ -2,24 +2,14 @@
  * Client-side cryptographic utilities
  * Handles private key validation and signing operations
  * Only supports posting key authentication for security
+ *
+ * All operations go through the steem-js SDK high-level auth helpers
+ * (steem.auth.*). Do not drop down to the ecc classes (PrivateKey /
+ * PublicKey / Signature) — their API changed in steem-js 1.x and
+ * hand-rolled usage has broken login twice already.
  */
 
-// Import steem object directly as a named export
 import { steem } from '@steemit/steem-js';
-
-// Import types directly from dist (these are TypeScript definition files)
-// @ts-expect-error - TypeScript can't resolve these paths, but they exist at runtime
-import type { PrivateKey } from '@steemit/steem-js/dist/auth/ecc/src/key_private';
-// @ts-expect-error - TypeScript can't resolve these paths, but they exist at runtime
-import type { PublicKey } from '@steemit/steem-js/dist/auth/ecc/src/key_public';
-// @ts-expect-error - TypeScript can't resolve these paths, but they exist at runtime
-import type { Signature } from '@steemit/steem-js/dist/auth/ecc/src/signature';
-
-// Get classes from steem object at runtime
-// Use type aliases for cleaner code
-const PrivateKey = steem.auth.PrivateKey;
-const PublicKey = steem.auth.PublicKey;
-const Signature = steem.auth.Signature;
 
 export interface KeyValidationResult {
   isValid: boolean;
@@ -41,13 +31,15 @@ export function validatePostingKey(
   expectedPostingPublicKey: string
 ): KeyValidationResult {
   try {
-    // Parse the private key
-    const privateKey = PrivateKey.fromWif(privateKeyWif);
-    
-    // Generate public key from private key
-    const publicKey = privateKey.toPublicKey();
-    const publicKeyString = publicKey.toString();
-    
+    if (!steem.auth.isWif(privateKeyWif)) {
+      return {
+        isValid: false,
+        error: 'Invalid private key format',
+      };
+    }
+
+    const publicKeyString = steem.auth.wifToPublic(privateKeyWif);
+
     // Check if it matches the expected posting public key
     if (publicKeyString !== expectedPostingPublicKey) {
       return {
@@ -55,7 +47,7 @@ export function validatePostingKey(
         error: 'Private key does not match the posting public key for this account',
       };
     }
-    
+
     return {
       isValid: true,
       publicKey: publicKeyString,
@@ -80,9 +72,8 @@ export function signAuthData(
   timestamp: number = Date.now()
 ): SignatureResult {
   try {
-    const privateKey = PrivateKey.fromWif(privateKeyWif);
-    const publicKey = privateKey.toPublicKey().toString();
-    
+    const publicKey = steem.auth.wifToPublic(privateKeyWif);
+
     // Create authentication data that includes username
     const authData = {
       username,
@@ -90,17 +81,17 @@ export function signAuthData(
       timestamp,
       action: 'login',
     };
-    
+
     const dataString = JSON.stringify(authData);
-    
-    // Sign the data. steem-js 1.x removed PrivateKey.sign(); signing is a
-    // static Signature.sign(string, key) which SHA-256 hashes the utf-8
-    // string internally (server verifies with verifyBuffer over the same
-    // bytes).
-    const signature = Signature.sign(dataString, privateKey);
-    
+
+    // steem.auth.sign() SHA-256 hashes the utf-8 message and returns the
+    // hex signature; the server verifies with verifySignature() over the
+    // same string (both are steem.auth helpers, so the hashing convention
+    // cannot drift apart).
+    const signature = steem.auth.sign(dataString, privateKeyWif);
+
     return {
-      signature: signature.toHex(),
+      signature,
       publicKey,
       data: dataString,
     };
@@ -116,8 +107,7 @@ export function signAuthData(
  */
 export function derivePostingKey(username: string, password: string): string {
   try {
-    const privateKey = PrivateKey.fromSeed(username + 'posting' + password);
-    return privateKey.toString();
+    return steem.auth.toWif(username, password, 'posting');
   } catch (error: unknown) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';
     throw new Error(`Failed to derive posting key: ${errorMessage}`);
@@ -128,25 +118,16 @@ export function derivePostingKey(username: string, password: string): string {
  * Check if a string looks like a WIF private key
  */
 export function isWifFormat(key: string): boolean {
-  try {
-    PrivateKey.fromWif(key);
-    return true;
-  } catch {
-    return false;
-  }
+  return steem.auth.isWif(key);
 }
 
 /**
  * Check if a string looks like a public key
  */
 export function isPublicKeyFormat(key: string): boolean {
-  try {
-    // steem-js 1.x returns null instead of throwing for non-public-key
-    // input (e.g. a WIF), so a bare try/catch misclassifies every key.
-    return PublicKey.fromString(key) != null;
-  } catch {
-    return false;
-  }
+  // steem.auth.isPubkey validates the STM-prefixed public key format and
+  // returns false (never throws) for WIFs and garbage input.
+  return steem.auth.isPubkey(key);
 }
 
 /**
@@ -158,16 +139,7 @@ export function verifySignature(
   publicKey: string
 ): boolean {
   try {
-    const sig = Signature.fromHex(signature);
-    const pubKey = PublicKey.fromString(publicKey);
-    if (!pubKey) {
-      // steem-js 1.x returns null for invalid public key strings
-      return false;
-    }
-
-    // verifyHash requires a 32-byte digest; verifyBuffer hashes the raw
-    // data with SHA-256 first, matching Signature.sign() on the signer side.
-    return sig.verifyBuffer(Buffer.from(data, 'utf8'), pubKey);
+    return steem.auth.verifySignature(data, signature, publicKey);
   } catch {
     return false;
   }

--- a/lib/steem/client.ts
+++ b/lib/steem/client.ts
@@ -412,5 +412,4 @@ export async function getUnreadNotifications(params: {
  * Export steem API for direct access if needed
  */
 export { steem };
-export const PrivateKey = steem.auth.PrivateKey;
 


### PR DESCRIPTION
## Motivation

Condenser's rewrite started before steem-js 1.x was stable, so some signing code hand-rolled the low-level ecc classes (`PrivateKey`/`PublicKey`/`Signature`). That produced two login-breaking bugs (#4002, #4003) when the 1.x API turned out to differ. The wallet codebase avoids this class of bug entirely by only using the SDK's high-level `steem.auth.*` helpers. This PR aligns condenser with that pattern: **where the SDK provides a wrapper, use it; never touch ecc classes directly.**

## Changes

- `lib/crypto/client.ts`
  - `validatePostingKey` → `steem.auth.isWif` + `wifToPublic`
  - `signAuthData` → `steem.auth.sign(dataString, wif)` (returns hex directly)
  - `derivePostingKey` → `steem.auth.toWif(username, password, 'posting')`
  - `isWifFormat` → `steem.auth.isWif`; `isPublicKeyFormat` → `steem.auth.isPubkey` (never throws, rejects WIFs)
  - `verifySignature` → `steem.auth.verifySignature`
  - Drops all ecc class references and the `dist/` deep-path type imports
- `app/api/auth/check-authority/route.ts` — derives public keys via `isWif` + `wifToPublic` / `toWif` instead of `PrivateKey.fromWif/fromSeed`; also removes the exception-based WIF/password branch (now an explicit `isWif` check)
- `app/api/auth/login/route.ts` — verification via `steem.auth.verifySignature` (same convention as wallet) instead of the package-root `verify()`
- `lib/steem/client.ts` — removes the `PrivateKey` re-export (no callers left)
- `__tests__/api/auth/login.test.ts` — mock updated to the `steem.auth.verifySignature` contract

No behavior change: the SDK helpers wrap the same operations (`toWif` ≡ `fromSeed(name+role+password)`, `sign`/`verifySignature` both SHA-256 the utf-8 message), verified at runtime against steem-js 1.0.19.

## Verification

- `pnpm test` — 27 files / 176 cases green
- `pnpm build` — passes; eslint clean on touched files