### PR TITLE
feat(nav): legacy-style two-level sidebar + fix avatar dropdown crash

### DIFF
--- a/__tests__/components/HeaderAvatarMenu.test.tsx
+++ b/__tests__/components/HeaderAvatarMenu.test.tsx
@@ -1,0 +1,60 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Provider } from 'react-redux';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { ReactNode } from 'react';
+
+import userReducer, { setUser } from '@/store/slices/userSlice';
+import { IntlWrapper } from '@/__tests__/helpers/i18n';
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), refresh: vi.fn() }),
+  usePathname: () => '/trending',
+}));
+
+vi.mock('@/components/layout/SidePanel', () => ({
+  SidePanel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+vi.mock('@/components/layout/SteemitLogo', () => ({
+  SteemitLogo: () => <div>logo</div>,
+}));
+
+import { Header } from '@/components/layout/Header';
+
+function makeStore() {
+  return configureStore({ reducer: { user: userReducer } });
+}
+
+describe('Header avatar menu (real base-ui dropdown, unmocked)', () => {
+  beforeEach(() => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) })
+    );
+  });
+
+  it('opens the account menu when clicking the avatar', async () => {
+    const store = makeStore();
+    store.dispatch(setUser({ username: 'alice', posting_authority: true }));
+
+    render(
+      <Provider store={store}>
+        <IntlWrapper>
+          <Header />
+        </IntlWrapper>
+      </Provider>
+    );
+
+    await userEvent.click(screen.getByLabelText('Account menu'));
+
+    // Simplified menu: Profile / Notifications / Wallet / Logout only.
+    expect(await screen.findByText('Profile')).toBeTruthy();
+    expect(screen.getByText('Notifications')).toBeTruthy();
+    expect(screen.getByText('Wallet')).toBeTruthy();
+    expect(screen.getByText('Logout')).toBeTruthy();
+    expect(screen.queryByText('Comments')).toBeNull();
+    expect(screen.queryByText('Replies')).toBeNull();
+    expect(screen.queryByText('Switch to Night Mode')).toBeNull();
+  });
+});

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -18,7 +18,6 @@ import {
 } from "@/components/ui/dropdown-menu";
 import { getSteemitWalletBaseUrl } from "@/lib/steemitWallet";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
-import { toggleNightmode } from "@/store/slices/appSlice";
 import { showLogin } from "@/store/slices/userSlice";
 import { logoutThunk } from "@/store/thunks/authThunks";
 import { SteemitLogo } from "@/components/layout/SteemitLogo";
