### PR TITLE
fix(ui): profile page parity, dotted-username 404s, sidebar context

### DIFF
--- a/__tests__/components/PrimaryNavigation.test.tsx
+++ b/__tests__/components/PrimaryNavigation.test.tsx
@@ -1,0 +1,113 @@
+import { configureStore } from '@reduxjs/toolkit';
+import { cleanup, render, screen } from '@testing-library/react';
+import { Provider } from 'react-redux';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import userReducer, { setUser } from '@/store/slices/userSlice';
+import { PrimaryNavigation } from '@/components/layout/PrimaryNavigation';
+
+afterEach(cleanup);
+
+function makeStore(loggedIn = true) {
+  const store = configureStore({ reducer: { user: userReducer } });
+  if (loggedIn) {
+    store.dispatch(setUser({ username: 'alice', posting_authority: true }));
+  }
+  return store;
+}
+
+function renderNav(pathname: string, loggedIn = true) {
+  return render(
+    <Provider store={makeStore(loggedIn)}>
+      <PrimaryNavigation pathname={pathname} />
+    </Provider>
+  );
+}
+
+function itemByLabel(label: string): HTMLElement {
+  const el = screen.getByText(label).closest('a,button');
+  if (!el) throw new Error(`no link/button for ${label}`);
+  return el as HTMLElement;
+}
+
+const isActive = (el: HTMLElement) => el.className.includes('font-semibold');
+
+describe('PrimaryNavigation post-page context (legacy previousUrl)', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('highlights My Profile > Posts when arriving at a post from the own profile', () => {
+    window.localStorage.setItem('previousUrl', '/@alice/posts');
+    renderNav('/category/@alice/some-post');
+    expect(isActive(itemByLabel('Posts'))).toBe(true);
+    // Explore collapsed: its children are not rendered at all.
+    expect(screen.queryByText('All Posts')).toBeNull();
+    expect(screen.queryByText('Communities')).toBeNull();
+  });
+
+  it('falls back to Explore > All Posts on a direct post visit', () => {
+    renderNav('/category/@bob/some-post');
+    expect(isActive(itemByLabel('All Posts'))).toBe(true);
+    // Explore expanded.
+    expect(screen.getByText('Communities')).toBeTruthy();
+  });
+
+  it('resolves permlink-style post urls (/@user/permlink) as post routes', () => {
+    window.localStorage.setItem('previousUrl', '/trending');
+    renderNav('/@bob/some-post');
+    expect(isActive(itemByLabel('All Posts'))).toBe(true);
+  });
+
+  it('records non-post navigations as previousUrl', () => {
+    renderNav('/@alice/posts');
+    expect(window.localStorage.getItem('previousUrl')).toBe('/@alice/posts');
+  });
+
+  it('keeps route-driven state on non-post pages regardless of previousUrl', () => {
+    window.localStorage.setItem('previousUrl', '/@alice/posts');
+    renderNav('/trending');
+    expect(isActive(itemByLabel('All Posts'))).toBe(true);
+    expect(window.localStorage.getItem('previousUrl')).toBe('/trending');
+  });
+});
+
+describe('PrimaryNavigation profile group identity', () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it('labels the group "My Profile" on the own profile page', () => {
+    renderNav('/@alice/posts');
+    expect(screen.getByText('My Profile')).toBeTruthy();
+    expect(isActive(itemByLabel('Posts'))).toBe(true);
+    // Own group has no Friends Feed entry (it lives under Explore).
+    expect(screen.queryByText('Friends Feed')).toBeNull();
+  });
+
+  it('labels the group with the viewed username on other profiles (logged in)', () => {
+    renderNav('/@bob/comments');
+    expect(screen.getByText('@bob')).toBeTruthy();
+    expect(screen.queryByText('My Profile')).toBeNull();
+    expect(isActive(itemByLabel('Comments'))).toBe(true);
+    // Other users' groups expose Friends Feed (legacy "More" menu).
+    expect(screen.getByText('Friends Feed')).toBeTruthy();
+  });
+
+  it('shows the viewed profile group when logged out', () => {
+    renderNav('/@bob/posts', false);
+    expect(screen.getByText('@bob')).toBeTruthy();
+    expect(isActive(itemByLabel('Posts'))).toBe(true);
+  });
+
+  it('expands the viewed profile group on their feed page', () => {
+    renderNav('/@bob/feed', false);
+    expect(isActive(itemByLabel('Friends Feed'))).toBe(true);
+  });
+
+  it('keeps My Friends under Explore on the own feed page', () => {
+    renderNav('/@alice/feed');
+    expect(isActive(itemByLabel('My Friends'))).toBe(true);
+    expect(screen.getByText('My Profile')).toBeTruthy();
+  });
+});

