### PR TITLE
fix(security): close open redirect via tag-route normalization 301s (F47 follow-up #2)

### DIFF
--- a/src/app/ResolveRoute.js
+++ b/src/app/ResolveRoute.js
@@ -11,7 +11,13 @@ const reg = pattern => {
             '<sort>',
             '(hot|trending|promoted|payout|payout_comments|muted|created)'
         )
-        .replace('<tag>', '([\\w\\W\\d-]{1,32})')
+        // <tag> must not admit path separators: a class like [\w\W] matches
+        // every char, letting `//evil.com/@a/b` pose as tag=/evil.com and
+        // reach the lowercase-normalization 301 (open redirect). Letters,
+        // digits, underscore, dot and hyphen cover every chain-legal tag
+        // (incl. hive-NNNNNN communities); case is kept on purpose so the
+        // 301 still normalizes /trending/HIVE-148441.
+        .replace('<tag>', '([\\w.-]{1,32})')
         .replace('<permlink>', '([\\w\\d-]+)')
         .replace('/', '\\/');
     return new RegExp('^\\/' + pattern + '$');

--- a/src/app/ResolveRoute.test.js
+++ b/src/app/ResolveRoute.test.js
@@ -11,13 +11,13 @@ describe('routeRegex', () => {
             ],
             [
                 'CategoryFilters',
-                /^\/(hot|trending|promoted|payout|payout_comments|muted|created)(?:\/([\w\W\d-]{1,32}))?\/?$/,
+                /^\/(hot|trending|promoted|payout|payout_comments|muted|created)(?:\/([\w.-]{1,32}))?\/?$/,
             ],
             ['PostNoCategory', /^\/(@[\w\.\d-]+)\/([\w\d-]+)$/],
-            ['Post', /^\/([\w\W\d-]{1,32})\/(@[\w\.\d-]+)\/([\w\d-]+)\/?$/],
+            ['Post', /^\/([\w.-]{1,32})\/(@[\w\.\d-]+)\/([\w\d-]+)\/?$/],
             [
                 'PostJson',
-                /^\/([\w\W\d-]{1,32})\/(@[\w\.\d-]+)\/([\w\d-]+)(\.json)$/,
+                /^\/([\w.-]{1,32})\/(@[\w\.\d-]+)\/([\w\d-]+)(\.json)$/,
             ],
             ['UserJson', /^\/(@[\w\.\d-]+)(\.json)$/],
         ];

--- a/src/server/__tests__/redirect.test.js
+++ b/src/server/__tests__/redirect.test.js
@@ -56,9 +56,35 @@ describe('isSafeRedirectTarget', () => {
         expect(isSafeRedirectTarget('/path?x=1#frag')).toBe(true);
         expect(isSafeRedirectTarget('/trending?next=%2Fhot')).toBe(true);
         // encoded slashes stay path content on this host — the browser
-        // never decodes them into an authority, so this is same-origin
+        // never decodes them into an authority, so this is same-origin.
+        // Intentional behavior: pinned here because WHATWG URL and the
+        // browser Location parser agree on it by spec.
         expect(isSafeRedirectTarget('/%2F%2Fevil.com')).toBe(true);
+        expect(isSafeRedirectTarget('/%2F%2Fevil.com/@a/b')).toBe(true);
         expect(isSafeRedirectTarget('/%5Cevil.com')).toBe(true);
+    });
+
+    it('rejects authority-override forms carrying full paths', () => {
+        // the payload shapes reported with the <tag> bypass: an
+        // authority spliced into the leading path segments
+        expect(isSafeRedirectTarget('/\\evil.com/@a/b')).toBe(false);
+        expect(isSafeRedirectTarget('//evil.com/@a/b')).toBe(false);
+        expect(isSafeRedirectTarget('/\\evil.com?x=1')).toBe(false);
+    });
+
+    it('keeps query and fragment content from changing the origin', () => {
+        // server.js validates the full lowercased URL (p), query and
+        // fragment included; '//-lookalikes' inside them are plain
+        // same-origin content, not an authority switch
+        expect(isSafeRedirectTarget('/trending/HIVE-148441?ref=//evil.com')).toBe(
+            true
+        );
+        expect(isSafeRedirectTarget('/trending/HIVE-148441#//evil.com')).toBe(
+            true
+        );
+        expect(
+            isSafeRedirectTarget('/hive-148441/@a/b?next=%2F%2Fevil.com#f')
+        ).toBe(true);
     });
 
     it('rejects non-string or empty inputs', () => {

--- a/src/server/__tests__/redirect.test.js
+++ b/src/server/__tests__/redirect.test.js
@@ -1,5 +1,6 @@
 /* global describe, it, expect */
 import isSafeRedirectTarget from '../utils/RedirectTarget';
+import { routeRegex } from '../../app/ResolveRoute';
 
 describe('isSafeRedirectTarget', () => {
     it('rejects protocol-relative targets', () => {
@@ -71,5 +72,36 @@ describe('isSafeRedirectTarget', () => {
         // it stays in the path on this origin
         expect(isSafeRedirectTarget('/%')).toBe(true);
         expect(isSafeRedirectTarget('%2F%2F')).toBe(false);
+    });
+
+    it('routeRegex does not swallow path separators into <tag>', () => {
+        // These previously matched Post with tag=/evil.com (the [\w\W]
+        // class matches every char), reached the lowercase-normalization
+        // 301 in server.js and redirected off-site once any uppercase
+        // char was present.
+        expect(routeRegex.Post.test('//evil.com/@a/b')).toBe(false);
+        expect(routeRegex.Post.test('/\\evil.com/@a/b')).toBe(false);
+        expect(routeRegex.Post.test('/\\/\\evil.com/@a/b')).toBe(false);
+        expect(routeRegex.PostJson.test('//evil.com/@a/b.json')).toBe(false);
+        expect(routeRegex.CategoryFilters.test('/trending//evil.com')).toBe(
+            false
+        );
+    });
+
+    it('routeRegex still matches legitimate tag routes', () => {
+        expect(routeRegex.Post.test('/hive-148441/@ety001/some-post')).toBe(
+            true
+        );
+        expect(routeRegex.Post.test('/photography/@ety001/some-post')).toBe(
+            true
+        );
+        // uppercase tags must keep matching so the 301 lowercase
+        // normalization in server.js still fires
+        expect(routeRegex.Post.test('/HIVE-148441/@a/B')).toBe(true);
+        expect(routeRegex.CategoryFilters.test('/trending/HIVE-148441')).toBe(
+            true
+        );
+        expect(routeRegex.CategoryFilters.test('/trending')).toBe(true);
+        expect(routeRegex.CommunityRoles.test('/roles/hive-123')).toBe(true);
     });
 });

--- a/src/server/app_render.jsx
+++ b/src/server/app_render.jsx
@@ -8,6 +8,7 @@ import secureRandom from 'secure-random';
 import ErrorPage from 'server/server-error';
 import { determineViewMode } from '../app/utils/Links';
 import { getSupportedLocales } from './utils/misc';
+import isSafeRedirectTarget from './utils/RedirectTarget';
 import {
     safeStartTimer,
     safeStopTimer,
@@ -147,7 +148,11 @@ async function appRender(ctx, locales = false, resolvedAssets = false) {
             ctx.session.uid
         );
 
-        if (redirectUrl) {
+        // Router-driven redirects are internal paths, but guard the exit
+        // anyway: if a future onEnter hook ever derives the target from
+        // request data, an unsafe target falls through to normal render
+        // instead of leaving the site.
+        if (redirectUrl && isSafeRedirectTarget(redirectUrl)) {
             console.log('Redirecting to', redirectUrl);
             ctx.status = 302;
             ctx.redirect(redirectUrl);
@@ -185,14 +190,20 @@ async function appRender(ctx, locales = false, resolvedAssets = false) {
         safeStopTimer(ctx.state.requestTimer, 'finalRender_ms');
     } catch (err) {
         // Render 500 error page from server
-        console.error('AppRender error', err, redirect);
+        // Destructure before logging: the old order referenced `redirect`
+        // inside console.error ahead of its const declaration (TDZ), so
+        // every caught error re-threw a ReferenceError and the router
+        // redirect/error handling below was unreachable.
         const { error, redirect } = err;
+        console.error('AppRender error', err, redirect);
         if (error) throw error;
 
         // Handle component `onEnter` transition
         if (redirect) {
             const { pathname, search } = redirect;
-            ctx.redirect(pathname + search);
+            if (isSafeRedirectTarget(pathname + search)) {
+                ctx.redirect(pathname + search);
+            }
         }
 
         throw err;

--- a/src/server/server.js
+++ b/src/server/server.js
@@ -213,7 +213,11 @@ app.use(function*(next) {
             this.status = 451;
             return;
         }
-        if (p !== this.originalUrl) {
+        // Guard the redirect exit, not just the route: a URL like
+        // `//evil.com/@a/B` used to match Post (tag swallowing the `/`),
+        // reach this 301 and send the browser to evil.com. Either the
+        // tightened <tag> regex or this guard blocks it independently.
+        if (p !== this.originalUrl && isSafeRedirectTarget(p)) {
             this.status = 301;
             this.redirect(p);
             return;
@@ -223,7 +227,7 @@ app.use(function*(next) {
     // normalize top category filtering from cased params
     if (this.method === 'GET' && routeRegex.CategoryFilters.test(this.url)) {
         const p = this.originalUrl.toLowerCase();
-        if (p !== this.originalUrl) {
+        if (p !== this.originalUrl && isSafeRedirectTarget(p)) {
             this.status = 301;
             this.redirect(p);
             return;

--- a/src/server/utils/RedirectTarget.js
+++ b/src/server/utils/RedirectTarget.js
@@ -40,6 +40,16 @@ const BASE_ORIGIN = new URL(BASE).origin;
  * comparing origins rejects every authority-override form while
  * accepting any rooted same-origin path (encoded characters such
  * as `/%2F%2Fevil.com` stay plain path content on this host).
+ *
+ * Parser contract: Node's WHATWG URL (imported from the `url` core
+ * module — global only from Node 10, engines declares >= 8.7.0)
+ * implements the same URL Standard browsers apply when resolving
+ * the Location header, so "origin === BASE_ORIGIN" here means the
+ * browser provably stays on this host. The unit tests pin that
+ * equivalence (backslash, encoded, control-char and query/fragment
+ * forms) so a future parser divergence or a runtime without a
+ * compliant URL fails loudly instead of silently re-opening the
+ * redirect.
  */
 export default function isSafeRedirectTarget(raw) {
     if (!raw || typeof raw !== 'string') return false;


### PR DESCRIPTION
## Summary

Second follow-up to the F47 open redirect finding, implementing the security team's proposed fix (all four points) plus one latent bug fix found during review.

## Root cause

PR #4008 guarded the `ch/cn/r` param-stripping redirect exit only. The two lowercase-normalization 301 blocks in `server.js` were unguarded, and the `<tag>` route token admitted path separators:

- `ResolveRoute.js` expanded `<tag>` to `([\w\W\d-]{1,32})` — `[\w\W]` matches **every** character, including `/` and `\`
- `GET //evil.com/@a/B` therefore matched `routeRegex.Post` with `tag=/evil.com`
- the user-normalization block lowercased it (`B`→`b`, so `p !== originalUrl`) and issued `301 Location: //evil.com/@a/b`
- the browser resolved that to `https://evil.com/@a/b` — open redirect
- `/\evil.com/@a/B` (backslash variant) worked identically

Verified against the actual regex construction before fixing:

| Input | before | after |
|---|---|---|
| `//evil.com/@a/B` (Post) | match → 301 off-site | no match |
| `/\evil.com/@a/B` (Post) | match → 301 off-site | no match |
| `/\/\evil.com/@a/B` (Post) | match | no match |
| `//evil.com/@a/b.json` (PostJson) | match | no match |
| `/hive-148441/@ety001/Some-Post` | match | match ✓ |
| `/trending/HIVE-148441` (CategoryFilters) | match | match ✓ (301 normalization preserved) |

## Changes (defense in depth — either layer blocks independently)

1. **`src/app/ResolveRoute.js`** — tighten `<tag>` to `([\w.-]{1,32})`; no path separators. Covers all chain-legal tags (`[a-z0-9-]`, `hive-NNNNNN`); uppercase kept on purpose so the lowercase 301 normalization still fires. Note this regex is shared with `resolveRoute()` (the actual router), so route behavior and the redirect gate stay consistent.
2. **`src/server/server.js`** — both normalization blocks now require `isSafeRedirectTarget(p)` (`server.js:216`-ish and `:227`-ish). Any future `<tag>`-style regex regression can no longer turn these 301s into exits.
3. **`src/server/app_render.jsx`** — the two router-driven `ctx.redirect` exits (`:153` redirectUrl, `:195` onEnter error path) guarded with `isSafeRedirectTarget`; unsafe targets fall through to normal render / rethrow instead of leaving the site.
4. **`src/server/app_render.jsx` TDZ fix** — `console.error('AppRender error', err, redirect)` referenced `redirect` before its `const` declaration, so every caught render error re-threw a `ReferenceError` and the redirect/error handling below it was dead code. Destructure reordered.
5. **Tests** — separator-swallowing regressions (Post/PostJson/CategoryFilters payloads), legitimate-tag positives (uppercase `hive-148441` normalization pinned), regex-pattern snapshot updated.

## Notes

- Behavior change: tag URLs with chars outside `[\w.-]` (non-ASCII, `%`, spaces) now 404 instead of rendering an empty listing — such tags are not chain-valid anyway.
- `redirects.js` keeps its deliberate external redirect (`/pick_account` → `https://signup.steemit.com`): hardcoded constant, no user input, intentionally **not** guarded — blanket-applying `isSafeRedirectTarget` there would break signup.
- eslint crashes (`Cannot read properties of null (reading 'range')`) on `server.js`/`app_render.jsx` and the 22 pre-existing lint errors in `ResolveRoute.test.js` are present on master unchanged — tooling debt, not introduced here.

## Test plan

- [x] `npx jest src/app/ResolveRoute.test.js src/server/__tests__/redirect.test.js` — 37/37
- [x] `npx jest` (full suite) — 197/197, 21 suites
- [x] eslint clean on `ResolveRoute.js`, `RedirectTarget.js`, `redirect.test.js`
- [x] Old-vs-new regex comparison table above run against real pattern construction