@@ -231,10 +230,15 @@ export function Header() {
                   />
                 </span>
               </DropdownMenuTrigger>
-              <DropdownMenuContent align="end" className="min-w-48">
-                <DropdownMenuLabel className="font-normal">
-                  @{username}
-                </DropdownMenuLabel>
+              <DropdownMenuContent align="end" sideOffset={10} className="min-w-48">
+                {/* Base UI requires Menu.GroupLabel to live inside a
+                    Menu.Group — otherwise opening the menu throws
+                    "MenuGroupContext is missing" and crashes the page. */}
+                <DropdownMenuGroup>
+                  <DropdownMenuLabel className="font-normal">
+                    @{username}
+                  </DropdownMenuLabel>
+                </DropdownMenuGroup>
                 <DropdownMenuSeparator />
                 <DropdownMenuGroup>
                   <DropdownMenuItem
@@ -248,25 +252,6 @@ export function Header() {
                     }
                   >
                     {t("g.notifications")}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() =>
-                      router.push(`/@${username}/comments`)
-                    }
-                  >
-                    {t("g.comments")}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() =>
-                      router.push(`/@${username}/replies`)
-                    }
-                  >
-                    {t("g.replies")}
-                  </DropdownMenuItem>
-                  <DropdownMenuItem
-                    onClick={() => dispatch(toggleNightmode())}
-                  >
-                    {t("g.toggle_nightmode")}
                   </DropdownMenuItem>
                   <DropdownMenuItem
                     onClick={() =>

--- a/components/layout/PrimaryNavigation.tsx
+++ b/components/layout/PrimaryNavigation.tsx
@@ -1,13 +1,10 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import {
-  BookMarkedIcon,
-  Building2Icon,
+  ChevronDownIcon,
   CompassIcon,
-  HeartIcon,
-  ListOrderedIcon,
   UserRoundIcon,
   WalletIcon,
 } from "lucide-react";
@@ -27,79 +24,24 @@ const GLOBAL_FEED_SORTS = new Set([
   "muted",
 ]);
 
-/** Usernames that must not be treated as profile paths (aligned with proxy.ts). */
-const RESERVED_USERNAMES = new Set(
-  [
-    "trending",
-    "hot",
-    "created",
-    "payout",
-    "payout_comments",
-    "muted",
-    "login",
-    "search",
-    "submit",
-    "about",
-    "faq",
-    "privacy",
-    "support",
-    "tos",
-    "communities",
-    "tags",
-    "rewards",
-    "roles",
-    "welcome",
-    "api",
-    "_next",
-  ].map((s) => s.toLowerCase())
-);
-
-const PROFILE_SECTIONS: { segment: string; label: string }[] = [
+/**
+ * Second-level items under "My Profile" (legacy ProfileNavigation).
+ * Settings is intentionally not in the sidebar; Feed is omitted because it
+ * duplicates Explore → My Friends (/@{me}/feed).
+ */
+const MY_PROFILE_SECTIONS: { segment: string; label: string }[] = [
   { segment: "blog", label: "Blog" },
   { segment: "posts", label: "Posts" },
   { segment: "comments", label: "Comments" },
   { segment: "replies", label: "Replies" },
-  { segment: "payout", label: "Payout" },
-  { segment: "feed", label: "Feed" },
   { segment: "notifications", label: "Notifications" },
-  { segment: "communities", label: "Communities" },
-  { segment: "settings", label: "Settings" },
+  { segment: "communities", label: "Subscriptions" },
+  { segment: "payout", label: "Payouts" },
 ];
-
-function parseProfileUsername(pathname: string): string | null {
-  const one = pathname.match(/^\/@([^/]+)$/);
-  if (one) {
-    const u = one[1];
-    if (!RESERVED_USERNAMES.has(u.toLowerCase())) return u;
-    return null;
-  }
-  const two = pathname.match(/^\/@([^/]+)\/([^/]+)$/);
-  if (two) {
-    const u = two[1];
-    const seg = two[2].toLowerCase();
-    if (RESERVED_USERNAMES.has(u.toLowerCase())) return null;
-    if (PROFILE_SECTIONS.some((s) => s.segment === seg)) return u;
-    return null;
-  }
-  return null;
-}
 
 function profileSectionHref(username: string, segment: string) {
   if (segment === "blog") return `/@${username}`;
   return `/@${username}/${segment}`;
-}
-
-function isProfileSectionActive(
-  pathname: string,
-  username: string,
-  segment: string
-) {
-  const blogRoot = `/@${username}`;
-  const blogExplicit = `/@${username}/blog`;
-  if (segment === "blog") {
-    return pathname === blogRoot || pathname === blogExplicit;
-  }
-  return pathname === profileSectionHref(username, segment);
 }
 
 /** True when viewing global ranked feeds (/trending, /hot/food, …). */
@@ -111,6 +53,8 @@ function isAllPostsExplore(pathname: string): boolean {
   if (seg.length === 1) return true;
   const second = seg[1];
   if (second.startsWith("@")) return false;
+  // /<sort>/my is the "My Subscriptions" feed, not All Posts.
+  if (second.toLowerCase() === "my") return false;
   return true;
 }
 
@@ -128,11 +72,14 @@ function isMyFriendsRoute(pathname: string, username: string | undefined) {
 
 function isMySubscriptionsRoute(pathname: string) {
   if (pathname === "/trending/my") return true;
-  const m = pathname.match(/^\/(trending|hot|created|promoted|payout|payout_comments|muted)\/(.+)$/);
+  const m = pathname.match(
+    /^\/(trending|hot|created|promoted|payout|payout_comments|muted)\/(.+)$/
+  );
   if (!m) return false;
   return m[2].toLowerCase() === "my";
 }
 
+/** True when browsing the logged-in user's own profile sections. */
 function isOwnProfileArea(pathname: string, username: string) {
   if (
     pathname === `/@${username}/feed` ||
@@ -143,46 +90,45 @@ function isOwnProfileArea(pathname: string, username: string) {
   if (pathname === `/@${username}` || pathname === `/@${username}/blog`) {
     return true;
   }
-  return PROFILE_SECTIONS.some(
-    (s) =>
-      s.segment !== "feed" &&
-      pathname === profileSectionHref(username, s.segment)
+  return MY_PROFILE_SECTIONS.some(
+    (s) => s.segment !== "blog" && pathname === profileSectionHref(username, s.segment)
   );
 }
 
-function NavExploreItem({
+type IconComponent = React.ComponentType<{ className?: string }>;
+
+const pillClass = (active: boolean, extra?: string) =>
+  cn(
+    "flex w-full items-center gap-2 rounded-md border-l-2 px-2 py-[0.6rem] text-sm transition-colors",
+    active
+      ? "border-accent-foreground bg-accent font-semibold text-accent-foreground"
+      : "border-transparent text-foreground hover:bg-accent hover:text-accent-foreground",
+    extra
+  );
+
+/** Second-level link/item: indented, iconless, same pill treatment. */
+function NavSubItem({
   href,
   label,
-  icon: Icon,
   active,
   useLoginPrompt,
   onLoginPrompt,
 }: {
   href: string;
   label: string;
-  icon: React.ComponentType<{ className?: string }>;
   active: boolean;
   useLoginPrompt?: boolean;
   onLoginPrompt?: () => void;
 }) {
-  // Sidebar pill item: transparent container, rounded hover/active background
-  // with a 2px teal left indicator on the active item.
-  const className = cn(
-    "flex w-full items-center gap-2 rounded-md border-l-2 px-2 py-[0.6rem] text-sm transition-colors",
-    active
-      ? "border-accent-foreground bg-accent font-semibold text-accent-foreground"
-      : "border-transparent text-foreground hover:bg-accent hover:text-accent-foreground"
-  );
+  const className = pillClass(active, "pl-8");
   return (
     <li>
       {useLoginPrompt ? (
         <button type="button" className={className} onClick={onLoginPrompt}>
-          <Icon className="size-4 shrink-0 opacity-90" aria-hidden />
           <span>{label}</span>
         </button>
       ) : (
         <Link href={href} className={className}>
-          <Icon className="size-4 shrink-0 opacity-90" aria-hidden />
           <span>{label}</span>
         </Link>
       )}
@@ -190,70 +136,51 @@ function NavExploreItem({
   );
 }
 
-function NavTopItem({
-  href,
+/**
+ * First-level collapsible group (legacy PrimaryNavTabs). The header row only
+ * toggles expansion — navigation happens through the second-level items.
+ */
+function NavGroup({
   label,
   icon: Icon,
   active,
-  external,
-  useLoginPrompt,
-  onLoginPrompt,
+  expanded,
+  onToggle,
+  children,
 }: {
-  href: string;
   label: string;
-  icon: React.ComponentType<{ className?: string }>;
-  active?: boolean;
-  external?: boolean;
-  /** When true, open login modal instead of following `href`. */
-  useLoginPrompt?: boolean;
-  onLoginPrompt?: () => void;
+  icon: IconComponent;
+  active: boolean;
+  expanded: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
 }) {
-  // Same pill treatment as NavExploreItem so all sidebar items align.
-  const className = cn(
-    "flex items-center gap-2 rounded-md border-l-2 px-2 py-[0.6rem] text-sm transition-colors",
-    active
-      ? "border-accent-foreground bg-accent font-semibold text-accent-foreground"
-      : "border-transparent text-foreground hover:bg-accent hover:text-accent-foreground"
-  );
-  if (useLoginPrompt) {
-    return (
+  return (
+    <section>
       <button
         type="button"
-        className={cn(className, "w-full text-left")}
-        onClick={onLoginPrompt}
+        onClick={onToggle}
+        aria-expanded={expanded}
+        className={pillClass(active, "font-bold")}
       >
-        <Icon className="size-4 shrink-0 opacity-90" aria-hidden />
-        <span>{label}</span>
+        <Icon className="size-[1.15rem] shrink-0" aria-hidden />
+        <span className="flex-1 text-left">{label}</span>
+        <ChevronDownIcon
+          className={cn(
+            "size-4 shrink-0 opacity-70 transition-transform",
+            expanded && "rotate-180"
+          )}
+          aria-hidden
+        />
       </button>
-    );
-  }
-  if (external) {
-    return (
-      <a href={href} className={className} target="_blank" rel="noreferrer">
-        <Icon className="size-4 shrink-0 opacity-90" aria-hidden />
-        <span>{label}</span>
-      </a>
-    );
-  }
-  return (
-    <Link href={href} className={className}>
-      <Icon className="size-4 shrink-0 opacity-90" aria-hidden />
-      <span>{label}</span>
-    </Link>
+      {expanded ? (
+        <ul className="mt-0.5 flex flex-col gap-0.5">{children}</ul>
+      ) : null}
+    </section>
   );
 }
 
-export function PrimaryNavigation({
-  pathname,
-  compact = false,
-}: {
-  pathname: string;
-  compact?: boolean;
-}) {
-  const profileUsername = useMemo(
-    () => parseProfileUsername(pathname),
-    [pathname]
-  );
+export function PrimaryNavigation({ pathname }: { pathname: string }) {
   const dispatch = useAppDispatch();
   const sessionUser = useAppSelector((s) => s.user.current?.username);
   const walletBase = getSteemitWalletBaseUrl();
@@ -262,138 +189,137 @@ export function PrimaryNavigation({
   const communitiesActive = isCommunitiesRoute(pathname);
   const myFriendsActive = isMyFriendsRoute(pathname, sessionUser);
   const mySubsActive = isMySubscriptionsRoute(pathname);
-
-  const myProfileTarget = sessionUser ? `/@${sessionUser}/posts` : "";
+  const exploreActive =
+    allPostsActive || communitiesActive || myFriendsActive || mySubsActive;
   const myProfileActive = Boolean(
     sessionUser && isOwnProfileArea(pathname, sessionUser)
   );
 
-  const walletHref = sessionUser
-    ? `${walletBase}/@${sessionUser}`
-    : walletBase;
+  // Route-driven expansion: the group containing the current route is
+  // expanded; clicking a group header records a manual override keyed to the
+  // current pathname, so the next navigation automatically reverts to
+  // route-driven behavior without an effect.
+  const routeGroup: "explore" | "profile" = myProfileActive
+    ? "profile"
+    : "explore";
+  const [manual, setManual] = useState<{
+    at: string;
+    group: "explore" | "profile" | null;
+  } | null>(null);
+  const expanded =
+    manual && manual.at === pathname ? manual.group : routeGroup;
+  const toggleGroup = (group: "explore" | "profile") =>
+    setManual({ at: pathname, group: expanded === group ? null : group });
+
+  const loginPrompt = () => dispatch(showLogin({}));
+
+  const profileSections = useMemo(
+    () =>
+      sessionUser
+        ? MY_PROFILE_SECTIONS.map(({ segment, label }) => ({
+            label,
+            href: profileSectionHref(sessionUser, segment),
+            active:
+              segment === "blog"
+                ? pathname === `/@${sessionUser}` ||
+                  pathname === `/@${sessionUser}/blog`
+                : pathname === profileSectionHref(sessionUser, segment),
+          }))
+        : [],
+    [sessionUser, pathname]
+  );
 
   return (
     <nav
       id="appNavigation"
-      className={cn(
-        "App__navigation flex flex-col gap-5",
-        compact ? "text-sm" : "text-sm md:text-base"
-      )}
+      className="App__navigation flex flex-col gap-5 text-sm"
       aria-label="Primary navigation"
     >
-      <section aria-labelledby="nav-explore-heading">
-        <div
-          id="nav-explore-heading"
-          className="mb-2 flex items-center gap-2 px-2 font-bold text-accent-foreground"
-        >
-          <CompassIcon className="size-[1.15rem] shrink-0" aria-hidden />
-          <span>Explore</span>
-        </div>
-        <ul className="flex flex-col gap-0.5">
-          <NavExploreItem
-            href="/trending"
-            label="All Posts"
-            icon={BookMarkedIcon}
-            active={allPostsActive}
-          />
-          <NavExploreItem
-            href="/communities"
-            label="Communities"
-            icon={Building2Icon}
-            active={communitiesActive}
-          />
-          {sessionUser ? (
-            <>
-              <NavExploreItem
-                href={`/@${sessionUser}/feed`}
-                label="My Friends"
-                icon={HeartIcon}
-                active={myFriendsActive}
-              />
-              <NavExploreItem
-                href="/trending/my"
-                label="My Subscriptions"
-                icon={ListOrderedIcon}
-                active={mySubsActive}
-              />
-            </>
-          ) : (
-            <>
-              <NavExploreItem
-                href=""
-                label="My Friends"
-                icon={HeartIcon}
-                active={false}
-                useLoginPrompt
-                onLoginPrompt={() => dispatch(showLogin({}))}
-              />
-              <NavExploreItem
-                href=""
-                label="My Subscriptions"
-                icon={ListOrderedIcon}
-                active={false}
-                useLoginPrompt
-                onLoginPrompt={() => dispatch(showLogin({}))}
-              />
-            </>
-          )}
-        </ul>
-      </section>
+      <NavGroup
+        label="Explore"
+        icon={CompassIcon}
+        active={exploreActive}
+        expanded={expanded === "explore"}
+        onToggle={() => toggleGroup("explore")}
+      >
+        <NavSubItem href="/trending" label="All Posts" active={allPostsActive} />
+        <NavSubItem
+          href="/communities"
+          label="Communities"
+          active={communitiesActive}
+        />
+        {sessionUser ? (
+          <>
+            <NavSubItem
+              href={`/@${sessionUser}/feed`}
+              label="My Friends"
+              active={myFriendsActive}
+            />
+            <NavSubItem
+              href="/trending/my"
+              label="My Subscriptions"
+              active={mySubsActive}
+            />
+          </>
+        ) : (
+          <>
+            <NavSubItem
+              href=""
+              label="My Friends"
+              active={false}
+              useLoginPrompt
+              onLoginPrompt={loginPrompt}
+            />
+            <NavSubItem
+              href=""
+              label="My Subscriptions"
+              active={false}
+              useLoginPrompt
+              onLoginPrompt={loginPrompt}
+            />
+          </>
+        )}
+      </NavGroup>
 
-      <section className="flex flex-col gap-1 border-t border-border pt-4">
-        <NavTopItem
-          href={myProfileTarget}
+      {sessionUser ? (
+        <NavGroup
           label="My Profile"
           icon={UserRoundIcon}
-          active={Boolean(sessionUser) && Boolean(myProfileActive)}
-          useLoginPrompt={!sessionUser}
-          onLoginPrompt={() => dispatch(showLogin({}))}
-        />
-        <NavTopItem
-          href={walletHref}
-          label="My Wallet"
-          icon={WalletIcon}
-          external
-        />
-      </section>
+          active={myProfileActive}
+          expanded={expanded === "profile"}
+          onToggle={() => toggleGroup("profile")}
+        >
+          {profileSections.map(({ href, label, active }) => (
+            <NavSubItem key={href} href={href} label={label} active={active} />
+          ))}
+        </NavGroup>
+      ) : (
+        <button
+          type="button"
+          onClick={loginPrompt}
+          className={pillClass(false, "font-bold")}
+        >
+          <UserRoundIcon className="size-[1.15rem] shrink-0" aria-hidden />
+          <span className="flex-1 text-left">My Profile</span>
+        </button>
+      )}
 
-      {profileUsername ? (
-        <section aria-labelledby="nav-account-heading" className="border-t border-border pt-4">
-          <p
-            id="nav-account-heading"
-            className="mb-2 px-2 font-bold text-foreground"
-          >
-            Account
-          </p>
-          <p className="mb-1 truncate px-2 text-xs text-muted-foreground">
-            @{profileUsername}
-          </p>
-          <ul className="flex flex-col gap-0.5">
-            {PROFILE_SECTIONS.map(({ segment, label }) => {
-              const href = profileSectionHref(profileUsername, segment);
-              const active = isProfileSectionActive(
-                pathname,
-                profileUsername,
-                segment
-              );
-              return (
-                <li key={segment}>
-                  <Link
-                    href={href}
-                    className={cn(
-                      "block rounded-md border-l-2 border-transparent px-2 py-[0.6rem] text-sm text-foreground transition-colors hover:bg-accent hover:text-accent-foreground",
-                      active &&
-                        "border-accent-foreground bg-accent font-semibold text-accent-foreground"
-                    )}
-                  >
-                    {label}
-                  </Link>
-                </li>
-              );
-            })}
-          </ul>
-        </section>
-      ) : null}
+      {sessionUser ? (
+        <a
+          href={`${walletBase}/@${sessionUser}`}
+          target="_blank"
+          rel="noreferrer"
+          className={pillClass(false, "font-bold")}
+        >
+          <WalletIcon className="size-[1.15rem] shrink-0" aria-hidden />
+          <span className="flex-1 text-left">My Wallet</span>
+        </a>
+      ) : (
+        <button type="button" onClick={loginPrompt} className={pillClass(false, "font-bold")}>
+          <WalletIcon className="size-[1.15rem] shrink-0" aria-hidden />
+          <span className="flex-1 text-left">My Wallet</span>
+        </button>
+      )}
     </nav>
   );
 }

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -33,7 +33,7 @@ function DropdownMenuContent({
   return (
     <MenuPrimitive.Portal>
       <MenuPrimitive.Positioner
-        className="isolate z-50 outline-none"
+        className="isolate z-[101] outline-none"
         align={align}
         alignOffset={alignOffset}
         side={side}
@@ -41,7 +41,7 @@ function DropdownMenuContent({
       >
         <MenuPrimitive.Popup
           data-slot="dropdown-menu-content"
-          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
+          className={cn("z-50 max-h-(--available-height) w-(--anchor-width) min-w-32 origin-(--transform-origin) overflow-x-hidden overflow-y-auto rounded-lg bg-popover p-1.5 text-popover-foreground shadow-md ring-1 ring-foreground/10 duration-100 outline-none data-[side=bottom]:slide-in-from-top-2 data-[side=inline-end]:slide-in-from-left-2 data-[side=inline-start]:slide-in-from-right-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-closed:animate-out data-closed:overflow-hidden data-closed:fade-out-0 data-closed:zoom-out-95", className )}
           {...props}
         />
       </MenuPrimitive.Positioner>
@@ -65,7 +65,7 @@ function DropdownMenuLabel({
       data-slot="dropdown-menu-label"
       data-inset={inset}
       className={cn(
-        "px-1.5 py-1 text-xs font-medium text-muted-foreground data-inset:pl-7",
+        "px-2.5 py-1.5 text-xs font-medium text-muted-foreground data-inset:pl-7",
         className
       )}
       {...props}
@@ -88,7 +88,7 @@ function DropdownMenuItem({
       data-inset={inset}
       data-variant={variant}
       className={cn(
-        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-1.5 py-1 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
+        "group/dropdown-menu-item relative flex cursor-default items-center gap-1.5 rounded-md px-2.5 py-2 text-sm outline-hidden select-none focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground data-inset:pl-7 data-[variant=destructive]:text-destructive data-[variant=destructive]:focus:bg-destructive/10 data-[variant=destructive]:focus:text-destructive dark:data-[variant=destructive]:focus:bg-destructive/20 data-disabled:pointer-events-none data-disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4 data-[variant=destructive]:*:[svg]:text-destructive",
         className
       )}
       {...props}


### PR DESCRIPTION
## Summary

Reworks the left sidebar into the legacy two-level navigation structure and fixes the header avatar dropdown, which crashed the whole page when opened.

### Sidebar (`PrimaryNavigation`)

Matches legacy `PrimaryNavigation.jsx`:

- **Level 1:** Explore / My Profile / My Wallet. Level-2 groups are collapsed by default; the group containing the current route auto-expands, and group headers toggle manually (override resets on navigation).
- **Explore:** All Posts, Communities, My Friends, My Subscriptions (login prompt when logged out).
- **My Profile:** Blog, Posts, Comments, Replies, Notifications, Subscriptions, Payouts. Feed (duplicate of My Friends) and Settings are removed from the sidebar.
- Removed the flat "Account" section (heading + `@username` + section list) that rendered for any viewed profile.
- Fixed "All Posts" staying highlighted on `/<sort>/my` (My Subscriptions).
- My Wallet prompts login when logged out (legacy behavior) instead of linking to the wallet home.

### Header avatar dropdown

- **Fix crash on open:** base-ui requires `Menu.GroupLabel` inside `Menu.Group`; the bare `DropdownMenuLabel` threw `MenuGroupContext is missing` and took the whole page down to the Next.js global-error screen ("This page couldn't load").
- Raise the dropdown positioner above the sticky header (`z-[101]`) and add `sideOffset` so the popup clears the header edge instead of sliding under it.
- Loosen item/label/container padding.
- Simplify the menu to Profile / Notifications / Wallet / Logout.

### Tests

- New `__tests__/components/HeaderAvatarMenu.test.tsx` renders the **real, unmocked** base-ui dropdown, clicks the avatar, and asserts the menu opens with the simplified items. It reproduces the `MenuGroupContext` crash on the old code. The pre-existing `Header.test.tsx` mocks the dropdown away, which is why the crash went unnoticed.

## Verification

- `pnpm test`: 179 passed
- `pnpm lint`: clean on touched files
- Manual check on a production build (`pnpm build && pnpm start`): logged-out `/trending` expands Explore with login prompts; logged-in My Profile expands its sub-items with correct active states; other users' profiles no longer show the Account section; avatar menu opens above the header with the four items working.