### PR TITLE
fix: legacy-style GA injection baked at build time + mobile nav fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,12 @@ FROM base AS builder
 # Copy source code
 COPY . .
 
+# GA id is baked into statically prerendered pages at build time (legacy
+# injects gtag into SSR HTML from runtime env; static pages can only see
+# build-time env). Dynamic pages additionally read the runtime env var.
+ARG SDC_GOOGLE_ANALYTICS_ID
+ENV SDC_GOOGLE_ANALYTICS_ID=${SDC_GOOGLE_ANALYTICS_ID}
+
 # Build the application
 RUN pnpm build
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,6 +1,5 @@
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Geist_Mono, Source_Sans_3 } from "next/font/google";
-import Script from "next/script";
 import "./globals.css";
 import { ReduxProvider } from "@/store/Provider";
 
@@ -14,9 +13,20 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
-// Google Analytics via gtag.js (legacy server-html.jsx). Disabled unless
-// SDC_GOOGLE_ANALYTICS_ID is set; legacy config defaulted it to false.
+// Google Analytics, injected exactly like legacy server-html.jsx: the id
+// comes from env (baked at build time for statically prerendered pages,
+// read at request time for dynamic ones) and the gtag scripts go straight
+// into the SSR HTML so the browser loads them at parse time — no
+// client-side injection and no hydration dependency.
 const gaId = process.env.SDC_GOOGLE_ANALYTICS_ID;
