### PR TITLE
feat: on-chain profile settings, notification mark-read, login challenge check

### DIFF
--- a/__tests__/api/auth/challenge.test.ts
+++ b/__tests__/api/auth/challenge.test.ts
@@ -1,38 +1,68 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 vi.mock('@/lib/auth/session', () => ({
+  COOKIE_NAME: 'steem-session',
   createSession: vi.fn(),
+  getSession: vi.fn(),
+  setSessionCookie: vi.fn(),
+  updateSession: vi.fn(),
 }));
 
 import { GET } from '@/app/api/auth/challenge/route';
-import { createSession } from '@/lib/auth/session';
+import { makeGetRequest } from '@/__tests__/helpers/request';
+import {
+  createSession,
+  getSession,
+  setSessionCookie,
+  updateSession,
+} from '@/lib/auth/session';
 
 const createSessionMock = vi.mocked(createSession);
+const getSessionMock = vi.mocked(getSession);
+const updateSessionMock = vi.mocked(updateSession);
+const setSessionCookieMock = vi.mocked(setSessionCookie);
 
 describe('GET /api/auth/challenge', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.spyOn(console, 'error').mockImplementation(() => {});
+    getSessionMock.mockResolvedValue(null);
+    createSessionMock.mockResolvedValue('session-token');
+    updateSessionMock.mockResolvedValue('updated-session-token');
   });
 
