### PR TITLE
feat: Coin Marketplace right-rail module + restore sticky left nav

### DIFF
--- a/app/api/steem/market/route.ts
+++ b/app/api/steem/market/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+
+/**
+ * Coin Marketplace data (legacy server/utils/SteemMarket.js): the legacy
+ * server polled an external market endpoint (STEEM_MARKET_ENDPOINT with a
+ * Token-auth header), cached it in-process with a 2h TTL, and injected it
+ * into every SSR render. Here the client fetches this route instead; the
+ * route does the same fetch+cache server-side. Unset endpoint means the
+ * module stays hidden (legacy stored empty data and SteemMarket rendered
+ * null).
+ */
+
+interface Timepoint {
+  price_usd: string | number;
+  timepoint: string;
+}
+
+interface Coin {
+  name: string;
+  symbol: string;
+  timepoints: Timepoint[];
+}
+
+interface MarketData {
+  steem?: Coin;
+  sbd?: Coin;
+  tron?: Coin;
+  jst?: Coin;
+  top_coins?: Coin[];
+}
+
+const TTL_MS = 2 * 60 * 60 * 1000; // legacy steem_market_cache.ttl: 7200
+
+let cache: { data: MarketData; at: number } | null = null;
+let inflight: Promise<MarketData> | null = null;
+
+async function fetchMarket(): Promise<MarketData> {
+  const endpoint = process.env.STEEM_MARKET_ENDPOINT;
+  if (!endpoint) return {};
+  const headers: Record<string, string> = {};
+  const token = process.env.STEEM_MARKET_TOKEN;
+  if (token) headers.Authorization = `Token ${token}`;
+  const res = await fetch(endpoint, {
+    headers,
+    signal: AbortSignal.timeout(10_000),
+  });
+  if (!res.ok) throw new Error(`market endpoint ${res.status}`);
+  return (await res.json()) as MarketData;
+}
+
+function getMarket(): Promise<MarketData> {
+  if (cache && Date.now() - cache.at < TTL_MS) return Promise.resolve(cache.data);
+  if (!inflight) {
+    inflight = fetchMarket()
+      .then((data) => {
+        cache = { data, at: Date.now() };
+        return data;
+      })
+      .catch((err) => {
+        // Serve stale past TTL rather than dropping the module; empty on
+        // the very first failure like legacy storeEmpty().
+        console.error("Steem market fetch failed:", err instanceof Error ? err.message : err);
+        return cache?.data ?? {};
+      })
+      .finally(() => {
+        inflight = null;
+      });
+  }
+  return inflight;
+}
+
+export async function GET() {
+  return NextResponse.json({ data: await getMarket() });
+}