--- a/app/(main)/user/[username]/UserRedirectClient.tsx
+++ b/app/(main)/user/[username]/UserRedirectClient.tsx
@@ -22,7 +22,7 @@ export default function UserRedirectClient() {
   }, [username, router]);
 
   return (
-    <FeedLayout>
+    <FeedLayout hideRightRail>
       <div className="flex flex-col items-center justify-center gap-2 py-12">
         <p className="text-muted-foreground">Loading...</p>
       </div>

--- a/app/(main)/user/[username]/[section]/UserSectionClient.tsx
+++ b/app/(main)/user/[username]/[section]/UserSectionClient.tsx
@@ -149,20 +149,32 @@ export default function UserSectionClient() {
     />
   );
 
-  // Show loading state if profile is still loading
+  // While the profile loads, the banner already renders (it falls back to
+  // the accountname) and post sections show the same skeleton cards as the
+  // feed pages instead of a bare loading label.
   if (profileLoading) {
+    const isPostsSection = ['blog', 'posts', 'comments', 'replies', 'payout', 'feed'].includes(section);
     return (
-      <FeedLayout>
-        <div className="flex flex-col items-center justify-center gap-2 py-12">
-          <p className="text-muted-foreground">Loading profile...</p>
-        </div>
+      <FeedLayout hideRightRail banner={profileHeader}>
+        {isPostsSection ? (
+          <PostsList
+            posts={[]}
+            loading
+            category={`@${accountname}`}
+            order={order}
+          />
+        ) : (
+          <div className="flex flex-col items-center justify-center gap-2 py-12">
+            <p className="text-muted-foreground">Loading profile...</p>
+          </div>
+        )}
       </FeedLayout>
     );
   }
 
   if (!profile) {
     return (
-      <FeedLayout>
+      <FeedLayout hideRightRail>
         <div className="flex flex-col items-center justify-center gap-2 py-12">
           <p className="text-destructive">User not found</p>
         </div>
@@ -174,7 +186,7 @@ export default function UserSectionClient() {
   if (section === 'settings') {
     if (!isMyAccount) {
       return (
-        <FeedLayout centerClassName="md:max-w-4xl">
+        <FeedLayout centerClassName="md:max-w-4xl" hideRightRail>
           <div className="rounded-lg border border-border bg-muted/50 p-4">
             <p className="text-foreground">
               You can only view your own settings.
@@ -185,8 +197,11 @@ export default function UserSectionClient() {
     }
 
     return (
-      <FeedLayout centerClassName="md:max-w-4xl">
-        {profileHeader}
+      <FeedLayout
+        centerClassName="md:max-w-4xl"
+        hideRightRail
+        banner={profileHeader}
+      >
         <div className="mt-8">
           <UserSettings 
             accountname={accountname} 
@@ -212,8 +227,11 @@ export default function UserSectionClient() {
   if (section === 'followers' || section === 'followed') {
     const followType = section === 'followers' ? 'followers' : 'following';
     return (
-      <FeedLayout centerClassName="md:max-w-4xl">
-        {profileHeader}
+      <FeedLayout
+        centerClassName="md:max-w-4xl"
+        hideRightRail
+        banner={profileHeader}
+      >
         <h3 className="mt-6 mb-4 text-lg font-bold text-foreground">
           {section === 'followers' ? 'Followers' : 'Following'}
         </h3>
@@ -232,8 +250,11 @@ export default function UserSectionClient() {
 
   if (section === 'notifications') {
     return (
-      <FeedLayout centerClassName="md:max-w-4xl lg:max-w-6xl">
-        {profileHeader}
+      <FeedLayout
+        centerClassName="md:max-w-4xl lg:max-w-6xl"
+        hideRightRail
+        banner={profileHeader}
+      >
         <NotificationsList username={accountname} />
       </FeedLayout>
     );
@@ -241,21 +262,27 @@ export default function UserSectionClient() {
 
   if (section === 'communities') {
     return (
-      <FeedLayout centerClassName="md:max-w-4xl lg:max-w-6xl">
-        {profileHeader}
+      <FeedLayout
+        centerClassName="md:max-w-4xl lg:max-w-6xl"
+        hideRightRail
+        banner={profileHeader}
+      >
         <CommunitiesList accountname={accountname} />
       </FeedLayout>
     );
   }
 
   return (
-    <FeedLayout>
-      {profileHeader}
-
+    <FeedLayout hideRightRail banner={profileHeader}>
       {loading && posts.length === 0 ? (
-        <div className="flex flex-col items-center justify-center gap-2 py-12">
-          <p className="text-muted-foreground">Loading posts...</p>
-        </div>
+        // Same skeleton placeholders as the feed pages (PostsList renders
+        // PostSummarySkeleton cards while the first page loads).
+        <PostsList
+          posts={[]}
+          loading
+          category={`@${accountname}`}
+          order={order}
+        />
       ) : posts.length === 0 ? (
         <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
           {emptySectionText(section, accountname, isMyAccount)}

--- a/app/globals.css
+++ b/app/globals.css
@@ -135,6 +135,9 @@
   }
   html {
     @apply font-sans;
+    /* Reserve the scrollbar gutter permanently so navigating between pages
+       with and without a scrollbar does not shift the layout horizontally. */
+    scrollbar-gutter: stable;
   }
 }
 /* Post-body rendering styles (ported from legacy markdown.scss /

--- a/components/layout/FeedLayout.tsx
+++ b/components/layout/FeedLayout.tsx
@@ -10,49 +10,67 @@ export function FeedLayout({
   children,
   className,
   centerClassName,
+  banner,
+  hideRightRail = false,
 }: {
   children: React.ReactNode;
   /** Optional class on the outer row (e.g. align with legacy full-width sections). */
   className?: string;
   /** Override center column max-width (default matches Legacy layout-list feed ~1056px; card grid used 664px). */
   centerClassName?: string;
+  /** Full-bleed content rendered above the columns (legacy UserProfile banner). */
+  banner?: React.ReactNode;
+  /** Render the right rail as an empty column (legacy profile pages: c-sidebar--right is an empty aside). */
+  hideRightRail?: boolean;
 }) {
   const pathname = usePathname();
 
   // Breakpoints follow legacy _layout.scss: M = 760px (left sidebar),
   // L = 1200px (right sidebar). Margins/padding are legacy 1em (16px).
   return (
-    <div
-      className={cn(
-        "mx-auto grid w-full max-w-[1600px] grid-cols-1 min-[760px]:grid-cols-[240px_minmax(0,1fr)] min-[1200px]:grid-cols-[240px_minmax(0,1fr)_320px]",
-        className
-      )}
-    >
-      {/* Column is 240px; width shrinks by the 1rem left margin so the
-          sidebar does not overflow into the center column (legacy 1em
-          margin was outside the float column, not inside a grid track). */}
-      <aside className="hidden min-[760px]:ml-4 min-[760px]:block min-[760px]:w-[calc(100%-1rem)]">
-        <div className="sticky top-20">
-          <PrimaryNavigation pathname={pathname} />
-        </div>
-      </aside>
-
-      <article
+    <div className="w-full">
+      {/* Full-bleed banner sits outside the max-width grid and reaches the
+          viewport edges; -mt-4 cancels AppShell's main top padding so it
+          stays flush with the header like legacy. */}
+      {banner ? <div className="-mt-4">{banner}</div> : null}
+      <div
         className={cn(
-          "min-w-0 w-full px-4",
-          centerClassName ?? "min-[760px]:max-w-[1056px]",
-          "mx-auto"
+          "mx-auto grid w-full max-w-[1600px] grid-cols-1 min-[760px]:grid-cols-[240px_minmax(0,1fr)] min-[1200px]:grid-cols-[240px_minmax(0,1fr)_320px]",
+          banner && "mt-4",
+          className
         )}
       >
-        {children}
-      </article>
+        {/* Column is 240px; width shrinks by the 1rem left margin so the
+            sidebar does not overflow into the center column (legacy 1em
+            margin was outside the float column, not inside a grid track). */}
+        <aside className="hidden min-[760px]:ml-4 min-[760px]:block min-[760px]:w-[calc(100%-1rem)]">
+          <div className="sticky top-20">
+            <PrimaryNavigation pathname={pathname} />
+          </div>
+        </aside>
 
-      {/* Legacy right rail is not sticky (modules fade in at page load). */}
-      <aside className="hidden min-[1200px]:mr-4 min-[1200px]:block min-[1200px]:w-[calc(100%-1rem)]">
-        <div className="py-1">
-          <FeedSidebarWidgets />
-        </div>
-      </aside>
+        <article
+          className={cn(
+            "min-w-0 w-full px-4",
+            centerClassName ?? "min-[760px]:max-w-[1056px]",
+            "mx-auto"
+          )}
+        >
+          {children}
+        </article>
+
+        {/* Legacy right rail is not sticky (modules fade in at page load).
+            Profile pages keep the column but render it empty (legacy
+            c-sidebar--right is an empty aside), so the center column stays
+            in the same place. */}
+        <aside className="hidden min-[1200px]:mr-4 min-[1200px]:block min-[1200px]:w-[calc(100%-1rem)]">
+          {!hideRightRail ? (
+            <div className="py-1">
+              <FeedSidebarWidgets />
+            </div>
+          ) : null}
+        </aside>
+      </div>
     </div>
   );
 }

--- a/components/layout/PrimaryNavigation.tsx
+++ b/components/layout/PrimaryNavigation.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import Link from "next/link";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   ChevronDownIcon,
   CompassIcon,
@@ -79,20 +79,84 @@ function isMySubscriptionsRoute(pathname: string) {
   return m[2].toLowerCase() === "my";
 }
 
-/** True when browsing the logged-in user's own profile sections. */
-function isOwnProfileArea(pathname: string, username: string) {
-  if (
-    pathname === `/@${username}/feed` ||
-    pathname.startsWith(`/@${username}/feed/`)
-  ) {
-    return false;
+/** Usernames that must not be treated as profile paths (aligned with proxy.ts). */
+const RESERVED_USERNAMES = new Set(
+  [
+    "trending",
+    "hot",
+    "created",
+    "payout",
+    "payout_comments",
+    "muted",
+    "login",
+    "search",
+    "submit",
+    "about",
+    "faq",
+    "privacy",
+    "support",
+    "tos",
+    "communities",
+    "tags",
+    "rewards",
+    "roles",
+    "welcome",
+    "api",
+    "_next",
+  ].map((s) => s.toLowerCase())
+);
+
+/**
+ * Parse the viewed profile username from profile-section URLs
+ * (/@user, /@user/blog, /@user/posts, …). Post URLs (/@user/permlink)
+ * return null because the permlink is not a known section.
+ */
+function parseViewedProfileUser(pathname: string): string | null {
+  const m = pathname.match(/^\/@([^/]+)(?:\/([^/]+))?\/?$/);
+  if (!m) return null;
+  const user = m[1];
+  if (RESERVED_USERNAMES.has(user.toLowerCase())) return null;
+  const seg = m[2];
+  if (!seg) return user;
+  return PROFILE_SECTION_SEGMENTS.has(seg.toLowerCase()) ? user : null;
+}
+
+function isProfileSectionActive(
+  pathname: string,
+  username: string,
+  segment: string
+) {
+  if (segment === "blog") {
+    return pathname === `/@${username}` || pathname === `/@${username}/blog`;
   }
-  if (pathname === `/@${username}` || pathname === `/@${username}/blog`) {
-    return true;
-  }
-  return MY_PROFILE_SECTIONS.some(
-    (s) => s.segment !== "blog" && pathname === profileSectionHref(username, s.segment)
-  );
+  return pathname === profileSectionHref(username, segment);
+}
+
+/** Profile URL segments that are sections, not permlinks (mirrors proxy.ts SECTIONS). */
+const PROFILE_SECTION_SEGMENTS = new Set([
+  "blog",
+  "posts",
+  "comments",
+  "replies",
+  "payout",
+  "feed",
+  "followers",
+  "followed",
+  "settings",
+  "notifications",
+  "communities",
+]);
+
+/** True for post detail URLs, with or without a category segment. */
+function isPostRoute(pathname: string): boolean {
+  // Internal rewrite targets, in case they are visited directly.
+  if (/^\/(post|post-no-category)\//.test(pathname)) return true;
+  // /category/@user/permlink
+  if (/^\/[^/]+\/@[^/]+\/[^/]+/.test(pathname)) return true;
+  // /@user/permlink (permlink is anything but a profile section)
+  const m = pathname.match(/^\/@[^/]+\/([^/]+)\/?$/);
+  if (m && !PROFILE_SECTION_SEGMENTS.has(m[1].toLowerCase())) return true;
+  return false;
 }
 
 type IconComponent = React.ComponentType<{ className?: string }>;
@@ -185,21 +249,73 @@ export function PrimaryNavigation({ pathname }: { pathname: string }) {
   const sessionUser = useAppSelector((s) => s.user.current?.username);
   const walletBase = getSteemitWalletBaseUrl();
 
-  const allPostsActive = isAllPostsExplore(pathname);
-  const communitiesActive = isCommunitiesRoute(pathname);
-  const myFriendsActive = isMyFriendsRoute(pathname, sessionUser);
-  const mySubsActive = isMySubscriptionsRoute(pathname);
+  // Legacy previousUrl semantics (PrimaryNavigation.jsx renderVisible): post
+  // pages carry no nav context of their own, so the sidebar inherits the
+  // referrer context stored in localStorage; every non-post page writes it.
+  const onPostRoute = isPostRoute(pathname);
+  const [postNavUrl, setPostNavUrl] = useState<string | null>(null);
+  useEffect(() => {
+    if (isPostRoute(pathname)) {
+      // eslint-disable-next-line react-hooks/set-state-in-effect -- syncs sidebar state with the localStorage referrer (external system)
+      setPostNavUrl(localStorage.getItem("previousUrl"));
+    } else {
+      localStorage.setItem("previousUrl", pathname);
+      setPostNavUrl(null);
+    }
+  }, [pathname]);
+
+  // The URL that drives all active/expanded state below.
+  const effectiveUrl = onPostRoute ? (postNavUrl ?? pathname) : pathname;
+
+  const allPostsMatched = isAllPostsExplore(effectiveUrl);
+  const communitiesActive = isCommunitiesRoute(effectiveUrl);
+  const myFriendsActive = isMyFriendsRoute(effectiveUrl, sessionUser);
+  const mySubsActive = isMySubscriptionsRoute(effectiveUrl);
+  // The profile group reflects the profile being viewed: "My Profile" when
+  // it is the logged-in user's own page (or when not on a profile page at
+  // all), otherwise the viewed "@username" — replacing legacy's separate
+  // other-profile tree.
+  const viewedUser = parseViewedProfileUser(effectiveUrl);
+  const isOwnProfile = Boolean(
+    sessionUser && viewedUser?.toLowerCase() === sessionUser.toLowerCase()
+  );
+  const profileGroupUser = viewedUser ?? sessionUser ?? null;
+
+  const profileSections = useMemo(() => {
+    if (!profileGroupUser) return [];
+    const user = profileGroupUser.toLowerCase();
+    // Other users' groups additionally expose Friends Feed (legacy "More"
+    // menu); one's own feed lives under Explore > My Friends instead.
+    const sections =
+      viewedUser && !isOwnProfile
+        ? [...MY_PROFILE_SECTIONS, { segment: "feed", label: "Friends Feed" }]
+        : MY_PROFILE_SECTIONS;
+    return sections.map(({ segment, label }) => ({
+      label,
+      href: profileSectionHref(user, segment),
+      active: isProfileSectionActive(effectiveUrl, user, segment),
+    }));
+  }, [profileGroupUser, viewedUser, isOwnProfile, effectiveUrl]);
+
+  const profileGroupActive = profileSections.some((s) => s.active);
+
+  // Legacy default state: on post pages whose referrer resolves to no nav
+  // item (including direct visits), highlight Explore > All Posts.
+  const nothingActive =
+    !allPostsMatched &&
+    !communitiesActive &&
+    !myFriendsActive &&
+    !mySubsActive &&
+    !profileGroupActive;
+  const allPostsActive = allPostsMatched || (onPostRoute && nothingActive);
   const exploreActive =
     allPostsActive || communitiesActive || myFriendsActive || mySubsActive;
-  const myProfileActive = Boolean(
-    sessionUser && isOwnProfileArea(pathname, sessionUser)
-  );
 
   // Route-driven expansion: the group containing the current route is
   // expanded; clicking a group header records a manual override keyed to the
   // current pathname, so the next navigation automatically reverts to
   // route-driven behavior without an effect.
-  const routeGroup: "explore" | "profile" = myProfileActive
+  const routeGroup: "explore" | "profile" = profileGroupActive
     ? "profile"
     : "explore";
   const [manual, setManual] = useState<{
@@ -212,22 +328,6 @@ export function PrimaryNavigation({ pathname }: { pathname: string }) {
     setManual({ at: pathname, group: expanded === group ? null : group });
 
   const loginPrompt = () => dispatch(showLogin({}));
-
-  const profileSections = useMemo(
-    () =>
-      sessionUser
-        ? MY_PROFILE_SECTIONS.map(({ segment, label }) => ({
-            label,
-            href: profileSectionHref(sessionUser, segment),
-            active:
-              segment === "blog"
-                ? pathname === `/@${sessionUser}` ||
-                  pathname === `/@${sessionUser}/blog`
-                : pathname === profileSectionHref(sessionUser, segment),
-          }))
-        : [],
-    [sessionUser, pathname]
-  );
 
   return (
     <nav
@@ -281,11 +381,11 @@ export function PrimaryNavigation({ pathname }: { pathname: string }) {
         )}
       </NavGroup>
 
-      {sessionUser ? (
+      {profileGroupUser ? (
         <NavGroup
-          label="My Profile"
+          label={viewedUser && !isOwnProfile ? `@${profileGroupUser}` : "My Profile"}
           icon={UserRoundIcon}
-          active={myProfileActive}
+          active={profileGroupActive}
           expanded={expanded === "profile"}
           onToggle={() => toggleGroup("profile")}
         >

--- a/proxy.ts
+++ b/proxy.ts
@@ -29,6 +29,11 @@ const SORT_TYPES = [
   'hot', 'trending', 'promoted', 'payout', 'payout_comments', 'muted', 'created'
 ];
 
+// Known static asset extensions served from public/ (or framework internals).
+// Anything else with a dot (usernames, permlinks) must continue routing.
+const STATIC_ASSET_RE =
+  /\.(ico|png|jpe?g|gif|svg|webp|avif|css|js|map|json|xml|txt|webmanifest|woff2?|ttf|eot|mp4|webm|pdf|html?)$/i;
+
 export function proxy(request: NextRequest) {
   // Get pathname and ensure it's decoded
   // Next.js should decode it automatically, but we handle %40 (@) encoding explicitly
@@ -44,13 +49,16 @@ export function proxy(request: NextRequest) {
     }
   }
 
-  // Skip API routes, static files, and the 404 page
+  // Skip API routes, static files, and the 404 page. Static files are
+  // detected by a known asset extension — NOT by any dot, because Steem
+  // usernames and permlinks may legitimately contain dots
+  // (e.g. /@ety001.test01, /@user/post-v1.2).
   if (
     pathname.startsWith('/api/') ||
     pathname.startsWith('/_next/') ||
     pathname.startsWith('/static/') ||
     pathname === '/404' ||
-    pathname.includes('.')
+    STATIC_ASSET_RE.test(pathname)
   ) {
     return NextResponse.next();
   }
@@ -59,9 +67,9 @@ export function proxy(request: NextRequest) {
   // (mirrors legacy ResolveRoute.js GDPRUserList checks): /@user,
   // /@user/<section|permlink|feed> and /category/@user/permlink.
   // A single guard covers all four families because the @-segment is always
-  // the first or second path segment in each of them. Note: usernames
-  // containing a dot (e.g. mateja.klaric) are skipped by the '.' guard above
-  // and 404 naturally via not-found — same net effect.
+  // the first or second path segment in each of them. Dotted usernames
+  // (e.g. mateja.klaric) reach this guard too — the static-asset check above
+  // only matches known file extensions.
   const gdprMatch = pathname.match(/^\/(?:[^\/]+\/)?@([^\/]+)/);
   if (gdprMatch && isGdprUser(gdprMatch[1])) {
     return NextResponse.rewrite(new URL('/404', request.url));

--- a/scripts/test-proxy-routes.ts
+++ b/scripts/test-proxy-routes.ts
@@ -71,7 +71,10 @@ const testCases = [
   { path: '/steem/@thedarkoverlord/my-post', expected: '404', description: 'GDPR user: post with category' },
   { path: '/@TheDarkOverlord', expected: '404', description: 'GDPR user: match is case-insensitive' },
   { path: '/@xondra/settings', expected: '404', description: 'GDPR user: settings section' },
-  { path: '/@mateja.klaric', expected: 'next', description: 'GDPR user with dot: skipped by "." guard (404s via not-found)' },
+  { path: '/@mateja.klaric', expected: '404', description: 'GDPR user with dot: caught by the GDPR guard directly' },
+  { path: '/@ety001.test01', expected: 'rewrite:/user/ety001.test01', description: 'Dotted non-GDPR username routes to profile' },
+  { path: '/@alice/post-v1.2', expected: 'rewrite:/post-no-category/alice/post-v1.2', description: 'Dotted permlink routes to post page' },
+  { path: '/file.svg', expected: 'next', description: 'Static public file passes through' },
   { path: '/@alice', expected: 'rewrite:/user/alice', description: 'Non-GDPR user unaffected' },
   { path: '/steem/@alice/my-post', expected: 'rewrite:/post/steem/alice/my-post', description: 'Non-GDPR user post unaffected' },
   


### PR DESCRIPTION
## Summary

Profile-page layout parity with legacy, a routing bug fix for dotted usernames, and sidebar context improvements.

### Routing (`proxy.ts`)

- **Dotted usernames/permlinks no longer 404.** The static-file guard skipped any path containing a dot, so accounts like `@ety001.test01` and permlinks like `post-v1.2` fell through to not-found. The guard now matches known asset extensions only (`svg|png|ico|html|…`). Dotted GDPR-listed users (e.g. `mateja.klaric`) are now caught by the GDPR guard itself instead of relying on the dot guard.

### Profile pages

- **Full-bleed banner above the columns**, flush with the header (legacy `UserProfile` structure), via a new `FeedLayout` `banner` slot.
- **Right rail renders as an empty column** on profile pages (legacy `c-sidebar--right` is an empty aside), so the center column stays exactly where feed pages put it — via `FeedLayout` `hideRightRail`.
- **Skeleton placeholders**: post sections show the same `PostSummarySkeleton` cards as feed pages while loading, and the banner renders immediately (accountname fallback) instead of a bare "Loading profile..." label.

### Sidebar (`PrimaryNavigation`)

- **The profile group reflects the viewed profile**: "My Profile" on one's own page (or non-profile pages), `@username` when viewing someone else — also when logged out. Other users' groups include a Friends Feed entry (legacy "More" menu); one's own feed stays under Explore > My Friends.
- **Post pages inherit referrer context** via `localStorage.previousUrl` (legacy `renderVisible`): arriving from `/@me/posts` highlights My Profile > Posts; direct visits fall back to Explore > All Posts. Non-post pages record themselves as `previousUrl`.

### Global

- `scrollbar-gutter: stable` on `<html>` — navigating between pages with and without scrollbars no longer shifts the layout horizontally.

## Tests

- `pnpm test:proxy`: 53 passing, incl. new cases for dotted usernames/permlinks/static files and the GDPR dotted user.
- `pnpm test`: 189 passing, incl. a new `PrimaryNavigation` suite (10 cases: post-page referrer context, profile group identity/expansion, own feed vs other feed).

## Verification

Production build served locally: `/@ety001.test01` and `/@ety001.test01/posts` return 200 (previously 404), GDPR users still 404, static files unaffected; logged-out view of `/@user/posts` shows the `@username` group with correct active states.