+
+// viewport-fit=cover is required for env(safe-area-inset-*) to take effect
+// on notched phones (the mobile bottom tab bar pads against it).
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
+  viewportFit: "cover",
+};
 
 export const metadata: Metadata = {
   title: "Condenser - Steemit Frontend",
@@ -69,18 +79,22 @@ export default function RootLayout({
           rel="stylesheet"
           href="https://fonts.googleapis.com/css?family=Source+Serif+Pro:400,600&display=swap"
         />
+        {/* GA, same as legacy server-html.jsx: plain script tags in the SSR
+            HTML (async gtag.js + inline dataLayer/config init). */}
         {gaId ? (
           <>
-            <Script
+            <script
+              async
               src={`https://www.googletagmanager.com/gtag/js?id=${gaId}`}
-              strategy="afterInteractive"
             />
-            <Script id="ga-gtag-init" strategy="afterInteractive">
-              {`window.dataLayer = window.dataLayer || [];
+            <script
+              dangerouslySetInnerHTML={{
+                __html: `window.dataLayer = window.dataLayer || [];
 function gtag(){dataLayer.push(arguments);}
 gtag('js', new Date());
-gtag('config', '${gaId}');`}
-            </Script>
+gtag('config', '${gaId}');`,
+              }}
+            />
           </>
         ) : null}
         <ReduxProvider>{children}</ReduxProvider>

--- a/components/cards/PostSummary.tsx
+++ b/components/cards/PostSummary.tsx
@@ -173,7 +173,7 @@ export default function PostSummary({ post, order }: PostSummaryProps) {
           <div className="articles__content-block articles__content-block--text min-w-0 flex-1">
             {/* legacy h2: 16px / line-clamp 3 on small screens,
                 15px / clamp 1 at ≥760px */}
-            <h2 className="articles__h2 line-clamp-3 text-[16px] font-bold leading-snug min-[760px]:truncate min-[760px]:text-[15px]">
+            <h2 className="articles__h2 line-clamp-3 text-[16px] font-bold leading-snug break-words min-[760px]:truncate min-[760px]:text-[15px]">
               {isNsfw && (
                 <span className="mr-1 rounded-[3px] border border-[#ff0264] px-[5px] py-[2px] align-middle font-[Arial] text-[75%] text-[#ff0264]">
                   nsfw
@@ -188,7 +188,7 @@ export default function PostSummary({ post, order }: PostSummaryProps) {
             </h2>
             {/* legacy PostSummary__body: the excerpt itself is a link */}
             {summary && (
-              <div className="PostSummary__body pb-[0.15rem] text-[0.9rem] leading-[1.4] text-foreground min-[760px]:truncate">
+              <div className="PostSummary__body pb-[0.15rem] text-[0.9rem] leading-[1.4] text-foreground break-words min-[760px]:truncate">
                 <Link prefetch={false}
                   href={postUrl}
                   className="block text-foreground min-[760px]:inline"

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -19,13 +19,13 @@ export function AppShell({ children }: { children: React.ReactNode }) {
   }, []);
 
   return (
-    <div className="flex min-h-screen flex-col bg-background text-foreground">
+    <div className="flex min-h-screen flex-col overflow-x-hidden bg-background text-foreground">
       <ThemeSync />
       <Analytics />
       <Header />
       <DegradationBanner />
       <GlobalModals />
-      <main className="flex flex-1 flex-col px-0 pb-[68px] pt-4 min-[760px]:pb-0">
+      <main className="flex flex-1 flex-col px-0 pb-[calc(68px+env(safe-area-inset-bottom))] pt-4 min-[760px]:pb-0">
         {children}
       </main>
       <MobileTabBar />

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -2,7 +2,7 @@
 
 import Link from "next/link";
 import { usePathname, useRouter } from "next/navigation";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { PenLineIcon, SearchIcon } from "lucide-react";
 import { useTranslations } from "next-intl";
 
@@ -17,6 +17,7 @@ import {
   DropdownMenuTrigger,
 } from "@/components/ui/dropdown-menu";
 import { getSteemitWalletBaseUrl } from "@/lib/steemitWallet";
+import { cn } from "@/lib/utils";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { showLogin } from "@/store/slices/userSlice";
 import { logoutThunk } from "@/store/thunks/authThunks";
@@ -119,6 +120,24 @@ export function Header() {
   const signupUrl =
     process.env.NEXT_PUBLIC_SIGNUP_URL ?? "https://signup.steemit.com";
 
+  // Hide the header when scrolling down past its height, reveal it again
+  // when scrolling up (mobile pattern; the transform is a no-op ≥760px).
+  const [headerHidden, setHeaderHidden] = useState(false);
+  useEffect(() => {
+    let lastY = window.scrollY;
+    const onScroll = () => {
+      const y = window.scrollY;
+      const delta = y - lastY;
+      // Ignore tiny jitter and the overscroll bounce at the top/bottom.
+      if (Math.abs(delta) > 5) {
+        setHeaderHidden(y > 64 && delta > 0);
+        lastY = y;
+      }
+    };
+    window.addEventListener("scroll", onScroll, { passive: true });
+    return () => window.removeEventListener("scroll", onScroll);
+  }, []);
+
   // legacy signup links carry a source tracker: #source=condenser|{routeTag}
   const routeTag = pathname?.split("/")[1] || "trending";
 
@@ -151,7 +170,12 @@ export function Header() {
   };
 
   return (
-    <header className="sticky top-0 z-[100] w-full border-b border-border bg-card shadow-[0_2px_4px_0_rgba(0,0,0,0.05)]">
+    <header
+      className={cn(
+        "sticky top-0 z-[100] w-full border-b border-border bg-card shadow-[0_2px_4px_0_rgba(0,0,0,0.05)] transition-transform duration-300",
+        headerHidden ? "-translate-y-full min-[760px]:translate-y-0" : "translate-y-0"
+      )}
+    >
       <nav className="mx-auto flex h-16 max-w-[100vw] items-center gap-2 px-3 sm:px-4">
         <div className="flex min-w-0 flex-1 items-center md:max-w-[40%] lg:max-w-[33%]">
           <Link

--- a/components/layout/MobileTabBar.tsx
+++ b/components/layout/MobileTabBar.tsx
@@ -12,6 +12,7 @@ import { cn } from "@/lib/utils";
  * Mobile bottom tab bar (legacy PrimaryNavigation on small screens):
  * fixed 60px bar with Explore / My Profile / My Wallet, icon above label,
  * active tab gets a teal bottom border. Visible only <760px.
+ * Always pinned to the bottom (unlike the header, it does not auto-hide).
  */
 export function MobileTabBar() {
   const pathname = usePathname();
@@ -61,7 +62,9 @@ export function MobileTabBar() {
       className="PrimaryNavigation fixed inset-x-0 bottom-0 z-[100] block min-[760px]:hidden"
       aria-label="Primary navigation"
     >
-      <ul className="PrimaryNavTabs flex justify-around border-t border-border bg-card">
+      {/* pb-[env(safe-area-inset-bottom)] lifts the bar above the phone's
+          home-indicator / gesture area, which otherwise covers the labels. */}
+      <ul className="PrimaryNavTabs flex justify-around border-t border-border bg-card pb-[env(safe-area-inset-bottom)]">
         {tabs.map((tab) => (
           <li key={tab.key} className="flex-1 text-center">
             <button

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -73,6 +73,13 @@ relay uses `STEEM_API_URL`. GA page views and route tags are recorded on every
 client-side navigation; `user_login` is reported server-side by
 `/api/auth/login`.
 
+GA (gtag.js) is inlined into the SSR HTML by the root layout, exactly like
+legacy `server-html.jsx` (async gtag.js + inline dataLayer/config init — the
+browser loads it at parse time, no hydration dependency). The id comes from
+`SDC_GOOGLE_ANALYTICS_ID`: statically prerendered pages bake it at Docker
+**build** time (the Dockerfile passes it as a build ARG into `pnpm build`),
+while dynamic pages read it from the runtime environment variable.
+
 ## Session Management
 
 The application supports two session storage modes:


### PR DESCRIPTION
## Summary

GA injection reworked to match legacy exactly, plus the mobile navigation fixes verified on the test environment.

### GA injection (legacy `server-html.jsx` parity)

- gtag.js is now emitted as plain `<script>` tags in the root layout SSR HTML (async gtag.js + inline `dataLayer`/`gtag('config')` init) — the browser loads it at parse time, no hydration dependency, same as legacy.
- Root cause fixed: `/trending`, `/communities`, `/login`, etc. are statically prerendered at build time, so a runtime env var never reached them. The Dockerfile now passes `SDC_GOOGLE_ANALYTICS_ID` as a build ARG into `pnpm build`, baking the id into static pages; dynamic pages keep reading the runtime env var.
- Removes the interim `/api/config` endpoint and client-side gtag injection (extra request, late load, hydration-dependent).
- Verified locally: built with `SDC_GOOGLE_ANALYTICS_ID=G-RBKQ87G4BF`, all 8 prerendered pages contain the gtag scripts; lint clean, 209 tests pass.

### Mobile nav fixes (user-verified on test env)

- Header auto-hides when scrolling down and reveals when scrolling up (mobile only; no-op ≥760px).
- Bottom tab bar pads against `env(safe-area-inset-bottom)` with `viewport-fit=cover` so it isn't clipped by the home-indicator area on notched phones.
- AppShell root clips horizontal overflow (fixed bottom nav rendering partially off-screen).
- PostSummary title/excerpt `break-words` so long words don't overflow the card.