--- a/components/elements/SteemMarket.tsx
+++ b/components/elements/SteemMarket.tsx
@@ -1,0 +1,212 @@
+"use client";
+
+import { useEffect, useState } from "react";
+
+import { useAppSelector } from "@/store/hooks";
+import { recordAdsView } from "@/lib/analytics/overseer";
+
+/**
+ * Coin Marketplace (legacy elements/SteemMarket.jsx): sparkline chart per
+ * coin in the right rail. Each chart is an ad slot — clicking through to
+ * poloniex reports recordAdsView with the page tag. Renders nothing while
+ * the market endpoint returns no data (legacy parity).
+ */
+
+interface Timepoint {
+  price_usd: string | number;
+  timepoint: string;
+}
+
+interface Coin {
+  name: string;
+  symbol: string;
+  timepoints: Timepoint[];
+}
+
+interface MarketData {
+  steem?: Coin;
+  sbd?: Coin;
+  tron?: Coin;
+  jst?: Coin;
+  top_coins?: Coin[];
+}
+
+/** Legacy Coin url switch: exchange pages on poloniex per symbol. */
+function exchangeUrl(symbol: string): string {
+  switch (symbol) {
+    case "STEEM":
+      return "https://poloniex.com/exchange#trx_steem";
+    case "BTC":
+      return "https://poloniex.com/exchange#usdt_btc";
+    case "ETH":
+      return "https://poloniex.com/exchange#usdt_eth";
+    case "TRX":
+      return "https://poloniex.com/exchange#usdt_trx";
+    case "JST":
+      return "https://poloniex.com/exchange#trx_jst";
+    default:
+      return "";
+  }
+}
+
+const STEEM_COLOR = "#09d6a8";
+const DEFAULT_COLOR = "#788187";
+const W = 120;
+const H = 30;
+
+function Sparkline({
+  prices,
+  color,
+  onHover,
+}: {
+  prices: number[];
+  color: string;
+  onHover?: (index: number | null) => void;
+}) {
+  const min = Math.min(...prices);
+  const max = Math.max(...prices);
+  const span = max - min || 1;
+  const points = prices.map((p, i) => {
+    const x = prices.length > 1 ? (i / (prices.length - 1)) * W : W / 2;
+    const y = H - 2 - ((p - min) / span) * (H - 4);
+    return { x, y };
+  });
+  const poly = points.map((p) => `${p.x.toFixed(1)},${p.y.toFixed(1)}`).join(" ");
+  return (
+    <svg
+      viewBox={`0 0 ${W} ${H}`}
+      preserveAspectRatio="none"
+      className="block h-[30px] w-full cursor-pointer"
+      onMouseLeave={() => onHover?.(null)}
+    >
+      <polyline
+        points={poly}
+        fill="none"
+        stroke={color}
+        strokeWidth={3}
+        vectorEffect="non-scaling-stroke"
+      />
+      {onHover &&
+        points.map((p, i) => (
+          <circle
+            key={i}
+            cx={p.x}
+            cy={p.y}
+            r={8}
+            fill="transparent"
+            onMouseEnter={() => onHover(i)}
+          />
+        ))}
+    </svg>
+  );
+}
+
+function CoinChart({
+  coin,
+  color,
+  trackingId,
+  page,
+}: {
+  coin: Coin;
+  color: string;
+  trackingId: string;
+  page: string;
+}) {
+  const [hover, setHover] = useState<number | null>(null);
+  // Legacy hides XEP via display:none in the Coin component.
+  if (coin.symbol === "XRP") return null;
+
+  const prices = coin.timepoints.map((p) => parseFloat(String(p.price_usd)));
+  if (prices.length === 0) return null;
+  const priceUsd = prices[prices.length - 1];
+  const url = exchangeUrl(coin.symbol);
+
+  let caption = "";
+  if (hover !== null && coin.timepoints[hover]) {
+    const point = coin.timepoints[hover];
+    const price = parseFloat(String(point.price_usd)).toFixed(2);
+    const time = new Date(point.timepoint).toLocaleString();
+    caption = `$${price} ${time}`;
+  }
+
+  const chart = (
+    <div className="chart">
+      <Sparkline
+        prices={prices}
+        color={color}
+        onHover={(i) => setHover(i)}
+      />
+      <div className="caption h-[1.2em] text-[0.75rem] text-muted-foreground">
+        {caption}
+      </div>
+    </div>
+  );
+
+  return (
+    <div className="coin mb-2 last:mb-0">
+      {url ? (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          onClick={() => recordAdsView({ trackingId, adTag: page })}
+        >
+          {chart}
+        </a>
+      ) : (
+        chart
+      )}
+      <div className="coin-label">
+        <span className="symbol font-bold text-foreground">{coin.symbol}</span>{" "}
+        <span className="price text-foreground">
+          {priceUsd.toFixed(coin.symbol === "JST" ? 3 : 2)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+export default function SteemMarket({ page }: { page: string }) {
+  const trackingId = useAppSelector((s) => s.user.trackingId);
+  const [data, setData] = useState<MarketData | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetch("/api/steem/market")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((json) => {
+        if (!cancelled && json?.data) setData(json.data as MarketData);
+      })
+      .catch(() => {});
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!data || !data.steem) return null;
+
+  // Legacy render order: steem, tron, jst, top_coins..., sbd.
+  const coins = [data.steem, data.tron, data.jst, ...(data.top_coins ?? []), data.sbd].filter(
+    (c): c is Coin => Boolean(c)
+  );
+  if (coins.length === 0) return null;
+
+  return (
+    <div className="c-sidebar__module mb-4 rounded-[6px] border border-border bg-card p-[1.5em]">
+      <div className="c-sidebar__header mb-2">
+        <h3 className="c-sidebar__h3 font-bold text-foreground">Coin Marketplace</h3>
+      </div>
+      <div className="c-sidebar__content">
+        {coins.map((coin) => (
+          <CoinChart
+            key={coin.symbol}
+            coin={coin}
+            color={coin.symbol === "STEEM" ? STEEM_COLOR : DEFAULT_COLOR}
+            trackingId={trackingId}
+            page={page}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -18,8 +18,11 @@ export function AppShell({ children }: { children: React.ReactNode }) {
     return () => window.removeEventListener("scroll", onScroll);
   }, []);
 
+  // overflow-x-clip (not hidden): hidden would turn this div into a scroll
+  // container and break position:sticky descendants (left nav, header);
+  // clip crops the same overflow without creating one.
   return (
-    <div className="flex min-h-screen flex-col overflow-x-hidden bg-background text-foreground">
+    <div className="flex min-h-screen flex-col overflow-x-clip bg-background text-foreground">
       <ThemeSync />
       <Analytics />
       <Header />

--- a/components/layout/FeedSidebarWidgets.tsx
+++ b/components/layout/FeedSidebarWidgets.tsx
@@ -12,6 +12,7 @@ import {
 import SubscribeButton from "@/components/elements/SubscribeButton";
 import AdSwipe from "@/components/elements/AdSwipe";
 import TronAd from "@/components/elements/TronAd";
+import SteemMarket from "@/components/elements/SteemMarket";
 import Announcement from "@/components/layout/Announcement";
 import { INDEX_LEFT_SIDE_AD_LIST, POST_LEFT_SIDE_AD_LIST, tronAdsConfig } from "@/lib/ads";
 
@@ -130,10 +131,10 @@ function CommunityPane({ community }: { community: string }) {
 }
 
 /**
- * Right rail modules (legacy PostsIndexLayout sidebar):
+ * Right rail modules (legacy PostsIndexLayout/Post.jsx sidebars):
  * community pane on community pages, then SidebarNewUsers (logged out) or
- * SidebarLinks (logged in). SteemMarket is not migrated — the new stack has
- * no market-data endpoint (legacy injects it server-side).
+ * SidebarLinks (logged in), then the Coin Marketplace (hidden unless
+ * STEEM_MARKET_ENDPOINT is configured), then ads last.
  */
 export function FeedSidebarWidgets() {
   const pathname = usePathname();
@@ -159,6 +160,17 @@ export function FeedSidebarWidgets() {
           of login state; community pages stay without it (legacy). */}
       {(isPostPage || !community) && <Announcement />}
       {username ? <SidebarLinks /> : <SidebarNewUsers />}
+      {/* Legacy ad tag: CoinMarketPlacePost on post pages, Index/Community
+          on feed pages depending on the community context. */}
+      <SteemMarket
+        page={
+          isPostPage
+            ? "CoinMarketPlacePost"
+            : community
+              ? "CoinMarketPlaceCommunity"
+              : "CoinMarketPlaceIndex"
+        }
+      />
       {/* Legacy PostsIndexLayout/Post right rail: ads are the LAST modules,
           rendered bare (no card chrome) so creatives fill the column. */}
       <div className="mb-4">

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -60,6 +60,10 @@ NEXT_PUBLIC_TRONADS_MOCK=0
 NEXT_PUBLIC_TRONADS_SIDEBAR_AD_PID=
 NEXT_PUBLIC_TRONADS_CONTENT_PC_AD_PID=
 NEXT_PUBLIC_TRONADS_CONTENT_MOBILE_AD_PID=
+# Coin Marketplace right-rail module (legacy steem_market_*). No endpoint
+# configured means the module stays hidden.
+STEEM_MARKET_ENDPOINT=
+STEEM_MARKET_TOKEN=
 ```
 
 ### Analytics (overseer)


### PR DESCRIPTION
## Summary

Restores the legacy Coin Marketplace module in the right rail and fixes the sticky left navigation that #4010's overflow fix accidentally broke.

### Coin Marketplace (legacy `elements/SteemMarket.jsx`)

- Per-coin sparkline charts (hand-written SVG polylines, no new dependency) in the right rail, legacy order STEEM/TRX/JST/top_coins/SBD, STEEM in brand teal, XRP hidden, JST 3-decimal prices.
- Hover a data point → `$price + time` caption; click-through to poloniex exchange pages reports `recordAdsView` with page tags `CoinMarketPlaceIndex`/`CoinMarketPlaceCommunity`/`CoinMarketPlacePost` (legacy ad-slot semantics).
- New route `/api/steem/market` replicates legacy `server/utils/SteemMarket.js`: server-side fetch of `STEEM_MARKET_ENDPOINT` (Token auth), 2h in-process TTL cache, stale-on-error fallback; unset endpoint keeps the module hidden (legacy default).
- Placed per legacy `PostsIndexLayout`/`Post.jsx`: after the links module, before the ad slots. `docs/CONFIGURATION.md` documents the two new env vars.

### Sticky left nav fix

- #4010 added `overflow-x-hidden` to the AppShell root to crop mobile horizontal overflow; that turns the div into a scroll container and disables every `position: sticky` descendant — the left nav's `sticky top-20` (equivalent of legacy's runtime `pin-top-padded`) and the header both scrolled away.
- Switched to `overflow-x-clip`, which crops the same overflow without creating a scroll container.

### Verification

- Headless-browser E2E against a local standalone build with a mock market endpoint: right rail renders 5 coins/5 sparklines/4 poloniex links; without the endpoint the module stays hidden; after scrolling 2500px the left nav holds at 80px and the header at 0; 375px viewport shows no horizontal scrollbar.
- Lint clean, 209 tests pass, production build passes.