### PR TITLE
fix: force-dynamic rendering so GA reads runtime env (community-distributed images)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,12 +39,6 @@ FROM base AS builder
 # Copy source code
 COPY . .
 
-# GA id is baked into statically prerendered pages at build time (legacy
-# injects gtag into SSR HTML from runtime env; static pages can only see
-# build-time env). Dynamic pages additionally read the runtime env var.
-ARG SDC_GOOGLE_ANALYTICS_ID
-ENV SDC_GOOGLE_ANALYTICS_ID=${SDC_GOOGLE_ANALYTICS_ID}
-
 # Build the application
 RUN pnpm build
 

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -13,11 +13,15 @@ const geistMono = Geist_Mono({
   subsets: ["latin"],
 });
 
+// All routes render per-request (legacy parity): published images are
+// pulled by the community to run their own condenser, so environment
+// like SDC_GOOGLE_ANALYTICS_ID must never be baked into prerendered HTML.
+export const dynamic = "force-dynamic";
+
 // Google Analytics, injected exactly like legacy server-html.jsx: the id
-// comes from env (baked at build time for statically prerendered pages,
-// read at request time for dynamic ones) and the gtag scripts go straight
-// into the SSR HTML so the browser loads them at parse time — no
-// client-side injection and no hydration dependency.
+// comes from the runtime env and the gtag scripts go straight into the
+// SSR HTML so the browser loads them at parse time — no client-side
+// injection and no hydration dependency.
 const gaId = process.env.SDC_GOOGLE_ANALYTICS_ID;
 
 // viewport-fit=cover is required for env(safe-area-inset-*) to take effect

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -75,10 +75,11 @@ client-side navigation; `user_login` is reported server-side by
 
 GA (gtag.js) is inlined into the SSR HTML by the root layout, exactly like
 legacy `server-html.jsx` (async gtag.js + inline dataLayer/config init — the
-browser loads it at parse time, no hydration dependency). The id comes from
-`SDC_GOOGLE_ANALYTICS_ID`: statically prerendered pages bake it at Docker
-**build** time (the Dockerfile passes it as a build ARG into `pnpm build`),
-while dynamic pages read it from the runtime environment variable.
+browser loads it at parse time, no hydration dependency). All routes render
+per-request (`force-dynamic` in the root layout), so the id is always read
+from the runtime `SDC_GOOGLE_ANALYTICS_ID` — unset means no GA. This keeps
+published images environment-agnostic: the community runs the same images
+with their own env.
 
 ## Session Management
 


### PR DESCRIPTION
## Summary

Follow-up to #4010: drop the build-time GA baking and render all routes per-request, keeping published images environment-agnostic.

- **Why**: published images are pulled by the community to run their own condenser. A Steemit GA id baked into prerendered HTML would (a) report community sites' visitor data to Steemit's GA property and (b) shadow any GA id a community sets at runtime. Legacy read the id from runtime config on every request; this restores that model.
- Root layout sets `force-dynamic` — all routes render per-request (the previously static `/trending`, `/communities`, `/login`, `/search`, `/submit`, `/404` were shell-only pages whose data is client-fetched anyway, so the cost is ~5-20ms shell SSR per request).
- The `SDC_GOOGLE_ANALYTICS_ID` Docker build ARG is removed; unset env means no GA everywhere. One image runs in any environment.
- Verified: build without env → all routes dynamic, zero GA in artifacts; standalone server with env → gtag inlined in every page's SSR HTML; without env → pages render with no GA; lint clean, 209 tests pass.