-  it('returns a 64-hex challenge and a session token', async () => {
-    createSessionMock.mockResolvedValue('session-token');
-
-    const res = await GET();
+  it('returns a 64-hex challenge, stores it in the session, and sets the cookie', async () => {
+    const res = await GET(makeGetRequest('/api/auth/challenge'));
     expect(res.status).toBe(200);
 
     const body = await res.json();
     expect(body.challenge).toMatch(/^[0-9a-f]{64}$/);
-    expect(body.sessionToken).toBe('session-token');
     expect(createSessionMock).toHaveBeenCalledWith({
       loginChallenge: body.challenge,
     });
+    // The cookie persists the challenge for the login route to verify.
+    expect(setSessionCookieMock).toHaveBeenCalledWith(res, 'session-token');
+  });
+
+  it('updates the existing session instead of minting a new one', async () => {
+    getSessionMock.mockResolvedValue({ uid: 'u1', loginChallenge: 'old' } as never);
+
+    const res = await GET(makeGetRequest('/api/auth/challenge'));
+    const body = await res.json();
+
+    expect(updateSessionMock).toHaveBeenCalledWith(
+      { uid: 'u1', loginChallenge: 'old' },
+      { loginChallenge: body.challenge },
+      undefined
+    );
+    expect(createSessionMock).not.toHaveBeenCalled();
+    expect(setSessionCookieMock).toHaveBeenCalledWith(res, 'updated-session-token');
   });
 
   it('returns 500 when session creation fails', async () => {
     createSessionMock.mockRejectedValue(new Error('redis down'));
 
-    const res = await GET();
+    const res = await GET(makeGetRequest('/api/auth/challenge'));
     expect(res.status).toBe(500);
     expect(await res.json()).toEqual({ error: 'Failed to generate challenge' });
   });

--- a/__tests__/api/auth/login.test.ts
+++ b/__tests__/api/auth/login.test.ts
@@ -58,6 +58,9 @@ describe('POST /api/auth/login', () => {
     vi.clearAllMocks();
     vi.spyOn(console, 'error').mockImplementation(() => {});
     verifySignatureMock.mockReturnValue(true);
+    // The challenge route stores the issued challenge in the session cookie;
+    // the login route verifies the signed challenge against it.
+    getSessionMock.mockResolvedValue({ loginChallenge: CHALLENGE } as never);
   });
 
   it('rejects bodies missing required fields', async () => {
@@ -96,12 +99,33 @@ describe('POST /api/auth/login', () => {
 
   it('returns 400 when the signed data does not match the request', async () => {
     getAccountMock.mockResolvedValue(accountWithPostingKey());
+    getSessionMock.mockResolvedValue({ loginChallenge: 'different' } as never);
 
     const res = await POST(
       makePostRequest('/api/auth/login', { ...validBody(), challenge: 'different' })
     );
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'Invalid authentication data' });
+  });
+
+  it('returns 400 when the challenge does not match the session', async () => {
+    getAccountMock.mockResolvedValue(accountWithPostingKey());
+    getSessionMock.mockResolvedValue({ loginChallenge: 'other-challenge' } as never);
+
+    const res = await POST(makePostRequest('/api/auth/login', validBody()));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Invalid or expired login challenge' });
+    expect(loginUserMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the session has no stored challenge', async () => {
+    getAccountMock.mockResolvedValue(accountWithPostingKey());
+    getSessionMock.mockResolvedValue(null);
+
+    const res = await POST(makePostRequest('/api/auth/login', validBody()));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Invalid or expired login challenge' });
+    expect(loginUserMock).not.toHaveBeenCalled();
   });
 
   it('returns 401 when the signature does not verify', async () => {
@@ -115,7 +139,7 @@ describe('POST /api/auth/login', () => {
 
   it('creates a session and sets the cookie on success', async () => {
     getAccountMock.mockResolvedValue(accountWithPostingKey());
-    getSessionMock.mockResolvedValue(null);
+    getSessionMock.mockResolvedValue({ loginChallenge: CHALLENGE } as never);
     loginUserMock.mockResolvedValue('new-session-token');
 
     const res = await POST(makePostRequest('/api/auth/login', validBody()));
@@ -124,7 +148,7 @@ describe('POST /api/auth/login', () => {
     const body = await res.json();
     expect(body.success).toBe(true);
     expect(body.user.username).toBe('alice');
-    expect(loginUserMock).toHaveBeenCalledWith(null, 'alice');
+    expect(loginUserMock).toHaveBeenCalledWith({ loginChallenge: CHALLENGE }, 'alice');
     expect(setSessionCookieMock).toHaveBeenCalledWith(res, 'new-session-token');
     // Legacy login_account checkpoint: sign-in is reported to overseer.
     expect(callSteemApiMock).toHaveBeenCalledWith('overseer.collect', [

--- a/__tests__/api/auth/login.test.ts
+++ b/__tests__/api/auth/login.test.ts
@@ -43,6 +43,7 @@ function validBody() {
     data: JSON.stringify({
       username: 'alice',
       challenge: CHALLENGE,
+      timestamp: Date.now(),
       action: 'login',
     }),
     challenge: CHALLENGE,
@@ -123,6 +124,24 @@ describe('POST /api/auth/login', () => {
     getSessionMock.mockResolvedValue(null);
 
     const res = await POST(makePostRequest('/api/auth/login', validBody()));
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: 'Invalid or expired login challenge' });
+    expect(loginUserMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 when the signed timestamp is stale', async () => {
+    getAccountMock.mockResolvedValue(accountWithPostingKey());
+
+    const staleBody = {
+      ...validBody(),
+      data: JSON.stringify({
+        username: 'alice',
+        challenge: CHALLENGE,
+        timestamp: Date.now() - 10 * 60 * 1000, // 10 minutes old
+        action: 'login',
+      }),
+    };
+    const res = await POST(makePostRequest('/api/auth/login', staleBody));
     expect(res.status).toBe(400);
     expect(await res.json()).toEqual({ error: 'Invalid or expired login challenge' });
     expect(loginUserMock).not.toHaveBeenCalled();

--- a/__tests__/lib/crypto/account-update2.test.ts
+++ b/__tests__/lib/crypto/account-update2.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+
+import { serializeAccountUpdate2Transaction } from '@/lib/crypto/transaction-signer';
+
+/**
+ * Golden byte-level compatibility test: the hand-rolled account_update2
+ * serializer must produce exactly the bytes the legacy steem-js 0.7
+ * serializer emits (the format production condenser has always used).
+ * Golden hex generated from condenser-legacy's operations.js.
+ */
+describe('serializeAccountUpdate2Transaction', () => {
+  it('matches the legacy steem-js 0.7 wire format byte-for-byte', () => {
+    const buf = serializeAccountUpdate2Transaction(
+      {
+        ref_block_num: 12345,
+        ref_block_prefix: 67890,
+        expiration: '2026-09-04T00:00:00',
+      },
+      {
+        account: 'alice',
+        json_metadata: '',
+        posting_json_metadata: JSON.stringify({
+          profile: { name: 'Alice', version: 2 },
+        }),
+      }
+    );
+
+    expect(buf.toString('hex')).toBe(
+      '393032090100000a9a6a012b05616c696365000000000028' +
+        '7b2270726f66696c65223a7b226e616d65223a22416c696365222c2276657273696f6e223a327d7d' +
+        '0000'
+    );
+  });
+
+  it('marks owner/active/posting/memo_key absent (0x00 flags)', () => {
+    const buf = serializeAccountUpdate2Transaction(
+      { ref_block_num: 1, ref_block_prefix: 2, expiration: '2026-09-04T00:00:00' },
+      { account: 'bob', json_metadata: '', posting_json_metadata: '{}' }
+    );
+    const hex = buf.toString('hex');
+    // 2B num + 4B prefix + 4B time + 01 op count + 2b op index +
+    // 03 'bob' + 0000 0000 (owner/active/posting/memo_key absent) + ...
+    expect(hex).toContain('2b03626f6200000000');
+  });
+});

--- a/app/(main)/user/[username]/[section]/UserSectionClient.tsx
+++ b/app/(main)/user/[username]/[section]/UserSectionClient.tsx
@@ -206,7 +206,6 @@ export default function UserSectionClient() {
           <UserSettings 
             accountname={accountname} 
             profile={profile?.metadata?.profile || null}
-            metadata={(profile?.metadata as Record<string, unknown>) ?? null}
             onProfileUpdate={(updatedProfile) => {
               // Update local profile state
               if (profile) {

--- a/app/(main)/user/[username]/[section]/UserSectionClient.tsx
+++ b/app/(main)/user/[username]/[section]/UserSectionClient.tsx
@@ -206,6 +206,7 @@ export default function UserSectionClient() {
           <UserSettings 
             accountname={accountname} 
             profile={profile?.metadata?.profile || null}
+            metadata={(profile?.metadata as Record<string, unknown>) ?? null}
             onProfileUpdate={(updatedProfile) => {
               // Update local profile state
               if (profile) {

--- a/app/api/auth/challenge/route.ts
+++ b/app/api/auth/challenge/route.ts
@@ -1,12 +1,20 @@
 /**
  * Auth API Route: Get Login Challenge
  * GET /api/auth/challenge
- * 
- * Returns a random challenge string for signature-based authentication
+ *
+ * Issues a random challenge for signature-based authentication and persists
+ * it in the session cookie so /api/auth/login can verify the signed
+ * challenge against it (legacy stores login_challenge in the koa session).
  */
 
-import { NextResponse } from 'next/server';
-import { createSession } from '@/lib/auth/session';
+import { NextRequest, NextResponse } from 'next/server';
+import {
+  COOKIE_NAME,
+  createSession,
+  getSession,
+  setSessionCookie,
+  updateSession,
+} from '@/lib/auth/session';
 
 /**
  * Generate a secure random challenge
@@ -17,20 +25,22 @@ function generateChallenge(): string {
   return Array.from(array, byte => byte.toString(16).padStart(2, '0')).join('');
 }
 
-export async function GET() {
+export async function GET(request: NextRequest) {
   try {
     const challenge = generateChallenge();
-    
-    // Create a temporary session with the challenge
-    // This will be used to verify the signature later
-    const sessionToken = await createSession({
-      loginChallenge: challenge,
-    });
 
-    return NextResponse.json({ 
-      challenge,
-      sessionToken, // Client needs this to maintain challenge context
-    });
+    const existing = await getSession(request);
+    const sessionToken = existing
+      ? await updateSession(
+          existing,
+          { loginChallenge: challenge },
+          request.cookies.get(COOKIE_NAME)?.value
+        )
+      : await createSession({ loginChallenge: challenge });
+
+    const response = NextResponse.json({ challenge });
+    setSessionCookie(response, sessionToken);
+    return response;
   } catch (error: unknown) {
     console.error('Error generating challenge:', error);
     return NextResponse.json(

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -60,10 +60,20 @@ export async function POST(request: NextRequest) {
       );
     }
 
-    // Step 3: Verify the challenge matches what we issued
-    // For now, we'll skip session-based challenge verification and just verify the signature
-    // In production, you'd want to verify the challenge came from our server
-    
+    // Step 3: Verify the challenge matches the one issued to this session
+    // (legacy general.js login_account verifies the signed challenge against
+    // session login_challenge — self-minted challenges are rejected).
+    const currentSession = await getSession(request);
+    if (
+      !currentSession?.loginChallenge ||
+      currentSession.loginChallenge !== challenge
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid or expired login challenge' },
+        { status: 400 }
+      );
+    }
+
     // Step 4: Parse and verify the signed data
     let authData;
     try {
@@ -92,7 +102,6 @@ export async function POST(request: NextRequest) {
     }
 
     // Step 6: Authentication successful, create session
-    const currentSession = await getSession(request);
     const sessionToken = await loginUser(currentSession, username);
     
     const response = NextResponse.json({

--- a/app/api/auth/login/route.ts
+++ b/app/api/auth/login/route.ts
@@ -93,6 +93,19 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Reject stale signatures: the client signs a millisecond timestamp
+    // (signAuthData) — accept a 5-minute window plus clock skew.
+    const signedAt = Number(authData.timestamp);
+    if (
+      !Number.isFinite(signedAt) ||
+      Math.abs(Date.now() - signedAt) > 5 * 60 * 1000
+    ) {
+      return NextResponse.json(
+        { error: 'Invalid or expired login challenge' },
+        { status: 400 }
+      );
+    }
+
     // Step 5: Verify the signature
     if (!steem.auth.verifySignature(data, signature, publicKey)) {
       return NextResponse.json(

--- a/app/api/steem/broadcast/route.ts
+++ b/app/api/steem/broadcast/route.ts
@@ -152,6 +152,12 @@ async function invalidateAfterBroadcast(operations: Array<[string, Record<string
         await cacheDeleteByPrefix('steem:profile:');
         break;
       }
+      case 'account_update2': {
+        // Profile settings save — the account's cached profile is stale.
+        const account = String(opData.account || '');
+        if (account) await cacheDeleteByPrefix(`steem:profile:${account}`);
+        break;
+      }
       default:
         // Other ops (transfer, witness, etc.) don't touch feed/profile caches.
         break;

--- a/app/api/steem/unread-notifications/route.ts
+++ b/app/api/steem/unread-notifications/route.ts
@@ -20,13 +20,14 @@ export async function GET(request: NextRequest) {
 
     const result = await getUnreadNotifications({ account });
 
-    // The bridge API returns unread notifications data
-    // Extract the count from the result
-    const unreadCount = result?.unread_count || 0;
+    // bridge.unread_notifications returns { lastread, unread } (legacy
+    // shape); map it onto the route's response fields.
+    const unreadCount = (result?.unread as number) ?? 0;
 
-    return NextResponse.json({ 
+    return NextResponse.json({
       account,
       unread_count: unreadCount,
+      lastread: (result?.lastread as string) ?? null,
       result: result || {},
     });
   } catch (error: unknown) {

--- a/components/cards/NotificationsList.tsx
+++ b/components/cards/NotificationsList.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect } from 'react';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import { receiveNotifications, receiveUnreadNotifications, notificationsLoading } from '@/store/slices/globalSlice';
 import { broadcastCustomJson } from '@/lib/api/broadcast';
+import { fetchUnreadNotificationsCount } from '@/lib/api/steem';
 import { cachedFetch } from '@/lib/cache/client-fetch';
 import LoadingIndicator from '@/components/elements/LoadingIndicator';
 import Userpic from '@/components/elements/Userpic';
@@ -84,19 +85,40 @@ export default function NotificationsList({ username }: NotificationsListProps) 
   const loading = useAppSelector((state) => state.global.notifications?.loading);
 
   const [filter, setFilter] = useState<FilterKey>('all');
+  const [markReadPending, setMarkReadPending] = useState(false);
+  const [markReadError, setMarkReadError] = useState('');
 
   // The slice stores untyped legacy items; this component owns the shape.
   const notifications = (notificationsState?.notifications ??
     []) as Notification[];
   const isLastPage = notificationsState?.isLastPage || false;
-  const unreadMap: Record<string, unknown> =
-    notificationsState?.unreadNotifications || {};
-  const unreadCount = Object.keys(unreadMap).length;
+  // Legacy store shape: unreadNotifications = { lastread, unread }.
+  const unreadState = (notificationsState?.unreadNotifications ?? {}) as {
+    lastread?: string;
+    unread?: number;
+  };
+  const unreadCount = Number(unreadState.unread ?? 0);
+  const lastRead = unreadState.lastread;
 
   // Load notifications on mount
   useEffect(() => {
     if (username) {
       loadNotifications(username);
+      // Legacy FetchDataSaga.getUnreadAccountNotificationsSaga: populate the
+      // unread state (lastread + count) so rows can show unread markers.
+      fetchUnreadNotificationsCount(username)
+        .then((res) => {
+          dispatch(
+            receiveUnreadNotifications({
+              name: username,
+              unreadNotifications: {
+                lastread: res.lastread ?? '',
+                unread: res.unread_count ?? 0,
+              },
+            })
+          );
+        })
+        .catch(() => {});
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [username]);
@@ -144,6 +166,12 @@ export default function NotificationsList({ username }: NotificationsListProps) 
     // a custom_json (id: 'notify') broadcast carrying setLastRead; hivemind
     // needs a few seconds to index it, so legacy clears the unread state
     // after a 6s delay.
+    if (markReadPending) return;
+    setMarkReadPending(true);
+    setMarkReadError('');
+    // Legacy naive format (no trailing Z): python-hivemind's VALID_DATE
+    // requires exactly this shape. NOTE: the Go hivemind rewrite parses with
+    // time.RFC3339 and rejects naive timestamps — cross-repo follow-up.
     const timeNow = new Date().toISOString().slice(0, 19);
     try {
       await broadcastCustomJson({
@@ -156,7 +184,7 @@ export default function NotificationsList({ username }: NotificationsListProps) 
         dispatch(
           receiveUnreadNotifications({
             name: username,
-            unreadNotifications: {},
+            unreadNotifications: { lastread: timeNow, unread: 0 },
           })
         );
         // The header badge polls on its own timer; tell it to zero now.
@@ -166,6 +194,9 @@ export default function NotificationsList({ username }: NotificationsListProps) 
       }, 6000);
     } catch (error) {
       console.error('Error marking notifications as read:', error);
+      setMarkReadError('Failed to mark notifications as read. Please try again.');
+    } finally {
+      setMarkReadPending(false);
     }
   };
 
@@ -210,10 +241,14 @@ export default function NotificationsList({ username }: NotificationsListProps) 
           <button
             type="button"
             onClick={handleMarkAsRead}
-            className="font-bold text-foreground hover:text-accent-foreground"
+            disabled={markReadPending}
+            className="font-bold text-foreground hover:text-accent-foreground disabled:opacity-50"
           >
-            Mark all as read
+            {markReadPending ? 'Marking...' : 'Mark all as read'}
           </button>
+          {markReadError && (
+            <p className="mt-1 text-sm text-destructive">{markReadError}</p>
+          )}
         </div>
       )}
 
@@ -230,7 +265,10 @@ export default function NotificationsList({ username }: NotificationsListProps) 
           {filteredNotifications.map((notification) => {
             const account = firstAccount(notification.msg || '');
             const TypeIcon = TYPE_ICONS[notification.type] || Bell;
-            const isUnread = Boolean(unreadMap[notification.id]);
+            // Legacy: a row is unread when its date is newer than lastread.
+            const isUnread = lastRead
+              ? Date.parse(`${lastRead}Z`) <= Date.parse(`${notification.date}Z`)
+              : false;
             const score = notification.score ?? 0;
             return (
               <div

--- a/components/cards/NotificationsList.tsx
+++ b/components/cards/NotificationsList.tsx
@@ -3,6 +3,7 @@
 import { useState, useEffect } from 'react';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import { receiveNotifications, receiveUnreadNotifications, notificationsLoading } from '@/store/slices/globalSlice';
+import { broadcastCustomJson } from '@/lib/api/broadcast';
 import { cachedFetch } from '@/lib/cache/client-fetch';
 import LoadingIndicator from '@/components/elements/LoadingIndicator';
 import Userpic from '@/components/elements/Userpic';
@@ -139,15 +140,30 @@ export default function NotificationsList({ username }: NotificationsListProps) 
   };
 
   const handleMarkAsRead = async () => {
+    // Legacy FetchDataSaga.markNotificationsAsReadSaga: the read marker is
+    // a custom_json (id: 'notify') broadcast carrying setLastRead; hivemind
+    // needs a few seconds to index it, so legacy clears the unread state
+    // after a 6s delay.
+    const timeNow = new Date().toISOString().slice(0, 19);
     try {
-      // TODO: Implement actual API call to mark notifications as read
-      // This requires broadcasting a custom_json operation
-      dispatch(
-        receiveUnreadNotifications({
-          name: username,
-          unreadNotifications: {},
-        })
-      );
+      await broadcastCustomJson({
+        requiredAuths: [],
+        requiredPostingAuths: [username],
+        id: 'notify',
+        json: JSON.stringify(['setLastRead', { date: timeNow }]),
+      });
+      setTimeout(() => {
+        dispatch(
+          receiveUnreadNotifications({
+            name: username,
+            unreadNotifications: {},
+          })
+        );
+        // The header badge polls on its own timer; tell it to zero now.
+        window.dispatchEvent(
+          new CustomEvent('notifications:marked-read', { detail: { username } })
+        );
+      }, 6000);
     } catch (error) {
       console.error('Error marking notifications as read:', error);
     }

--- a/components/elements/NotificationBadge.tsx
+++ b/components/elements/NotificationBadge.tsx
@@ -53,9 +53,21 @@ export default function NotificationBadge({
 
     fetchCount();
 
+    // Zero immediately when the user marks notifications as read (the list
+    // page broadcasts custom_json setLastRead and emits this event).
+    const onMarkedRead = (e: Event) => {
+      if ((e as CustomEvent).detail?.username === username) {
+        setUnreadCount(0);
+      }
+    };
+    window.addEventListener('notifications:marked-read', onMarkedRead);
+
     // Optionally refresh count periodically
     const interval = setInterval(fetchCount, 60000); // Refresh every minute
-    return () => clearInterval(interval);
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener('notifications:marked-read', onMarkedRead);
+    };
   }, [username]);
 
   // Don't render if loading or no username

--- a/components/modules/UserSettings.tsx
+++ b/components/modules/UserSettings.tsx
@@ -6,7 +6,35 @@ import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setLocale } from '@/store/slices/appSlice';
 import { LOCALES, LOCALE_LABELS, DEFAULT_LOCALE, isLocale, type Locale } from '@/lib/i18n/config';
 import { broadcastAccountUpdate } from '@/lib/api/broadcast';
+import { fetchAccount } from '@/lib/api/steem';
 import { userActionRecord } from '@/lib/analytics/overseer';
+
+/** Legacy o2j.ifStringParseJSON. */
+function ifStringParseJSON(value: unknown): unknown {
+  if (typeof value !== 'string') return value;
+  try {
+    return JSON.parse(value);
+  } catch {
+    return value;
+  }
+}
+
+/** Legacy Settings.jsx read_profile_v2: prefer posting_json_metadata when it
+ *  carries profile.version, else fall back to (possibly double-encoded,
+ *  issue #1237) json_metadata. */
+function readProfileV2(account: Record<string, unknown> | null): Record<string, unknown> {
+  if (!account) return {};
+  let md = ifStringParseJSON(account.posting_json_metadata);
+  if (md && typeof md === 'object') {
+    const profile = (md as Record<string, unknown>).profile;
+    if (profile && typeof profile === 'object' && (profile as Record<string, unknown>).version) {
+      return md as Record<string, unknown>;
+    }
+  }
+  md = ifStringParseJSON(account.json_metadata);
+  if (typeof md === 'string') md = ifStringParseJSON(md);
+  return md && typeof md === 'object' ? (md as Record<string, unknown>) : {};
+}
 
 interface UserProfile {
   name?: string;
@@ -21,9 +49,6 @@ interface UserProfile {
 interface UserSettingsProps {
   accountname: string;
   profile: UserProfile | null;
-  /** Full account metadata object (for merging on save, legacy
-   *  Settings.jsx merges into the account's existing metadata). */
-  metadata?: Record<string, unknown> | null;
   onProfileUpdate?: (profile: UserProfile) => void;
 }
 
@@ -35,7 +60,6 @@ interface UserSettingsProps {
 export default function UserSettings({ 
   accountname, 
   profile, 
-  metadata,
   onProfileUpdate 
 }: UserSettingsProps) {
   const currentUser = useAppSelector((state) => state.user.current?.username);
@@ -142,10 +166,13 @@ export default function UserSettings({
     setSuccessMessage('');
 
     try {
-      // Legacy Settings.jsx handleSubmit: merge into the account's existing
-      // metadata, drop legacy user_image and empty fields, mark profile
-      // version 2, then broadcast account_update2 (posting_json_metadata).
-      const metaData: Record<string, unknown> = { ...(metadata ?? {}) };
+      // Legacy Settings.jsx handleSubmit + read_profile_v2: merge into the
+      // RAW account metadata (bridge get_profile only returns the sanitized
+      // profile sub-object — merging into it would drop arbitrary top-level
+      // keys written by other apps), drop legacy user_image and empty
+      // fields, mark profile version 2, then broadcast account_update2.
+      const account = await fetchAccount(accountname);
+      const metaData: Record<string, unknown> = { ...readProfileV2(account) };
       delete metaData.user_image;
       const profileData: Record<string, unknown> = {
         ...((metaData.profile as Record<string, unknown>) ?? {}),
@@ -170,7 +197,7 @@ export default function UserSettings({
       setSuccessMessage('Profile updated successfully!');
 
       if (onProfileUpdate) {
-        onProfileUpdate(formData);
+        onProfileUpdate(profileData);
       }
     } catch (error) {
       console.error('Error updating profile:', error);

--- a/components/modules/UserSettings.tsx
+++ b/components/modules/UserSettings.tsx
@@ -5,6 +5,8 @@ import { useTranslations } from 'next-intl';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setLocale } from '@/store/slices/appSlice';
 import { LOCALES, LOCALE_LABELS, DEFAULT_LOCALE, isLocale, type Locale } from '@/lib/i18n/config';
+import { broadcastAccountUpdate } from '@/lib/api/broadcast';
+import { userActionRecord } from '@/lib/analytics/overseer';
 
 interface UserProfile {
   name?: string;
@@ -19,6 +21,9 @@ interface UserProfile {
 interface UserSettingsProps {
   accountname: string;
   profile: UserProfile | null;
+  /** Full account metadata object (for merging on save, legacy
+   *  Settings.jsx merges into the account's existing metadata). */
+  metadata?: Record<string, unknown> | null;
   onProfileUpdate?: (profile: UserProfile) => void;
 }
 
@@ -30,6 +35,7 @@ interface UserSettingsProps {
 export default function UserSettings({ 
   accountname, 
   profile, 
+  metadata,
   onProfileUpdate 
 }: UserSettingsProps) {
   const currentUser = useAppSelector((state) => state.user.current?.username);
@@ -136,15 +142,33 @@ export default function UserSettings({
     setSuccessMessage('');
 
     try {
-      // TODO: Implement actual profile update via blockchain
-      // This would involve creating a account_update operation
-      console.log('Updating profile:', formData);
+      // Legacy Settings.jsx handleSubmit: merge into the account's existing
+      // metadata, drop legacy user_image and empty fields, mark profile
+      // version 2, then broadcast account_update2 (posting_json_metadata).
+      const metaData: Record<string, unknown> = { ...(metadata ?? {}) };
+      delete metaData.user_image;
+      const profileData: Record<string, unknown> = {
+        ...((metaData.profile as Record<string, unknown>) ?? {}),
+      };
+      for (const field of ['profile_image', 'cover_image', 'name', 'about', 'location', 'website']) {
+        const value = formData[field];
+        if (value) profileData[field] = value;
+        else delete profileData[field];
+      }
+      profileData.version = 2;
+      metaData.profile = profileData;
 
-      // For now, simulate the update
-      await new Promise(resolve => setTimeout(resolve, 1000));
+      await broadcastAccountUpdate({
+        account: accountname,
+        jsonMetadata: '',
+        postingJsonMetadata: JSON.stringify(metaData),
+      });
+
+      // Legacy update_account tracking.
+      userActionRecord('update_account', { username: accountname });
 
       setSuccessMessage('Profile updated successfully!');
-      
+
       if (onProfileUpdate) {
         onProfileUpdate(formData);
       }

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -22,6 +22,8 @@ ADDRESS_PREFIX=STM
 ### Authentication
 ```bash
 JWT_SECRET=your-secret-key-change-in-production
+# NOTE: production deployments fail closed without a real JWT_SECRET
+# (session creation/verification throws) — the fallback secret is dev-only.
 ```
 
 ### Session Management - Redis (Optional)

--- a/lib/api/broadcast.ts
+++ b/lib/api/broadcast.ts
@@ -8,6 +8,7 @@ import {
   signVoteOperation,
   signCustomJsonOperation,
   signDeleteCommentOperation,
+  signAccountUpdate2Operation,
   SignedTransaction
 } from '@/lib/crypto/transaction-signer';
 import { getCachedKey, decryptAndRetrieveKey } from '@/lib/crypto/key-storage';
@@ -157,6 +158,28 @@ export async function broadcastDeleteComment(
   const signedTransaction = await signDeleteCommentOperation(privateKey, {
     author: params.author,
     permlink: params.permlink,
+  });
+
+  return broadcastSignedTransaction(signedTransaction);
+}
+
+/**
+ * Update account profile metadata (legacy Settings.jsx updateAccount):
+ * broadcasts account_update2 with the profile in posting_json_metadata.
+ */
+export async function broadcastAccountUpdate(
+  params: {
+    account: string;
+    jsonMetadata: string;
+    postingJsonMetadata: string;
+  }
+): Promise<{ success: boolean; result: unknown; transactionId?: string; permlink?: string }> {
+  const privateKey = await getPrivateKeyForSigning();
+
+  const signedTransaction = await signAccountUpdate2Operation(privateKey, {
+    account: params.account,
+    jsonMetadata: params.jsonMetadata,
+    postingJsonMetadata: params.postingJsonMetadata,
   });
 
   return broadcastSignedTransaction(signedTransaction);

--- a/lib/api/steem.ts
+++ b/lib/api/steem.ts
@@ -266,6 +266,22 @@ export async function fetchUserProfile(
   }
 }
 
+/** Raw condenser account (posting_json_metadata/json_metadata included).
+ *  Never cached — used on settings save to merge into fresh metadata. */
+export async function fetchAccount(username: string): Promise<Record<string, unknown> | null> {
+  const searchParams = new URLSearchParams({ username });
+  try {
+    const { data } = await cachedFetch<Record<string, unknown>>(
+      `/api/steem/account?${searchParams.toString()}`,
+      { ...SWR.profile, noStore: true }
+    );
+    return data;
+  } catch (error) {
+    console.error('Error fetching account:', error);
+    return null;
+  }
+}
+
 /**
  * Follower/Following item interface
  */
@@ -331,6 +347,8 @@ export async function fetchFollowing(
 export interface UnreadNotificationsResponse {
   account: string;
   unread_count: number;
+  /** bridge lastread timestamp ('YYYY-MM-DD HH:MM:SS'), for row-level unread. */
+  lastread?: string | null;
   result?: unknown;
   error?: string;
 }

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -8,9 +8,29 @@ import { SignJWT, jwtVerify } from 'jose';
 import { cookies } from 'next/headers';
 import * as RedisSession from './redis-session';
 
+const FALLBACK_JWT_SECRET = 'your-secret-key-change-in-production';
+
 const JWT_SECRET = new TextEncoder().encode(
-  process.env.JWT_SECRET || 'your-secret-key-change-in-production'
+  process.env.JWT_SECRET || FALLBACK_JWT_SECRET
 );
+
+/**
+ * Fail closed when a production deployment runs with the fallback JWT
+ * secret: anyone could mint session cookies (including a forged
+ * loginChallenge, defeating the login challenge check). Called by session
+ * creation/verification, not at module load, so static prerendering at
+ * build time (where env is absent) never trips it.
+ */
+function assertJwtSecretConfigured(): void {
+  if (
+    process.env.NODE_ENV === 'production' &&
+    (!process.env.JWT_SECRET || process.env.JWT_SECRET === FALLBACK_JWT_SECRET)
+  ) {
+    throw new Error(
+      'JWT_SECRET is not configured. Set a strong random JWT_SECRET for production deployments.'
+    );
+  }
+}
 
 export const COOKIE_NAME = 'steem-session';
 const COOKIE_OPTIONS = {
@@ -61,6 +81,7 @@ function generateLoginChallenge(): string {
  * Uses Redis if available, otherwise falls back to JWT
  */
 export async function createSession(data: Partial<SessionData> = {}): Promise<string> {
+  assertJwtSecretConfigured();
   const now = Math.floor(Date.now() / 1000);
   
   const sessionData: SessionData = {
@@ -99,6 +120,7 @@ export async function createSession(data: Partial<SessionData> = {}): Promise<st
  * Handles both Redis session IDs and JWT tokens
  */
 export async function verifySession(token: string): Promise<SessionData | null> {
+  assertJwtSecretConfigured();
   // Try Redis first (session IDs are typically shorter and hex-only)
   if (RedisSession.isRedisAvailable() && token.length <= 32 && /^[a-f0-9]+$/.test(token)) {
     const sessionData = await RedisSession.getSession(token);
@@ -238,8 +260,13 @@ export async function loginUser(
     },
   };
 
+  // The login challenge is single-use: never carry it into the session
+  // produced by a successful login (replay resistance).
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  const { loginChallenge, ...sessionWithoutChallenge } = sessionData;
+
   return createSession({
-    ...sessionData,
+    ...sessionWithoutChallenge,
     username,
   });
 }

--- a/lib/auth/session.ts
+++ b/lib/auth/session.ts
@@ -12,7 +12,7 @@ const JWT_SECRET = new TextEncoder().encode(
   process.env.JWT_SECRET || 'your-secret-key-change-in-production'
 );
 
-const COOKIE_NAME = 'steem-session';
+export const COOKIE_NAME = 'steem-session';
 const COOKIE_OPTIONS = {
   httpOnly: true,
   secure: process.env.NODE_ENV === 'production',

--- a/lib/crypto/transaction-signer.ts
+++ b/lib/crypto/transaction-signer.ts
@@ -290,3 +290,112 @@ export async function signDeleteCommentOperation(
     throw new Error(`Failed to create delete_comment operation: ${errorMessage}`);
   }
 }
+
+/**
+ * Create and sign an account_update2 operation (legacy Settings.jsx
+ * updateAccount). Only metadata is touched — the op carries no authority
+ * fields or memo_key.
+ *
+ * steem-js 1.x's serializeAccountUpdate2 unconditionally calls
+ * serializeAuthority on owner/active/posting (and requires memo_key), so
+ * metadata-only updates throw "Invalid authority" through
+ * steem.auth.signTransaction. We therefore serialize this op manually per
+ * the protocol wire format — verified byte-for-byte against the legacy
+ * steem-js 0.7 serializer (golden test in __tests__/lib/crypto):
+ *   account, owner/active/posting: optional<authority> (0x00 = absent),
+ *   memo_key: optional<public_key> (0x00), json_metadata /
+ *   posting_json_metadata: varint-len + utf8, extensions: empty set (0x00).
+ */
+
+/** Operation index of account_update2 in the protocol operation map. */
+const ACCOUNT_UPDATE2_OP_INDEX = 43;
+
+/** Unsigned LEB128 varint. */
+function varintBytes(n: number): number[] {
+  const out: number[] = [];
+  let v = n >>> 0;
+  do {
+    let b = v & 0x7f;
+    v = Math.floor(v / 128);
+    if (v) b |= 0x80;
+    out.push(b);
+  } while (v);
+  return out;
+}
+
+/** varint length prefix + utf8 bytes (protocol `string`). */
+function stringBytes(s: string): number[] {
+  const utf8 = Array.from(Buffer.from(s, 'utf8'));
+  return [...varintBytes(utf8.length), ...utf8];
+}
+
+/** Serialize a transaction carrying one metadata-only account_update2 op. */
+export function serializeAccountUpdate2Transaction(
+  header: { ref_block_num: number; ref_block_prefix: number; expiration: string },
+  op: { account: string; json_metadata: string; posting_json_metadata: string }
+): Buffer {
+  const bytes: number[] = [];
+  const pushU16 = (n: number) => bytes.push(n & 0xff, (n >> 8) & 0xff);
+  const pushU32 = (n: number) =>
+    bytes.push(n & 0xff, (n >> 8) & 0xff, (n >> 16) & 0xff, (n >> 24) & 0xff);
+
+  pushU16(header.ref_block_num);
+  pushU32(header.ref_block_prefix);
+  // time_point_sec: legacy appends "Z" when missing, then floor(ms/1000).
+  const exp = header.expiration.endsWith('Z')
+    ? header.expiration
+    : header.expiration + 'Z';
+  pushU32(Math.floor(new Date(exp).getTime() / 1000));
+
+  bytes.push(1); // one operation
+  bytes.push(ACCOUNT_UPDATE2_OP_INDEX);
+  bytes.push(...stringBytes(op.account));
+  bytes.push(0, 0, 0); // owner / active / posting absent
+  bytes.push(0); // memo_key absent
+  bytes.push(...stringBytes(op.json_metadata));
+  bytes.push(...stringBytes(op.posting_json_metadata));
+  bytes.push(0); // op extensions (empty set)
+  bytes.push(0); // transaction extensions
+  return Buffer.from(bytes);
+}
+
+export async function signAccountUpdate2Operation(
+  privateKeyWif: string,
+  params: {
+    account: string;
+    /** Cleared on save like legacy (profile lives in posting metadata). */
+    jsonMetadata: string;
+    /** The full metadata object as a JSON string (profile + version: 2). */
+    postingJsonMetadata: string;
+  }
+): Promise<SignedTransaction> {
+  try {
+    const header = await getTransactionHeader();
+
+    const opPayload = {
+      account: params.account,
+      json_metadata: params.jsonMetadata,
+      posting_json_metadata: params.postingJsonMetadata,
+      extensions: [],
+    };
+
+    // Hand-serialize + sign the digest directly (see the note above).
+    const serialized = serializeAccountUpdate2Transaction(header, opPayload);
+    const chainId = Buffer.from(
+      (steem.config.get('chain_id') as string) ?? '',
+      'hex'
+    );
+    const digest = Buffer.concat([chainId, serialized]);
+    const sig = steem.auth.Signature.signBuffer(digest, privateKeyWif);
+
+    return {
+      ...header,
+      operations: [['account_update2', opPayload]],
+      extensions: [],
+      signatures: [sig.toBuffer().toString('hex')],
+    };
+  } catch (error: unknown) {
+    const errorMessage = error instanceof Error ? error.message : 'Unknown error';
+    throw new Error(`Failed to create account_update2 operation: ${errorMessage}`);
+  }
+}


### PR DESCRIPTION
## Summary

Second-stage feature gaps, all matching legacy behavior.

### UserSettings saves on-chain (was a stub)

- Saves broadcast `account_update2` with the profile in `posting_json_metadata` (legacy `Settings.jsx`): merges into the account's existing metadata, drops empty fields and the legacy `user_image` key, marks `profile.version = 2`.
- **steem-js serializer workaround**: steem-js 1.x's `serializeAccountUpdate2` unconditionally requires `owner`/`active`/`posting` authority objects and a `memo_key`, throwing `Invalid authority` for metadata-only updates. The op is serialized manually per the protocol wire format (optional fields as absent flags) — **verified byte-for-byte against the legacy steem-js 0.7 serializer** in a golden test. Digest signing uses steem-js's `Signature.signBuffer` over `sha256(chain_id || serialized)`.
- Overseer `update_account` tracking wired on save.

### Notification mark-as-read (was a stub)

- "Mark all as read" broadcasts the legacy `custom_json` (`id: 'notify'`, `setLastRead` with the timestamp), clears Redux unread state after the 6s hivemind indexing delay, and zeroes the header badge immediately via a window event (the badge otherwise only polls every 60s).

### Login challenge verification (was skipped)

- `/api/auth/challenge` now persists the issued challenge in the session cookie (it previously created a session that was never sent to the client).
- `/api/auth/login` rejects signatures whose challenge doesn't match the session's stored challenge (legacy `login_account` behavior) — self-minted challenges no longer pass.

## Tests

- `challenge` route rewritten for the session-cookie behavior; `login` route gains challenge-mismatch and missing-challenge rejection cases; new `account_update2` golden byte test vs the legacy wire format.
- `pnpm test`: 234 passing. `pnpm lint`: 0 errors.
