### PR TITLE
feat(i18n): migrate long-tail hardcoded strings to next-intl

### DIFF
--- a/__tests__/components/PrimaryNavigation.test.tsx
+++ b/__tests__/components/PrimaryNavigation.test.tsx
@@ -4,6 +4,7 @@ import { Provider } from 'react-redux';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import userReducer, { setUser } from '@/store/slices/userSlice';
+import { IntlWrapper } from '@/__tests__/helpers/i18n';
 import { PrimaryNavigation } from '@/components/layout/PrimaryNavigation';
 
 afterEach(cleanup);
@@ -19,7 +20,9 @@ function makeStore(loggedIn = true) {
 function renderNav(pathname: string, loggedIn = true) {
   return render(
     <Provider store={makeStore(loggedIn)}>
-      <PrimaryNavigation pathname={pathname} />
+      <IntlWrapper>
+        <PrimaryNavigation pathname={pathname} />
+      </IntlWrapper>
     </Provider>
   );
 }

--- a/app/(main)/communities/page.tsx
+++ b/app/(main)/communities/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState, useCallback } from "react";
 import Link from "next/link";
 import { SearchIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 import { FeedLayout } from "@/components/layout/FeedLayout";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
@@ -16,9 +17,9 @@ import SubscribeButton from "@/components/elements/SubscribeButton";
 import { Skeleton } from "@/components/ui/skeleton";
 
 const SORT_OPTIONS = [
-  { value: "rank", label: "Rank" },
-  { value: "subs", label: "Subscribers" },
-  { value: "new", label: "New" },
+  { value: "rank", labelKey: "g.rank" },
+  { value: "subs", labelKey: "communities_jsx.subscribers" },
+  { value: "new", labelKey: "g.new" },
 ];
 
 /**
@@ -27,6 +28,7 @@ const SORT_OPTIONS = [
  */
 export default function CommunitiesPage() {
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const username = useAppSelector((s) => s.user.current?.username);
   const walletBase = getSteemitWalletBaseUrl();
 
@@ -83,13 +85,13 @@ export default function CommunitiesPage() {
               type="search"
               value={query}
               onChange={(e) => setQuery(e.target.value)}
-              placeholder="Search"
-              aria-label="Search communities"
+              placeholder={t("g.search")}
+              aria-label={t("communities_jsx.search_communities")}
               className="h-[42px] w-full rounded-full border border-[#06D6A9] bg-transparent pl-4 pr-10 text-[16px] text-foreground outline-none placeholder:text-muted-foreground"
             />
             <button
               type="submit"
-              aria-label="Submit search"
+              aria-label={t("g.submit_search")}
               className="absolute right-2 top-1/2 -translate-y-1/2 text-foreground"
             >
               <SearchIcon className="size-5" strokeWidth={1.2} />
@@ -103,7 +105,7 @@ export default function CommunitiesPage() {
                 rel="noopener noreferrer"
                 className="whitespace-nowrap text-sm text-accent-foreground"
               >
-                Create a community
+                {t("g.create_community")}
               </a>
             )}
             <select
@@ -112,12 +114,12 @@ export default function CommunitiesPage() {
                 setSort(e.target.value);
                 void performSearch(query, e.target.value);
               }}
-              aria-label="Sort communities"
+              aria-label={t("communities_jsx.sort_communities")}
               className="h-10 w-[300px] max-w-[33vw] cursor-pointer border border-input bg-card px-2 text-sm text-foreground"
             >
               {SORT_OPTIONS.map((o) => (
                 <option key={o.value} value={o.value}>
-                  {o.label}
+                  {t(o.labelKey)}
                 </option>
               ))}
             </select>
@@ -144,7 +146,7 @@ export default function CommunitiesPage() {
           </div>
         ) : communities.length === 0 ? (
           <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
-            Nothing was found.
+            {t("communities_jsx.nothing_found")}
           </div>
         ) : (
           <table className="mt-4 w-full">
@@ -166,8 +168,11 @@ export default function CommunitiesPage() {
                     <br />
                     <span className="text-foreground">{comm.about}</span>
                     <small className="block text-[#999]">
-                      {comm.subscribers} subscribers &bull; {comm.num_authors}{" "}
-                      posters &bull; {comm.num_pending} posts
+                      {t("communities_jsx.stats", {
+                        subscribers: comm.subscribers ?? 0,
+                        posters: comm.num_authors ?? 0,
+                        posts: comm.num_pending ?? 0,
+                      })}
                     </small>
                   </th>
                   <td className="w-px whitespace-nowrap py-2 text-right align-middle">

--- a/app/(main)/post/[category]/[username]/[permlink]/PostPageClient.tsx
+++ b/app/(main)/post/[category]/[username]/[permlink]/PostPageClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useParams } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setPathname } from '@/store/slices/globalSlice';
 import { normalizeUsername, formatUsername } from '@/lib/utils/username';
@@ -28,6 +29,7 @@ import { FeedLayout } from '@/components/layout/FeedLayout';
 export default function PostPageClient() {
   const params = useParams();
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const trackingId = useAppSelector((s) => s.user.trackingId);
   const category = params.category as string;
   const usernameRaw = params.username as string;
@@ -56,18 +58,18 @@ export default function PostPageClient() {
           const fetchedComments = await fetchCommentsByPermlink(username, permlink);
           setComments(fetchedComments);
         } else {
-          setError('Post not found');
+          setError(t('postfull_jsx.post_not_found'));
         }
       } catch (err) {
         console.error('Error fetching post or comments:', err);
-        setError('Failed to load post or comments');
+        setError(t('postfull_jsx.failed_to_load'));
       } finally {
         setLoading(false);
       }
     };
 
     loadData();
-  }, [category, username, permlink]);
+  }, [category, username, permlink, t]);
 
   // PostEditor already broadcast the reply; optimistically append a
   // synthesized comment built from the known author/permlink/body instead of
@@ -119,7 +121,7 @@ export default function PostPageClient() {
       );
     } catch (err) {
       console.error('Delete comment broadcast error:', err);
-      alert('Failed to delete the comment. Please try again.');
+      alert(t('comments.delete_failed'));
     }
   };
 
@@ -142,7 +144,7 @@ export default function PostPageClient() {
     return (
       <FeedLayout>
         <div className="flex flex-col items-center justify-center gap-2 py-12">
-          <p className="text-destructive">{error || "Post not found"}</p>
+          <p className="text-destructive">{error || t('postfull_jsx.post_not_found')}</p>
         </div>
       </FeedLayout>
     );
@@ -155,7 +157,7 @@ export default function PostPageClient() {
           and feed columns start at the same visual offset. */}
       <header className="mb-4 min-[760px]:mb-[10px] min-[760px]:pl-2">
         <nav
-          aria-label="Breadcrumb"
+          aria-label={t('navigation.breadcrumb')}
           className="flex h-10 items-center gap-2 text-sm text-muted-foreground"
         >
           <Link
@@ -166,7 +168,7 @@ export default function PostPageClient() {
           </Link>
           <span aria-hidden>/</span>
           <span className="min-w-0 truncate" aria-current="page">
-            {post.title || "Untitled"}
+            {post.title || t('g.untitled')}
           </span>
         </nav>
       </header>

--- a/app/(main)/roles/[tag]/page.tsx
+++ b/app/(main)/roles/[tag]/page.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "next/navigation";
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 import { useAppDispatch } from "@/store/hooks";
 import { setPathname } from "@/store/slices/globalSlice";
 import {
@@ -44,6 +45,7 @@ function CommunityMemberCard({
   title?: string | null;
   role?: string | null;
 }) {
+  const t = useTranslations();
   const initial = name?.charAt(0)?.toUpperCase() || "U";
 
   return (
@@ -83,7 +85,7 @@ function CommunityMemberCard({
           nativeButton={false}
           render={<Link href={`/@${name}`} />}
         >
-          View profile
+          {t("user_roles.view_profile")}
         </Button>
       </div>
     </Card>
@@ -92,6 +94,7 @@ function CommunityMemberCard({
 
 export default function CommunityRolesPage() {
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const params = useParams();
   const tag = (Array.isArray(params.tag) ? params.tag[0] : params.tag) ?? "";
   const [roles, setRoles] = useState<CommunityRole[]>([]);
@@ -129,7 +132,7 @@ export default function CommunityRolesPage() {
     return (
       <FeedLayout centerClassName="md:max-w-4xl lg:max-w-6xl">
         <div className="flex flex-col items-center justify-center gap-2 py-12">
-          <p className="text-muted-foreground">Loading community data...</p>
+          <p className="text-muted-foreground">{t("user_roles.loading_community_data")}</p>
         </div>
       </FeedLayout>
     );
@@ -139,7 +142,7 @@ export default function CommunityRolesPage() {
     <FeedLayout centerClassName="md:max-w-4xl lg:max-w-6xl">
       <div className="mb-6">
         <h1 className="mb-2 font-sans text-2xl font-bold text-foreground md:text-3xl">
-          Community Management
+          {t("user_roles.community_management")}
         </h1>
         <div className="flex flex-wrap items-center gap-2 text-muted-foreground">
           <Link
@@ -149,7 +152,7 @@ export default function CommunityRolesPage() {
             {tag}
           </Link>
           <span aria-hidden>/</span>
-          <span>Roles &amp; Members</span>
+          <span>{t("user_roles.roles_and_members")}</span>
         </div>
       </div>
 
@@ -164,7 +167,7 @@ export default function CommunityRolesPage() {
                 : "border-transparent text-muted-foreground hover:border-border hover:text-foreground"
             }`}
           >
-            Roles ({roles.length})
+            {t("g.roles")} ({roles.length})
           </button>
           <button
             type="button"
@@ -175,7 +178,7 @@ export default function CommunityRolesPage() {
                 : "border-transparent text-muted-foreground hover:border-border hover:text-foreground"
             }`}
           >
-            Subscribers ({subscribers.length})
+            {t("user_roles.subscribers")} ({subscribers.length})
           </button>
         </nav>
       </div>
@@ -185,7 +188,7 @@ export default function CommunityRolesPage() {
           {roles.length === 0 ? (
             <div className="rounded-lg border border-border bg-muted/40 p-8 text-center">
               <p className="text-muted-foreground">
-                No roles found for this community.
+                {t("user_roles.no_roles")}
               </p>
             </div>
           ) : (
@@ -207,7 +210,7 @@ export default function CommunityRolesPage() {
           {subscribers.length === 0 ? (
             <div className="rounded-lg border border-border bg-muted/40 p-8 text-center">
               <p className="text-muted-foreground">
-                No subscribers found for this community.
+                {t("user_roles.no_subscribers")}
               </p>
             </div>
           ) : (

--- a/app/(main)/search/SearchContent.tsx
+++ b/app/(main)/search/SearchContent.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useState } from "react";
 import { useSearchParams, useRouter } from "next/navigation";
+import { useTranslations } from "next-intl";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
 import { setPathname } from "@/store/slices/globalSlice";
 import {
@@ -42,6 +43,7 @@ export default function SearchContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   
   const query = searchParams.get('q') || '';
   const sortParam = searchParams.get('s') || 'created_at';
@@ -205,13 +207,13 @@ export default function SearchContent() {
             type="search"
             value={localQuery}
             onChange={(e) => setLocalQuery(e.target.value)}
-            placeholder="Search"
-            aria-label="Search"
+            placeholder={t("g.search")}
+            aria-label={t("g.search")}
             className="h-[42px] w-full border-none bg-transparent pr-10 text-[16px] text-foreground outline-none placeholder:text-muted-foreground"
           />
           <button
             type="submit"
-            aria-label="Submit search"
+            aria-label={t("g.submit_search")}
             className="absolute right-2 top-1/2 -translate-y-1/2 text-foreground"
           >
             <SearchIcon className="size-5" strokeWidth={1.2} />
@@ -225,9 +227,9 @@ export default function SearchContent() {
           <div className="mb-4 flex flex-wrap items-center gap-y-2 border-b border-border pb-2">
             <div className="flex items-center">
               {[
-                { value: 0, label: "Posts" },
-                { value: 1, label: "Comments" },
-                { value: 2, label: "Accounts" },
+                { value: 0, label: t("g.posts") },
+                { value: 1, label: t("g.comments") },
+                { value: 2, label: t("search_jsx.accounts") },
               ].map((tab) => (
                 <button
                   key={tab.value}
@@ -252,7 +254,7 @@ export default function SearchContent() {
                   htmlFor="search-sort"
                   className="text-sm text-muted-foreground"
                 >
-                  Sort by:
+                  {t("search_jsx.sort_by")}
                 </label>
                 <select
                   id="search-sort"
@@ -263,8 +265,8 @@ export default function SearchContent() {
                     "focus-visible:border-ring focus-visible:ring-2 focus-visible:ring-ring/50"
                   )}
                 >
-                  <option value="created_at">Newest</option>
-                  <option value="payout">Highest Payout</option>
+                  <option value="created_at">{t("search_jsx.newest")}</option>
+                  <option value="payout">{t("search_jsx.highest_payout")}</option>
                 </select>
               </div>
             )}
@@ -272,11 +274,11 @@ export default function SearchContent() {
 
           {searchState.pending && posts.length === 0 ? (
             <div className="flex flex-col items-center justify-center gap-2 py-12">
-              <p className="text-muted-foreground">Searching...</p>
+              <p className="text-muted-foreground">{t("search_jsx.searching")}</p>
             </div>
           ) : posts.length === 0 ? (
             <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
-              Nothing was found.
+              {t("search_jsx.nothing_found")}
             </div>
           ) : depth === 2 ? (
             <SearchUserList hits={hits} />
@@ -292,7 +294,7 @@ export default function SearchContent() {
         </>
       ) : (
         <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
-          Enter a search query above to find posts, comments, and accounts.
+          {t("search_jsx.enter_query_hint")}
         </div>
       )}
     </FeedLayout>

--- a/app/(main)/submit/page.tsx
+++ b/app/(main)/submit/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
+import { useTranslations } from 'next-intl';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setPathname } from '@/store/slices/globalSlice';
 import { showLogin } from '@/store/slices/userSlice';
@@ -16,6 +17,7 @@ import { FeedLayout } from '@/components/layout/FeedLayout';
 export default function SubmitPostPage() {
   const router = useRouter();
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const username = useAppSelector((state) => state.user.current?.username);
 
   useEffect(() => {
@@ -32,7 +34,7 @@ export default function SubmitPostPage() {
     return (
       <FeedLayout centerClassName="md:max-w-4xl">
         <div className="rounded-lg border border-border bg-muted/50 p-4">
-          <p className="text-foreground">Please log in to create a post.</p>
+          <p className="text-foreground">{t('submit_jsx.please_log_in')}</p>
         </div>
       </FeedLayout>
     );

--- a/app/(main)/user/[username]/[section]/UserSectionClient.tsx
+++ b/app/(main)/user/[username]/[section]/UserSectionClient.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from 'react';
 import { useParams } from 'next/navigation';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setPathname } from '@/store/slices/globalSlice';
 import {
@@ -34,6 +35,7 @@ import UserSettings from '@/components/modules/UserSettings';
 export default function UserSectionClient() {
   const params = useParams();
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const username = useAppSelector((state) => state.user.current?.username);
   
   const usernameRaw = params.username as string;
@@ -165,7 +167,7 @@ export default function UserSectionClient() {
           />
         ) : (
           <div className="flex flex-col items-center justify-center gap-2 py-12">
-            <p className="text-muted-foreground">Loading profile...</p>
+            <p className="text-muted-foreground">{t('user_profile.loading_profile')}</p>
           </div>
         )}
       </FeedLayout>
@@ -176,7 +178,7 @@ export default function UserSectionClient() {
     return (
       <FeedLayout hideRightRail>
         <div className="flex flex-col items-center justify-center gap-2 py-12">
-          <p className="text-destructive">User not found</p>
+          <p className="text-destructive">{t('user_profile.user_not_found')}</p>
         </div>
       </FeedLayout>
     );
@@ -189,7 +191,7 @@ export default function UserSectionClient() {
         <FeedLayout centerClassName="md:max-w-4xl" hideRightRail>
           <div className="rounded-lg border border-border bg-muted/50 p-4">
             <p className="text-foreground">
-              You can only view your own settings.
+              {t('user_profile.only_view_own_settings')}
             </p>
           </div>
         </FeedLayout>
@@ -233,7 +235,7 @@ export default function UserSectionClient() {
         banner={profileHeader}
       >
         <h3 className="mt-6 mb-4 text-lg font-bold text-foreground">
-          {section === 'followers' ? 'Followers' : 'Following'}
+          {section === 'followers' ? t('user_profile.followers') : t('user_profile.following')}
         </h3>
         <FollowList
           accountname={accountname}
@@ -285,7 +287,7 @@ export default function UserSectionClient() {
         />
       ) : posts.length === 0 ? (
         <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
-          {emptySectionText(section, accountname, isMyAccount)}
+          {emptySectionText(t, section, accountname, isMyAccount)}
         </div>
       ) : (
         <PostsList
@@ -302,27 +304,28 @@ export default function UserSectionClient() {
 
 /** Legacy UserProfile empty-state copy per section (UserProfile.jsx:23-69). */
 function emptySectionText(
+  t: ReturnType<typeof useTranslations>,
   section: string,
   accountname: string,
   isMyAccount: boolean
 ): React.ReactNode {
   switch (section) {
     case 'replies':
-      return `@${accountname} hasn't had any replies yet.`;
+      return t('user_profile.user_hasnt_had_any_replies_yet', { name: `@${accountname}` });
     case 'payout':
-      return 'No pending payouts.';
+      return t('user_profile.no_pending_payouts');
     case 'comments':
-      return `@${accountname} hasn't made any comments yet.`;
+      return t('user_profile.user_hasnt_made_any_comments_yet', { name: `@${accountname}` });
     case 'posts':
-      return `@${accountname} hasn't made any posts yet.`;
+      return t('user_profile.user_hasnt_made_any_posts_yet', { name: `@${accountname}` });
     case 'feed':
       // Legacy PostsIndex noFriendsText (empty home feed).
       return (
         <span className="flex flex-col items-center gap-2">
-          <span>You haven&apos;t followed anyone yet!</span>
+          <span>{t('user_profile.no_friends_feed')}</span>
           <span className="flex flex-wrap justify-center gap-3">
             <Link href="/trending" className="text-accent-foreground underline">
-              Explore Trending
+              {t('user_profile.explore_trending')}
             </Link>
             <a
               href="https://steemit.com/welcome"
@@ -330,7 +333,7 @@ function emptySectionText(
               rel="noopener noreferrer"
               className="text-accent-foreground underline"
             >
-              New users guide
+              {t('user_profile.new_users_guide')}
             </a>
           </span>
         </span>
@@ -341,16 +344,16 @@ function emptySectionText(
   if (isMyAccount) {
     return (
       <span className="flex flex-col items-center gap-2">
-        <span>You haven&apos;t posted anything yet.</span>
+        <span>{t('user_profile.looks_like_you_havent_posted_anything_yet')}</span>
         <span className="flex flex-wrap justify-center gap-3">
           <Link href="/communities" className="text-accent-foreground underline">
-            Explore Communities
+            {t('g.explore_communities')}
           </Link>
           <Link href="/submit" className="text-accent-foreground underline">
-            Create a post
+            {t('user_profile.create_a_post')}
           </Link>
           <Link href="/trending" className="text-accent-foreground underline">
-            Trending Articles
+            {t('user_profile.explore_trending_articles')}
           </Link>
           <a
             href="https://steemit.com/welcome"
@@ -358,12 +361,12 @@ function emptySectionText(
             rel="noopener noreferrer"
             className="text-accent-foreground underline"
           >
-            Welcome Guide
+            {t('g.welcome_guide')}
           </a>
         </span>
       </span>
     );
   }
-  return `@${accountname} hasn't posted anything yet.`;
+  return t('user_profile.user_hasnt_posted_anything_yet', { name: `@${accountname}` });
 }
 

--- a/components/NotFoundView.tsx
+++ b/components/NotFoundView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import Link from "next/link";
+import { useTranslations } from "next-intl";
 
 /** Legacy steem round icon (from SteemLogo), shown at 4x on the 404 page. */
 function SteemIcon() {
@@ -17,11 +18,11 @@ function SteemIcon() {
 }
 
 const MENU = [
-  { href: "/created", label: "new posts" },
-  { href: "/hot", label: "hot posts" },
-  { href: "/trending", label: "trending posts" },
-  { href: "/promoted", label: "promoted posts" },
-  { href: "/payout", label: "active posts" },
+  { href: "/created", labelKey: "notfound.menu_new_posts" },
+  { href: "/hot", labelKey: "notfound.menu_hot_posts" },
+  { href: "/trending", labelKey: "notfound.menu_trending_posts" },
+  { href: "/promoted", labelKey: "notfound.menu_promoted_posts" },
+  { href: "/payout", labelKey: "notfound.menu_active_posts" },
 ];
 
 /**
@@ -29,18 +30,19 @@ const MENU = [
  * pipe-separated feed links (pages/NotFound.jsx, app.scss .NotFound).
  */
 export function NotFoundView() {
+  const t = useTranslations();
   return (
     <div className="NotFound mx-auto mt-[2em] w-[340px] text-center min-[640px]:w-[640px]">
       <SteemIcon />
       <h4 className="mb-4 text-lg font-bold text-foreground">
-        Sorry! This page doesn&apos;t exist.
+        {t("notfound.title")}
       </h4>
       <p className="mb-4 text-foreground">
-        Not to worry. You can head back to{" "}
+        {t("notfound.head_back")}{" "}
         <Link href="/" className="font-bold text-accent-foreground">
-          our homepage
+          {t("notfound.our_homepage")}
         </Link>
-        , or check out some great posts below.
+        {t("notfound.or_check_posts")}
       </p>
       <ul className="NotFound__menu mt-[1em]">
         {MENU.map((item, i) => (
@@ -49,7 +51,7 @@ export function NotFoundView() {
               href={item.href}
               className="text-accent-foreground hover:underline"
             >
-              {item.label}
+              {t(item.labelKey)}
             </Link>
             {i < MENU.length - 1 && (
               <span className="text-muted-foreground">&nbsp;|</span>

--- a/components/cards/Comment.tsx
+++ b/components/cards/Comment.tsx
@@ -2,6 +2,7 @@
 
 import { useState } from 'react';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 import { useAppSelector } from '@/store/hooks';
 import MarkdownViewer from '@/components/elements/MarkdownViewer';
 import Voting from '@/components/elements/Voting';
@@ -56,6 +57,7 @@ export default function Comment({
   // legacy: gray comments render with the body hidden behind a reveal link
   const [revealGray, setRevealGray] = useState(false);
   const username = useAppSelector((state) => state.user.current?.username);
+  const t = useTranslations();
 
   const isMyComment = username === comment.author;
   const gray = Boolean(comment.stats?.gray) && !isMyComment;
@@ -67,7 +69,7 @@ export default function Comment({
   const commentUrl = `/${comment.category}/@${comment.author}/${comment.permlink}`;
 
   const handleDelete = () => {
-    if (onDelete && confirm('Are you sure you want to delete this comment?')) {
+    if (onDelete && confirm(t('comments.confirm_delete'))) {
       onDelete(comment.author, comment.permlink);
     }
   };
@@ -119,7 +121,7 @@ export default function Comment({
               type="button"
               onClick={() => setCollapsed(!collapsed)}
               className="float-right tracking-[0.1rem] text-muted-foreground hover:text-foreground"
-              title={collapsed ? 'Expand' : 'Collapse'}
+              title={collapsed ? t('comments.expand') : t('comments.collapse')}
             >
               {collapsed ? '[+]' : '[-]'}
             </button>
@@ -143,7 +145,7 @@ export default function Comment({
                   (comment.last_update || '') + 'Z'
                 ).toLocaleString()}`}
               >
-                (edited)
+                ({t('g.edited')})
               </span>
             )}
             {gray && hideBody && (
@@ -152,16 +154,14 @@ export default function Comment({
                 onClick={() => setRevealGray(true)}
                 className="ml-2 text-accent-foreground hover:underline"
               >
-                reveal comment
+                {t('g.reveal_comment')}
               </button>
             )}
             {collapsed && (comment.children ?? sortedReplies.length) > 0 && (
               <span className="ml-2 text-muted-foreground">
-                ({comment.children ?? sortedReplies.length}{' '}
-                {(comment.children ?? sortedReplies.length) === 1
-                  ? 'reply'
-                  : 'replies'}
-                )
+                ({t('comments.reply_count', {
+                  count: comment.children ?? sortedReplies.length,
+                })})
               </span>
             )}
           </div>
@@ -179,7 +179,7 @@ export default function Comment({
                 )}
                 {gray && (
                   <p className="text-[85%] text-muted-foreground">
-                    This comment will be hidden due to low ratings.
+                    {t('g.will_be_hidden_due_to_low_rating')}
                   </p>
                 )}
               </div>
@@ -195,7 +195,7 @@ export default function Comment({
                   }}
                   className="text-foreground hover:text-accent-foreground"
                 >
-                  Reply
+                  {t('g.reply')}
                 </button>
                 {isMyComment && (
                   <>
@@ -207,14 +207,14 @@ export default function Comment({
                       }}
                       className="text-foreground hover:text-accent-foreground"
                     >
-                      Edit
+                      {t('g.edit')}
                     </button>
                     <button
                       type="button"
                       onClick={handleDelete}
                       className="text-foreground hover:text-accent-foreground"
                     >
-                      Delete
+                      {t('g.delete')}
                     </button>
                   </>
                 )}
@@ -263,10 +263,9 @@ export default function Comment({
                 href={commentUrl}
                 className="text-accent-foreground hover:underline"
               >
-                Show {comment.children || sortedReplies.length} more{' '}
-                {(comment.children || sortedReplies.length) === 1
-                  ? 'reply'
-                  : 'replies'}
+                {t('comments.show_more_replies', {
+                  count: comment.children || sortedReplies.length,
+                })}
               </Link>
             ) : (
               sortedReplies.map((reply) => (

--- a/components/cards/FollowList.tsx
+++ b/components/cards/FollowList.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback } from 'react';
 import Link from 'next/link';
+import { useTranslations } from 'next-intl';
 
 import { fetchFollowers, fetchFollowing, FollowItem } from '@/lib/api/steem';
 import Follow from '@/components/elements/Follow';
@@ -22,6 +23,7 @@ const PAGE_SIZE = 20;
  * with page-number pagination (ReactPaginate style).
  */
 export default function FollowList({ accountname, type, total }: FollowListProps) {
+  const t = useTranslations();
   const currentUser = useAppSelector((s) => s.user.current?.username);
   const [items, setItems] = useState<FollowItem[]>([]);
   const [loading, setLoading] = useState(true);
@@ -71,8 +73,8 @@ export default function FollowList({ accountname, type, total }: FollowListProps
     return (
       <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
         {type === 'followers'
-          ? `@${accountname} has no followers yet.`
-          : `@${accountname} is not following anyone yet.`}
+          ? t('follow_list.no_followers', { username: accountname })
+          : t('follow_list.not_following', { username: accountname })}
       </div>
     );
   }
@@ -115,7 +117,7 @@ export default function FollowList({ accountname, type, total }: FollowListProps
 
       {totalPages > 1 && (
         <nav
-          aria-label="Pagination"
+          aria-label={t('g.pagination')}
           className="mt-6 flex items-center justify-center gap-1 text-sm"
         >
           <button
@@ -124,7 +126,7 @@ export default function FollowList({ accountname, type, total }: FollowListProps
             onClick={() => void loadPage(page - 1)}
             className="rounded px-2 py-1 text-foreground hover:bg-accent disabled:opacity-40"
           >
-            previous
+            {t('g.previous')}
           </button>
           {start > 0 && <span className="px-1 text-muted-foreground">…</span>}
           {pageNumbers.map((p) => (
@@ -151,7 +153,7 @@ export default function FollowList({ accountname, type, total }: FollowListProps
             onClick={() => void loadPage(page + 1)}
             className="rounded px-2 py-1 text-foreground hover:bg-accent disabled:opacity-40"
           >
-            next
+            {t('g.next')}
           </button>
         </nav>
       )}

--- a/components/cards/NotificationsList.tsx
+++ b/components/cards/NotificationsList.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import { receiveNotifications, receiveUnreadNotifications, notificationsLoading } from '@/store/slices/globalSlice';
 import { broadcastCustomJson } from '@/lib/api/broadcast';
@@ -34,12 +35,12 @@ interface NotificationsListProps {
 }
 
 const FILTERS = [
-  { key: 'all', label: 'All' },
-  { key: 'replies', label: 'Replies' },
-  { key: 'mentions', label: 'Mentions' },
-  { key: 'follows', label: 'Follows' },
-  { key: 'upvotes', label: 'Upvotes' },
-  { key: 'resteems', label: 'Resteems' },
+  { key: 'all', labelKey: 'notificationslist_jsx.all' },
+  { key: 'replies', labelKey: 'notificationslist_jsx.replies' },
+  { key: 'mentions', labelKey: 'notificationslist_jsx.mentions' },
+  { key: 'follows', labelKey: 'notificationslist_jsx.follows' },
+  { key: 'upvotes', labelKey: 'notificationslist_jsx.upvotes' },
+  { key: 'resteems', labelKey: 'notificationslist_jsx.resteems' },
 ] as const;
 
 type FilterKey = (typeof FILTERS)[number]['key'];
@@ -79,6 +80,7 @@ function renderMsg(msg: string): React.ReactNode {
  */
 export default function NotificationsList({ username }: NotificationsListProps) {
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const notificationsState = useAppSelector((state) =>
     state.global.notifications?.[username]
   );
@@ -194,7 +196,7 @@ export default function NotificationsList({ username }: NotificationsListProps) 
       }, 6000);
     } catch (error) {
       console.error('Error marking notifications as read:', error);
-      setMarkReadError('Failed to mark notifications as read. Please try again.');
+      setMarkReadError(t('notificationslist_jsx.mark_as_read_error'));
     } finally {
       setMarkReadPending(false);
     }
@@ -230,7 +232,7 @@ export default function NotificationsList({ username }: NotificationsListProps) 
                 filter === f.key ? 'font-bold' : ''
               } ${i > 0 ? 'border-l border-[#ababab]' : ''}`}
             >
-              {f.label}
+              {t(f.labelKey)}
             </button>
           </span>
         ))}
@@ -244,7 +246,7 @@ export default function NotificationsList({ username }: NotificationsListProps) 
             disabled={markReadPending}
             className="font-bold text-foreground hover:text-accent-foreground disabled:opacity-50"
           >
-            {markReadPending ? 'Marking...' : 'Mark all as read'}
+            {markReadPending ? t('notificationslist_jsx.marking') : t('notificationslist_jsx.mark_all_as_read')}
           </button>
           {markReadError && (
             <p className="mt-1 text-sm text-destructive">{markReadError}</p>
@@ -258,7 +260,7 @@ export default function NotificationsList({ username }: NotificationsListProps) 
         </div>
       ) : filteredNotifications.length === 0 ? (
         <div className="rounded-[6px] border border-border bg-card px-6 py-8 text-center text-muted-foreground">
-          Welcome! You don&apos;t have any notifications yet.
+          {t('notificationslist_jsx.empty')}
         </div>
       ) : (
         <div>
@@ -284,7 +286,7 @@ export default function NotificationsList({ username }: NotificationsListProps) 
                 {isUnread && (
                   <span
                     className="absolute right-4 top-3 text-[2em] leading-none text-accent-foreground"
-                    title="Unread"
+                    title={t('notificationslist_jsx.unread')}
                   >
                     •
                   </span>
@@ -326,7 +328,7 @@ export default function NotificationsList({ username }: NotificationsListProps) 
                 disabled={loading}
                 className="font-bold text-foreground hover:text-accent-foreground disabled:opacity-50"
               >
-                {loading ? 'Loading...' : 'Load more'}
+                {loading ? t('g.loading') : t('notificationslist_jsx.load_more')}
               </button>
             </div>
           )}

--- a/components/cards/PostSummary.tsx
+++ b/components/cards/PostSummary.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import Link from "next/link";
 import { ChevronUp, MessageCircle, Pin } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 import type { Post } from "@/lib/api/steem";
 import {
@@ -31,6 +32,7 @@ interface PostSummaryProps {
  */
 export default function PostSummary({ post, order }: PostSummaryProps) {
   const [revealNsfw, setRevealNsfw] = useState(false);
+  const t = useTranslations();
 
   const tags = post.json_metadata?.tags || [];
   const isNsfw = tags.includes("nsfw");
@@ -64,16 +66,17 @@ export default function PostSummary({ post, order }: PostSummaryProps) {
     return (
       <li className="list-none rounded-[6px] border border-border bg-card px-2 py-3 min-[760px]:px-2 min-[760px]:py-1">
         <div className="py-2 text-[15px] text-muted-foreground">
-          This post is <span className="font-semibold text-[#ff0264]">nsfw</span>
-          .{" "}
+          {t("postsummary_jsx.this_post_is_nsfw")}{" "}
+          <span className="font-semibold text-[#ff0264]">nsfw</span>.{" "}
           <button
             type="button"
             className="text-accent-foreground underline"
             onClick={() => setRevealNsfw(true)}
           >
-            Reveal it
+            {t("postsummary_jsx.reveal_it")}
           </button>{" "}
-          or adjust your display preferences.
+          {t("g.or")} {t("postsummary_jsx.adjust_your")}{" "}
+          {t("postsummary_jsx.display_preferences")}.
         </div>
       </li>
     );
@@ -98,7 +101,7 @@ export default function PostSummary({ post, order }: PostSummaryProps) {
               >
                 {rebloggedBy[0]}
               </Link>{" "}
-              resteemed
+              {t("postsummary_jsx.resteemed")}
             </span>
           </div>
         )}
@@ -117,7 +120,7 @@ export default function PostSummary({ post, order }: PostSummaryProps) {
             </Link>{" "}
             {rep !== null && <Reputation value={rep} />}{" "}
             <span className="text-muted-foreground">
-              in{" "}
+              {t("g.in")}{" "}
               <Link prefetch={false}
                 href={tagUrl}
                 className="text-muted-foreground hover:text-accent-foreground"
@@ -132,14 +135,14 @@ export default function PostSummary({ post, order }: PostSummaryProps) {
               )}
             </span>
             {powerUp100 && (
-              <span title="100% Steem Power payout" className="ml-1 align-middle">
+              <span title={t("g.powered_up_100")} className="ml-1 align-middle">
                 ⚡
               </span>
             )}
             {isPinned && (
               <span className="ml-1 inline-flex items-center gap-0.5 rounded border border-accent-foreground px-1 py-px text-[11px] text-accent-foreground">
                 <Pin className="size-3" />
-                Pinned
+                {t("g.pinned")}
               </span>
             )}
           </span>
@@ -183,7 +186,7 @@ export default function PostSummary({ post, order }: PostSummaryProps) {
                 href={postUrl}
                 className="text-foreground visited:text-muted-foreground"
               >
-                {post.title || "Untitled"}
+                {post.title || t("g.untitled")}
               </Link>
             </h2>
             {/* legacy PostSummary__body: the excerpt itself is a link */}
@@ -206,7 +209,7 @@ export default function PostSummary({ post, order }: PostSummaryProps) {
                 <Voting post={post} showList={false} />
                 <span
                   className="flex items-center gap-1 border-r border-border pr-4 text-muted-foreground"
-                  title={`${totalVotes} votes`}
+                  title={t("voting_jsx.vote_count", { count: totalVotes })}
                 >
                   <ChevronUp className="size-4" aria-hidden />
                   {totalVotes}

--- a/components/cards/UserProfileHeader.tsx
+++ b/components/cards/UserProfileHeader.tsx
@@ -2,6 +2,7 @@
 
 import Link from 'next/link';
 import { Calendar, Link2, MapPin } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 
 import { proxifyImageUrl } from '@/lib/media/proxify-url';
 import Userpic from '@/components/elements/Userpic';
@@ -53,6 +54,7 @@ export default function UserProfileHeader({
   active,
   blacklists = [],
 }: UserProfileHeaderProps) {
+  const t = useTranslations();
   const displayName = profile?.name || accountname;
 
   const coverImage = profile?.cover_image;
@@ -98,7 +100,7 @@ export default function UserProfileHeader({
           {rep !== null && (
             <span
               className="UserProfile__rep text-[80%] font-extralight"
-              title={`This is ${accountname}'s reputation score. It is based on the history of votes.`}
+              title={t('user_profile.reputation_title', { name: accountname })}
             >
               ({rep})
             </span>
@@ -106,7 +108,7 @@ export default function UserProfileHeader({
           {blacklists.length > 0 && (
             <span
               className="account_warn ml-1 font-bold text-[#ff4d4f]"
-              title={`Blacklisted on: ${blacklists.join(', ')}`}
+              title={t('user_profile.blacklisted_on', { list: blacklists.join(', ') })}
             >
               ({blacklists.length})
             </span>
@@ -123,17 +125,20 @@ export default function UserProfileHeader({
           <div className="UserProfile__stats mb-[5px] pb-[5px] text-[90%]">
             <span className="px-2.5">
               <Link href={`/@${accountname}/followers`}>
-                <strong>{stats?.followers ?? 0}</strong> followers
+                <strong>{stats?.followers ?? 0}</strong>{' '}
+                {t('user_profile.followers_label', { count: stats?.followers ?? 0 })}
               </Link>
             </span>
             <span className="border-l border-[#ccc] px-2.5">
               <Link href={`/@${accountname}`}>
-                <strong>{postCount ?? 0}</strong> posts
+                <strong>{postCount ?? 0}</strong>{' '}
+                {t('user_profile.posts_label', { count: postCount ?? 0 })}
               </Link>
             </span>
             <span className="border-l border-[#ccc] px-2.5">
               <Link href={`/@${accountname}/followed`}>
-                <strong>{stats?.following ?? 0}</strong> following
+                <strong>{stats?.following ?? 0}</strong>{' '}
+                {t('user_profile.following_label', { count: stats?.following ?? 0 })}
               </Link>
             </span>
             {typeof stats?.sp === 'number' && stats.sp > 0 && (
@@ -169,12 +174,13 @@ export default function UserProfileHeader({
             )}
             {joinDate && (
               <span className="inline-flex items-center gap-1">
-                <Calendar className="size-4" aria-hidden /> Joined {joinDate}
+                <Calendar className="size-4" aria-hidden />{' '}
+                {t('user_profile.joined_date', { date: joinDate })}
               </span>
             )}
             {active && (
               <span className="inline-flex items-center gap-1">
-                <Calendar className="size-4" aria-hidden /> Active{' '}
+                <Calendar className="size-4" aria-hidden /> {t('g.active')}{' '}
                 <TimeAgo date={active} />
               </span>
             )}

--- a/components/elements/Follow.tsx
+++ b/components/elements/Follow.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import { showLogin } from '@/store/slices/userSlice';
 import { broadcastCustomJson } from '@/lib/api/broadcast';
@@ -29,6 +30,7 @@ export default function Follow({
   children,
 }: FollowProps) {
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const currentUser = useAppSelector((state) => state.user.current?.username);
   const follower = propFollower || currentUser;
 
@@ -60,7 +62,7 @@ export default function Follow({
         }}
         className={`${fat ? '' : 'px-2 py-1 text-sm'} border border-gray-300 rounded text-gray-700 hover:bg-gray-50`}
       >
-        Follow
+        {t('g.follow')}
       </button>
     );
   }
@@ -69,7 +71,7 @@ export default function Follow({
   if (loading) {
     return (
       <span className="text-sm text-gray-500">
-        Loading...
+        {t('g.loading')}...
       </span>
     );
   }
@@ -190,7 +192,7 @@ export default function Follow({
           disabled={busy}
           className={inactiveButtonClass}
         >
-          Follow
+          {t('g.follow')}
         </button>
       )}
 
@@ -200,7 +202,7 @@ export default function Follow({
           disabled={busy}
           className={activeButtonClass}
         >
-          Unfollow
+          {t('g.unfollow')}
         </button>
       )}
 
@@ -210,7 +212,7 @@ export default function Follow({
           disabled={busy}
           className={inactiveButtonClass}
         >
-          Mute
+          {t('g.mute')}
         </button>
       )}
 
@@ -220,7 +222,7 @@ export default function Follow({
           disabled={busy}
           className={activeButtonClass}
         >
-          Unmute
+          {t('g.unmute')}
         </button>
       )}
 

--- a/components/elements/MarkdownViewer.tsx
+++ b/components/elements/MarkdownViewer.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useMemo, useState } from 'react';
+import { useTranslations } from 'next-intl';
 import MarkdownIt from 'markdown-it';
 import sanitizeHtml from 'sanitize-html';
 import htmlReady from '@/lib/html-ready';
@@ -56,6 +57,7 @@ export default function MarkdownViewer({
   hideImages = false,
   isProxifyImages = false,
 }: MarkdownViewerProps) {
+  const t = useTranslations();
   // Low-ratings posts hide images until the user clicks the banner.
   const [allowNoImage, setAllowNoImage] = useState(true);
 
@@ -140,19 +142,19 @@ export default function MarkdownViewer({
         );
       } else {
         let url: string | null = null;
-        let title = '';
+        let provider = '';
         if (type === 'threespeak') {
           url = `https://3speak.online/embed?v=${id}`;
-          title = `ThreeSpeak video ${id}`;
+          provider = 'ThreeSpeak';
         } else if (type === 'vimeo') {
           url = `https://player.vimeo.com/video/${id}#t=${startTime}s`;
-          title = `Vimeo video ${id}`;
+          provider = 'Vimeo';
         } else if (type === 'twitch') {
           url = `https://player.twitch.tv/${id}`;
-          title = `Twitch video ${id}`;
+          provider = 'Twitch';
         } else if (type === 'dtube') {
           url = `https://emb.d.tube/#!/${id}`;
-          title = `DTube video ${id}`;
+          provider = 'DTube';
         } else {
           console.error('MarkdownViewer unknown embed type', type);
         }
@@ -168,7 +170,7 @@ export default function MarkdownViewer({
                 webkitallowfullscreen="true"
                 mozallowfullscreen="true"
                 allowFullScreen
-                title={title}
+                title={t('markdownviewer_jsx.embedded_video_title', { provider, id })}
               />
             </div>
           );
@@ -200,12 +202,12 @@ export default function MarkdownViewer({
           onClick={() => setAllowNoImage(false)}
           className="MarkdownViewer__negative_group"
         >
-          Images were hidden due to low ratings
+          {t('markdownviewer_jsx.images_were_hidden_due_to_low_ratings')}
           <button
             style={{ marginBottom: 0 }}
             className="button hollow tiny float-right"
           >
-            Show
+            {t('g.show')}
           </button>
         </div>
       )}

--- a/components/elements/NotificationBadge.tsx
+++ b/components/elements/NotificationBadge.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { fetchUnreadNotificationsCount, UnreadNotificationsResponse } from '@/lib/api/steem';
 
 interface NotificationBadgeProps {
@@ -19,6 +20,7 @@ export default function NotificationBadge({
   className = '', 
   showZero = false 
 }: NotificationBadgeProps) {
+  const t = useTranslations();
   const [unreadCount, setUnreadCount] = useState<number>(0);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -44,7 +46,7 @@ export default function NotificationBadge({
         }
       } catch (err) {
         console.error('Error fetching notification count:', err);
-        setError('Failed to load notifications');
+        setError(t('notificationslist_jsx.failed_to_load'));
         setUnreadCount(0);
       } finally {
         setLoading(false);
@@ -68,7 +70,7 @@ export default function NotificationBadge({
       clearInterval(interval);
       window.removeEventListener('notifications:marked-read', onMarkedRead);
     };
-  }, [username]);
+  }, [username, t]);
 
   // Don't render if loading or no username
   if (loading || !username) {
@@ -93,7 +95,7 @@ export default function NotificationBadge({
   return (
     <span 
       className={`inline-flex items-center justify-center min-w-5 h-5 text-xs font-bold text-white bg-red-500 rounded-full ${className}`}
-      title={`${unreadCount} unread notification${unreadCount !== 1 ? 's' : ''}`}
+      title={t('notificationslist_jsx.unread_notifications', { count: unreadCount })}
     >
       {unreadCount > 99 ? '99+' : unreadCount}
     </span>

--- a/components/elements/Reblog.tsx
+++ b/components/elements/Reblog.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { useTranslations } from 'next-intl';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import { showLogin } from '@/store/slices/userSlice';
 import { broadcastCustomJson } from '@/lib/api/broadcast';
@@ -20,6 +21,7 @@ interface ReblogProps {
  */
 export default function Reblog({ author, permlink, iconOnly = false }: ReblogProps) {
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const username = useAppSelector((state) => state.user.current?.username);
 
   const [active, setActive] = useState(false);
@@ -76,8 +78,8 @@ export default function Reblog({ author, permlink, iconOnly = false }: ReblogPro
         className={`inline-flex items-center p-0.5 transition-colors ${
           loading ? 'opacity-50 cursor-not-allowed' : ''
         }`}
-        title={active ? 'Already reblogged' : 'Reblog this post'}
-        aria-label={active ? 'Already reblogged' : 'Reblog this post'}
+        title={active ? t('reblog_jsx.already_reblogged') : t('reblog_jsx.reblog_this_post')}
+        aria-label={active ? t('reblog_jsx.already_reblogged') : t('reblog_jsx.reblog_this_post')}
       >
         {loading ? (
           <svg
@@ -109,7 +111,7 @@ export default function Reblog({ author, permlink, iconOnly = false }: ReblogPro
           ? 'bg-[#06D6A9]/15 text-[#0b8f68] dark:text-[#06D6A9]'
           : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
       } ${loading ? 'opacity-50 cursor-not-allowed' : ''} ${active ? 'cursor-default' : ''}`}
-      title={active ? 'Already reblogged' : 'Reblog this post'}
+      title={active ? t('reblog_jsx.already_reblogged') : t('reblog_jsx.reblog_this_post')}
     >
       {loading ? (
         <svg
@@ -142,7 +144,7 @@ export default function Reblog({ author, permlink, iconOnly = false }: ReblogPro
           />
         </svg>
       )}
-      <span className="text-sm">{active ? 'Reblogged' : 'Reblog'}</span>
+      <span className="text-sm">{active ? t('reblog_jsx.reblogged') : t('reblog_jsx.reblog')}</span>
     </button>
   );
 }

--- a/components/elements/Reputation.tsx
+++ b/components/elements/Reputation.tsx
@@ -1,14 +1,19 @@
+'use client';
+
+import { useTranslations } from 'next-intl';
+
 /**
  * Reputation — "(73)" style reputation number after an author name.
  * Ported from legacy src/app/components/elements/Reputation.jsx.
  */
 export default function Reputation({ value }: { value: number }) {
+  const t = useTranslations();
   if (Number.isNaN(value)) {
     console.log('Unexpected rep value:', value);
     return null;
   }
   return (
-    <span className="Reputation" title="Reputation">
+    <span className="Reputation" title={t('g.reputation')}>
       ({Math.floor(value)})
     </span>
   );

--- a/components/elements/ShareMenu.tsx
+++ b/components/elements/ShareMenu.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { Facebook, Linkedin, Twitter } from 'lucide-react';
+import { useTranslations } from 'next-intl';
 
 import { userActionRecord } from '@/lib/analytics/overseer';
 
@@ -25,6 +26,7 @@ interface ShareMenuProps {
  * icons side by side, each opening the share dialog in a popup window.
  */
 export default function ShareMenu({ url, title }: ShareMenuProps) {
+  const t = useTranslations();
   const fullUrl =
     typeof window !== 'undefined' ? `${window.location.origin}${url}` : url;
 
@@ -98,8 +100,8 @@ export default function ShareMenu({ url, title }: ShareMenuProps) {
           key={item.name}
           type="button"
           onClick={item.onClick}
-          title={`Share on ${item.name}`}
-          aria-label={`Share on ${item.name}`}
+          title={t('share_menu.share_on', { name: item.name })}
+          aria-label={t('share_menu.share_on', { name: item.name })}
           className="p-[2px] text-muted-foreground transition-colors hover:text-accent-foreground"
         >
           <item.icon className="size-5 fill-current" aria-hidden />

--- a/components/elements/SteemMarket.tsx
+++ b/components/elements/SteemMarket.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 
 import { useAppSelector } from "@/store/hooks";
 import { recordAdsView } from "@/lib/analytics/overseer";
@@ -167,6 +168,7 @@ function CoinChart({
 }
 
 export default function SteemMarket({ page }: { page: string }) {
+  const t = useTranslations();
   const trackingId = useAppSelector((s) => s.user.trackingId);
   const [data, setData] = useState<MarketData | null>(null);
 
@@ -194,7 +196,7 @@ export default function SteemMarket({ page }: { page: string }) {
   return (
     <div className="c-sidebar__module mb-4 rounded-[6px] border border-border bg-card p-[1.5em]">
       <div className="c-sidebar__header mb-2">
-        <h3 className="c-sidebar__h3 font-bold text-foreground">Coin Marketplace</h3>
+        <h3 className="c-sidebar__h3 font-bold text-foreground">{t("sidebar.coin_marketplace")}</h3>
       </div>
       <div className="c-sidebar__content">
         {coins.map((coin) => (

--- a/components/elements/SubscribeButton.tsx
+++ b/components/elements/SubscribeButton.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { showLogin } from '@/store/slices/userSlice';
 import { broadcastCustomJson } from '@/lib/api/broadcast';
@@ -21,6 +22,7 @@ export default function SubscribeButton({
   subscribed = false,
 }: SubscribeButtonProps) {
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const username = useAppSelector((s) => s.user.current?.username);
   const [loading, setLoading] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
@@ -57,11 +59,11 @@ export default function SubscribeButton({
 
   const buttonText = isHovered
     ? isSubscribed
-      ? 'Leave'
-      : 'Subscribe'
+      ? t('g.leave')
+      : t('g.subscribe')
     : isSubscribed
-      ? 'Joined'
-      : 'Subscribe';
+      ? t('g.joined')
+      : t('g.subscribe');
 
   return (
     <button

--- a/components/elements/TimeAgo.tsx
+++ b/components/elements/TimeAgo.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useEffect, useState } from 'react';
+import { useTranslations } from 'next-intl';
 
 /**
  * TimeAgo — relative timestamp like legacy's TimeAgoWrapper
@@ -13,21 +14,33 @@ const HOUR = 3600;
 const DAY = 86400;
 const WEEK = 604800;
 
-export function timeAgo(date: Date, now: number = Date.now()): string {
+export type TimeAgoUnit =
+  | 'just_now'
+  | 'minutes'
+  | 'hours'
+  | 'days'
+  | 'weeks'
+  | 'months'
+  | 'years';
+
+/** Pick the time_ago.* message key and its count for a given age. */
+export function timeAgoUnit(
+  date: Date,
+  now: number = Date.now()
+): { unit: TimeAgoUnit; count: number } {
   const seconds = Math.max(0, Math.floor((now - date.getTime()) / 1000));
-  if (seconds < 45) return 'just now';
+  if (seconds < 45) return { unit: 'just_now', count: 0 };
   const minutes = Math.floor(seconds / MINUTE);
-  if (minutes < 45) return `${minutes} minute${minutes === 1 ? '' : 's'} ago`;
+  if (minutes < 45) return { unit: 'minutes', count: minutes };
   const hours = Math.floor(seconds / HOUR);
-  if (hours < 22) return `${hours} hour${hours === 1 ? '' : 's'} ago`;
+  if (hours < 22) return { unit: 'hours', count: hours };
   const days = Math.floor(seconds / DAY);
-  if (days < 7) return `${days} day${days === 1 ? '' : 's'} ago`;
+  if (days < 7) return { unit: 'days', count: days };
   const weeks = Math.floor(seconds / WEEK);
-  if (weeks < 4) return `${weeks} week${weeks === 1 ? '' : 's'} ago`;
+  if (weeks < 4) return { unit: 'weeks', count: weeks };
   const months = Math.floor(days / 30);
-  if (months < 12) return `${months} month${months === 1 ? '' : 's'} ago`;
-  const years = Math.floor(days / 365);
-  return `${years} year${years === 1 ? '' : 's'} ago`;
+  if (months < 12) return { unit: 'months', count: months };
+  return { unit: 'years', count: Math.floor(days / 365) };
 }
 
 interface TimeAgoProps {
@@ -39,6 +52,7 @@ interface TimeAgoProps {
 }
 
 export default function TimeAgo({ date, className, prefix }: TimeAgoProps) {
+  const t = useTranslations();
   // Chain timestamps have no timezone suffix; they are UTC.
   const d = new Date(date.endsWith('Z') || /[+-]\d{2}:?\d{2}$/.test(date) ? date : date + 'Z');
   const [, setTick] = useState(0);
@@ -47,10 +61,12 @@ export default function TimeAgo({ date, className, prefix }: TimeAgoProps) {
     return () => clearInterval(id);
   }, []);
 
+  const { unit, count } = timeAgoUnit(d);
+
   return (
     <span className={className} title={d.toLocaleString()}>
       {prefix}
-      {timeAgo(d)}
+      {t(`time_ago.${unit}`, { count })}
     </span>
   );
 }

--- a/components/elements/Voting.tsx
+++ b/components/elements/Voting.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState, useRef } from 'react';
+import { useTranslations } from 'next-intl';
 import { useAppSelector, useAppDispatch } from '@/store/hooks';
 import { showLogin } from '@/store/slices/userSlice';
 import { voted, set } from '@/store/slices/globalSlice';
@@ -126,6 +127,7 @@ export default function Voting({
   isComment = false,
 }: VotingProps) {
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const username = useAppSelector((state) => state.user.current?.username);
   const voting = useAppSelector((state) => {
     const key = `transaction_vote_active_${post.author}_${post.permlink}`;
@@ -279,7 +281,7 @@ export default function Voting({
             voting={Boolean(voting) && votingDir === 'up'}
             disabled={Boolean(voting)}
             onClick={() => handleChevronClick(true)}
-            title={upvoteActive ? 'Remove Vote' : 'Upvote'}
+            title={upvoteActive ? t('g.remove_vote') : t('g.upvote')}
           />
           {enableSlider && showWeight === 'up' && (
             <div className="absolute left-1/2 top-full z-[100] mt-1 w-[180px] -translate-x-1/2 rounded-[6px] border border-border bg-card p-3 shadow-lg">
@@ -298,14 +300,14 @@ export default function Voting({
                   saveSliderWeight(true, w);
                 }}
                 className="w-full"
-                aria-label="Vote weight"
+                aria-label={t('voting_jsx.vote_weight')}
               />
               <button
                 type="button"
                 onClick={() => handleVote(true)}
                 className="mt-2 w-full rounded bg-[#06D6A9] px-2 py-1 text-sm font-bold text-white"
               >
-                Vote {sliderWeight.up / 100}%
+                {t('voting_jsx.vote_percent', { percent: sliderWeight.up / 100 })}
               </button>
             </div>
           )}
@@ -318,7 +320,7 @@ export default function Voting({
             voting={Boolean(voting) && votingDir === 'down'}
             disabled={Boolean(voting)}
             onClick={() => handleChevronClick(false)}
-            title={downvoteActive ? 'Remove Vote' : 'Downvote'}
+            title={downvoteActive ? t('g.remove_vote') : t('g.downvote')}
           />
           {enableSlider && showWeight === 'down' && (
             <div className="absolute left-1/2 top-full z-[100] mt-1 w-[180px] -translate-x-1/2 rounded-[6px] border border-border bg-card p-3 shadow-lg">
@@ -337,14 +339,14 @@ export default function Voting({
                   saveSliderWeight(false, w);
                 }}
                 className="w-full"
-                aria-label="Downvote weight"
+                aria-label={t('voting_jsx.downvote_weight')}
               />
               <button
                 type="button"
                 onClick={() => handleVote(false)}
                 className="mt-2 w-full rounded bg-[#f66] px-2 py-1 text-sm font-bold text-white"
               >
-                Downvote {sliderWeight.down / 100}%
+                {t('voting_jsx.downvote_percent', { percent: sliderWeight.down / 100 })}
               </button>
             </div>
           )}
@@ -357,7 +359,7 @@ export default function Voting({
                 <button
                   type="button"
                   className="flex items-center gap-0.5 px-1 text-foreground hover:text-accent-foreground"
-                  title="Payout details"
+                  title={t('voting_jsx.payout_details')}
                 />
               }
             >
@@ -368,16 +370,16 @@ export default function Voting({
             </DropdownMenuTrigger>
             <DropdownMenuContent align="start" className="min-w-56">
               <DropdownMenuItem disabled>
-                Pending Payout {fmtPayout(post.pending_payout_value)}
+                {t('voting_jsx.pending_payout_amount', { value: fmtPayout(post.pending_payout_value) })}
               </DropdownMenuItem>
               {post.payout_at && (
-                <DropdownItemText text={`Payout Date ${new Date(post.payout_at + 'Z').toLocaleString()}`} />
+                <DropdownItemText text={t('voting_jsx.payout_date', { date: new Date(post.payout_at + 'Z').toLocaleString() })} />
               )}
               {post.author_payout_value && (
-                <DropdownItemText text={`Author Payout ${fmtPayout(post.author_payout_value)}`} />
+                <DropdownItemText text={t('voting_jsx.author_payout', { value: fmtPayout(post.author_payout_value) })} />
               )}
               {post.curator_payout_value && (
-                <DropdownItemText text={`Curator Payout ${fmtPayout(post.curator_payout_value)}`} />
+                <DropdownItemText text={t('voting_jsx.curator_payout', { value: fmtPayout(post.curator_payout_value) })} />
               )}
             </DropdownMenuContent>
           </DropdownMenu>
@@ -391,11 +393,11 @@ export default function Voting({
               <button
                 type="button"
                 className="px-1 text-foreground hover:text-accent-foreground"
-                title="Voters"
+                title={t('voting_jsx.voters')}
               />
             }
           >
-            {totalVotes} vote{totalVotes === 1 ? '' : 's'}
+            {t('voting_jsx.vote_count', { count: totalVotes })}
           </DropdownMenuTrigger>
           <DropdownMenuContent align="start" className="min-w-[140px]">
             {votes.map((v) => (
@@ -405,7 +407,7 @@ export default function Voting({
               />
             ))}
             {extraVoters > 0 && (
-              <DropdownItemText text={`and ${extraVoters} more`} />
+              <DropdownItemText text={t('voting_jsx.and_more', { count: extraVoters })} />
             )}
           </DropdownMenuContent>
         </DropdownMenu>

--- a/components/elements/YoutubePreview.tsx
+++ b/components/elements/YoutubePreview.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useState } from 'react';
+import { useTranslations } from 'next-intl';
 
 interface YoutubePreviewProps {
   youTubeId: string;
@@ -25,6 +26,7 @@ export default function YoutubePreview({
   startTime = 0,
   dataParams = 'enablejsapi=0&rel=0&origin=https://steemit.com',
 }: YoutubePreviewProps) {
+  const t = useTranslations();
   const [play, setPlay] = useState(false);
 
   if (!play) {
@@ -54,7 +56,7 @@ export default function YoutubePreview({
         src={autoPlaySrc}
         frameBorder="0"
         allowFullScreen
-        title={`YouTube video ${youTubeId}`}
+        title={t('markdownviewer_jsx.embedded_video_title', { provider: 'YouTube', id: youTubeId })}
       />
     </div>
   );

--- a/components/layout/AppShell.tsx
+++ b/components/layout/AppShell.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
+import { useTranslations } from "next-intl";
 import { Header } from "@/components/layout/Header";
 import { DegradationBanner } from "@/components/layout/DegradationBanner";
 import { GlobalModals } from "@/components/modules/GlobalModals";
@@ -9,6 +10,7 @@ import { MobileTabBar } from "@/components/layout/MobileTabBar";
 import { Analytics } from "@/components/providers/Analytics";
 
 export function AppShell({ children }: { children: React.ReactNode }) {
+  const t = useTranslations();
   const [scrollVisible, setScrollVisible] = useState(false);
 
   useEffect(() => {
@@ -36,7 +38,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
         <button
           type="button"
           className="scroll-to-top fixed bottom-[76px] right-6 z-40 flex size-10 items-center justify-center rounded-md border border-border bg-card text-lg text-foreground shadow-md transition-opacity hover:bg-muted min-[760px]:bottom-6"
-          aria-label="Scroll to top"
+          aria-label={t("g.scroll_to_top")}
           onClick={() =>
             window.scrollTo({ top: 0, behavior: "smooth" })
           }

--- a/components/layout/DegradationBanner.tsx
+++ b/components/layout/DegradationBanner.tsx
@@ -1,5 +1,7 @@
 'use client';
 
+import { useTranslations } from 'next-intl';
+
 import {
   useServiceHealth,
   type ServiceHealthStatus,
@@ -24,13 +26,14 @@ const bannerStyles: Record<ServiceHealthStatus, string> = {
 
 export function DegradationBanner() {
   const status = useServiceHealth();
+  const t = useTranslations();
 
   if (status === 'healthy' || status === 'unknown') return null;
 
   const message =
     status === 'outage'
-      ? 'Connection to the Steem network is unstable. Some actions may fail.'
-      : 'Showing cached content — the Steem network is slow to respond.';
+      ? t('degradation_banner.outage')
+      : t('degradation_banner.degraded');
 
   return (
     <div

--- a/components/layout/FeedListHeader.tsx
+++ b/components/layout/FeedListHeader.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useTranslations } from "next-intl";
+
 import { FeedSortDropdown } from "@/components/layout/FeedSortDropdown";
 import { cn } from "@/lib/utils";
 
@@ -19,6 +21,7 @@ export function FeedListHeader({
   unmoderatedTagHint?: boolean;
   className?: string;
 }) {
+  const t = useTranslations();
   return (
     // Legacy spacing: header padding-bottom 10px; articles__hr is
     // display:none in layout-list (a later SCSS rule overrides the MQ(M)
@@ -30,7 +33,7 @@ export function FeedListHeader({
           {/* legacy h1.articles__h1 removed: redundant with the sort dropdown */}
           {unmoderatedTagHint ? (
             <p className="mt-1 hidden text-[80%] text-muted-foreground min-[1200px]:block">
-              Unmoderated tag
+              {t("posts_index.unmoderated_tag")}
             </p>
           ) : null}
         </div>

--- a/components/layout/FeedSidebarWidgets.tsx
+++ b/components/layout/FeedSidebarWidgets.tsx
@@ -3,6 +3,7 @@
 import { useEffect, useState } from "react";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useTranslations } from "next-intl";
 
 import { useAppSelector } from "@/store/hooks";
 import {
@@ -38,8 +39,9 @@ function SidebarModule({
 
 /** Logged-out rail: "New to Steemit?" (legacy SidebarNewUsers). */
 function SidebarNewUsers() {
+  const t = useTranslations();
   return (
-    <SidebarModule title="New to Steemit?">
+    <SidebarModule title={t("sidebar.new_to_steemit")}>
       <ul>
         <li className="py-1">
           <a
@@ -48,7 +50,7 @@ function SidebarNewUsers() {
             target="_blank"
             rel="noopener noreferrer"
           >
-            Welcome Guide
+            {t("g.welcome_guide")}
           </a>
         </li>
       </ul>
@@ -58,6 +60,7 @@ function SidebarNewUsers() {
 
 /** Logged-in rail: trending communities (legacy SidebarLinks). */
 function SidebarLinks() {
+  const t = useTranslations();
   const [topics, setTopics] = useState<CommunitySubscription[]>([]);
 
   useEffect(() => {
@@ -77,7 +80,7 @@ function SidebarLinks() {
   return (
     <SidebarModule>
       <ul>
-        <li className="py-1 text-[#aaa]">Trending communities</li>
+        <li className="py-1 text-[#aaa]">{t("g.trending_communities")}</li>
         {topics.map((c) => (
           <li key={c.name} className="py-1">
             <Link
@@ -95,6 +98,7 @@ function SidebarLinks() {
 
 /** Community info panel for /(sort)/hive-* pages (legacy CommunityPane). */
 function CommunityPane({ community }: { community: string }) {
+  const t = useTranslations();
   const username = useAppSelector((s) => s.user.current?.username);
   const [info, setInfo] = useState<CommunitySubscription | null>(null);
 
@@ -120,7 +124,10 @@ function CommunityPane({ community }: { community: string }) {
         <p className="mb-2 text-sm text-muted-foreground">{info.about}</p>
       )}
       <p className="mb-3 text-sm text-muted-foreground">
-        {info.subscribers} subscribers &bull; {info.num_authors} active posters
+        {t("sidebar.community_stats", {
+          subscribers: info.subscribers ?? 0,
+          posters: info.num_authors ?? 0,
+        })}
       </p>
       <SubscribeButton
         community={info.name}

--- a/components/layout/MobileTabBar.tsx
+++ b/components/layout/MobileTabBar.tsx
@@ -2,6 +2,7 @@
 
 import { usePathname, useRouter } from "next/navigation";
 import { BookMarkedIcon, UserRoundIcon, WalletIcon } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 import { getSteemitWalletBaseUrl } from "@/lib/steemitWallet";
 import { useAppDispatch, useAppSelector } from "@/store/hooks";
@@ -18,20 +19,21 @@ export function MobileTabBar() {
   const pathname = usePathname();
   const router = useRouter();
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const username = useAppSelector((s) => s.user.current?.username);
   const walletBase = getSteemitWalletBaseUrl();
 
   const tabs = [
     {
       key: "explore",
-      label: "Explore",
+      label: t("g.explore"),
       icon: BookMarkedIcon,
       active: !pathname?.startsWith("/@"),
       onClick: () => router.push("/trending"),
     },
     {
       key: "profile",
-      label: "My Profile",
+      label: t("g.my_profile"),
       icon: UserRoundIcon,
       active: Boolean(username && pathname?.startsWith(`/@${username}`)),
       onClick: () => {
@@ -44,7 +46,7 @@ export function MobileTabBar() {
     },
     {
       key: "wallet",
-      label: "My Wallet",
+      label: t("g.my_wallet"),
       icon: WalletIcon,
       active: false,
       onClick: () => {
@@ -60,7 +62,7 @@ export function MobileTabBar() {
   return (
     <nav
       className="PrimaryNavigation fixed inset-x-0 bottom-0 z-[100] block min-[760px]:hidden"
-      aria-label="Primary navigation"
+      aria-label={t("navigation.primary_navigation")}
     >
       {/* pb-[env(safe-area-inset-bottom)] lifts the bar above the phone's
           home-indicator / gesture area, which otherwise covers the labels. */}

--- a/components/layout/PrimaryNavigation.tsx
+++ b/components/layout/PrimaryNavigation.tsx
@@ -8,6 +8,7 @@ import {
   UserRoundIcon,
   WalletIcon,
 } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 import { cn } from "@/lib/utils";
 import { getSteemitWalletBaseUrl } from "@/lib/steemitWallet";
@@ -28,15 +29,16 @@ const GLOBAL_FEED_SORTS = new Set([
  * Second-level items under "My Profile" (legacy ProfileNavigation).
  * Settings is intentionally not in the sidebar; Feed is omitted because it
  * duplicates Explore → My Friends (/@{me}/feed).
+ * labelKey is a next-intl message key resolved with useTranslations().
  */
-const MY_PROFILE_SECTIONS: { segment: string; label: string }[] = [
-  { segment: "blog", label: "Blog" },
-  { segment: "posts", label: "Posts" },
-  { segment: "comments", label: "Comments" },
-  { segment: "replies", label: "Replies" },
-  { segment: "notifications", label: "Notifications" },
-  { segment: "communities", label: "Subscriptions" },
-  { segment: "payout", label: "Payouts" },
+const MY_PROFILE_SECTIONS: { segment: string; labelKey: string }[] = [
+  { segment: "blog", labelKey: "g.blog" },
+  { segment: "posts", labelKey: "g.posts" },
+  { segment: "comments", labelKey: "g.comments" },
+  { segment: "replies", labelKey: "g.replies" },
+  { segment: "notifications", labelKey: "g.notifications" },
+  { segment: "communities", labelKey: "g.subscriptions" },
+  { segment: "payout", labelKey: "g.payouts" },
 ];
 
 function profileSectionHref(username: string, segment: string) {
@@ -246,6 +248,7 @@ function NavGroup({
 
 export function PrimaryNavigation({ pathname }: { pathname: string }) {
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const sessionUser = useAppSelector((s) => s.user.current?.username);
   const walletBase = getSteemitWalletBaseUrl();
 
@@ -288,14 +291,14 @@ export function PrimaryNavigation({ pathname }: { pathname: string }) {
     // menu); one's own feed lives under Explore > My Friends instead.
     const sections =
       viewedUser && !isOwnProfile
-        ? [...MY_PROFILE_SECTIONS, { segment: "feed", label: "Friends Feed" }]
+        ? [...MY_PROFILE_SECTIONS, { segment: "feed", labelKey: "g.friends_feed" }]
         : MY_PROFILE_SECTIONS;
-    return sections.map(({ segment, label }) => ({
-      label,
+    return sections.map(({ segment, labelKey }) => ({
+      label: t(labelKey),
       href: profileSectionHref(user, segment),
       active: isProfileSectionActive(effectiveUrl, user, segment),
     }));
-  }, [profileGroupUser, viewedUser, isOwnProfile, effectiveUrl]);
+  }, [profileGroupUser, viewedUser, isOwnProfile, effectiveUrl, t]);
 
   const profileGroupActive = profileSections.some((s) => s.active);
 
@@ -333,31 +336,31 @@ export function PrimaryNavigation({ pathname }: { pathname: string }) {
     <nav
       id="appNavigation"
       className="App__navigation flex flex-col gap-5 text-sm"
-      aria-label="Primary navigation"
+      aria-label={t("navigation.primary_navigation")}
     >
       <NavGroup
-        label="Explore"
+        label={t("g.explore")}
         icon={CompassIcon}
         active={exploreActive}
         expanded={expanded === "explore"}
         onToggle={() => toggleGroup("explore")}
       >
-        <NavSubItem href="/trending" label="All Posts" active={allPostsActive} />
+        <NavSubItem href="/trending" label={t("g.posts_all")} active={allPostsActive} />
         <NavSubItem
           href="/communities"
-          label="Communities"
+          label={t("g.communities")}
           active={communitiesActive}
         />
         {sessionUser ? (
           <>
             <NavSubItem
               href={`/@${sessionUser}/feed`}
-              label="My Friends"
+              label={t("g.my_friends")}
               active={myFriendsActive}
             />
             <NavSubItem
               href="/trending/my"
-              label="My Subscriptions"
+              label={t("g.my_subscriptions")}
               active={mySubsActive}
             />
           </>
@@ -365,14 +368,14 @@ export function PrimaryNavigation({ pathname }: { pathname: string }) {
           <>
             <NavSubItem
               href=""
-              label="My Friends"
+              label={t("g.my_friends")}
               active={false}
               useLoginPrompt
               onLoginPrompt={loginPrompt}
             />
             <NavSubItem
               href=""
-              label="My Subscriptions"
+              label={t("g.my_subscriptions")}
               active={false}
               useLoginPrompt
               onLoginPrompt={loginPrompt}
@@ -383,7 +386,7 @@ export function PrimaryNavigation({ pathname }: { pathname: string }) {
 
       {profileGroupUser ? (
         <NavGroup
-          label={viewedUser && !isOwnProfile ? `@${profileGroupUser}` : "My Profile"}
+          label={viewedUser && !isOwnProfile ? `@${profileGroupUser}` : t("g.my_profile")}
           icon={UserRoundIcon}
           active={profileGroupActive}
           expanded={expanded === "profile"}
@@ -400,7 +403,7 @@ export function PrimaryNavigation({ pathname }: { pathname: string }) {
           className={pillClass(false, "font-bold")}
         >
           <UserRoundIcon className="size-[1.15rem] shrink-0" aria-hidden />
-          <span className="flex-1 text-left">My Profile</span>
+          <span className="flex-1 text-left">{t("g.my_profile")}</span>
         </button>
       )}
 
@@ -412,12 +415,12 @@ export function PrimaryNavigation({ pathname }: { pathname: string }) {
           className={pillClass(false, "font-bold")}
         >
           <WalletIcon className="size-[1.15rem] shrink-0" aria-hidden />
-          <span className="flex-1 text-left">My Wallet</span>
+          <span className="flex-1 text-left">{t("g.my_wallet")}</span>
         </a>
       ) : (
         <button type="button" onClick={loginPrompt} className={pillClass(false, "font-bold")}>
           <WalletIcon className="size-[1.15rem] shrink-0" aria-hidden />
-          <span className="flex-1 text-left">My Wallet</span>
+          <span className="flex-1 text-left">{t("g.my_wallet")}</span>
         </button>
       )}
     </nav>

--- a/components/layout/SidePanel.tsx
+++ b/components/layout/SidePanel.tsx
@@ -2,6 +2,7 @@
 
 import Link from "next/link";
 import { ExternalLink } from "lucide-react";
+import { useTranslations } from "next-intl";
 
 import {
   Sheet,
@@ -35,6 +36,7 @@ const linkClass =
  */
 export function SidePanel({ children }: { children: React.ReactNode }) {
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const username = useAppSelector((s) => s.user.current?.username);
   const loggedIn = Boolean(username);
   const nightmode = useAppSelector((s) => s.app.user_preferences.nightmode);
@@ -56,8 +58,8 @@ export function SidePanel({ children }: { children: React.ReactNode }) {
       key: "extras",
       hidden: loggedIn,
       items: [
-        { label: "Sign in", onClick: () => dispatch(showLogin({})) },
-        { label: "Sign up", link: signupUrl, external: true },
+        { label: t("g.sign_in"), onClick: () => dispatch(showLogin({})) },
+        { label: t("g.sign_up"), link: signupUrl, external: true },
       ],
     },
     {
@@ -66,11 +68,12 @@ export function SidePanel({ children }: { children: React.ReactNode }) {
       items: [
         // The rewrite does not host /welcome; point at the legacy site for
         // now (same treatment as faq/privacy/tos below).
-        { label: "Welcome", link: "https://steemit.com/welcome", external: true },
-        // Legacy's language switcher is not ported (no i18n in the rewrite).
-        { label: "FAQ", link: "https://steemit.com/faq.html", external: true },
+        { label: t("navigation.welcome"), link: "https://steemit.com/welcome", external: true },
+        // Legacy's language switcher is superseded by the locale selector in
+        // UserSettings (next-intl bridge), so it is not in this drawer.
+        { label: t("navigation.faq"), link: "https://steemit.com/faq.html", external: true },
         {
-          label: nightmode ? "Toggle day mode" : "Toggle night mode",
+          label: nightmode ? t("g.toggle_daymode") : t("g.toggle_nightmode"),
           onClick: () => dispatch(toggleNightmode()),
         },
       ],
@@ -80,22 +83,22 @@ export function SidePanel({ children }: { children: React.ReactNode }) {
       mt: "always",
       items: [
         {
-          label: "Stolen Account Recovery",
+          label: t("navigation.stolen_account_recovery"),
           link: `${walletBase}/recover_account_step_1`,
           external: true,
         },
         {
-          label: "Change Account Password",
+          label: t("navigation.change_account_password"),
           link: `${walletBase}/change_password`,
           external: true,
         },
         {
-          label: "Vote for Witnesses",
+          label: t("navigation.vote_for_witnesses"),
           link: `${walletBase}/~witnesses`,
           external: true,
         },
         {
-          label: "Steem Proposals",
+          label: t("navigation.steem_proposals"),
           link: `${walletBase}/proposals`,
           external: true,
         },
@@ -104,7 +107,7 @@ export function SidePanel({ children }: { children: React.ReactNode }) {
     {
       key: "exchanges",
       mt: "always",
-      section: "Third Party Exchanges",
+      section: t("navigation.third_party_exchanges"),
       items: [
         {
           label: "Poloniex",
@@ -118,12 +121,12 @@ export function SidePanel({ children }: { children: React.ReactNode }) {
       mt: "always",
       items: [
         {
-          label: "Advertise",
+          label: t("navigation.advertise"),
           link: "https://selfserve.steemit.com",
           external: true,
         },
         {
-          label: "Jobs",
+          label: t("navigation.jobs"),
           link: "https://recruiting.paylocity.com/recruiting/jobs/List/3288/Steemit-Inc",
           external: true,
         },
@@ -134,18 +137,18 @@ export function SidePanel({ children }: { children: React.ReactNode }) {
       mt: "always",
       items: [
         {
-          label: "API Docs",
+          label: t("navigation.api_docs"),
           link: "https://developers.steem.io/",
           external: true,
         },
         {
-          label: "Bluepaper",
+          label: t("navigation.bluepaper"),
           link: "https://steem.io/steem-bluepaper.pdf",
           external: true,
         },
-        { label: "SMT Whitepaper", link: "https://smt.steem.io/", external: true },
+        { label: t("navigation.smt_whitepaper"), link: "https://smt.steem.io/", external: true },
         {
-          label: "Whitepaper",
+          label: t("navigation.whitepaper"),
           link: "https://steem.com/SteemWhitePaper.pdf",
           external: true,
         },
@@ -156,12 +159,12 @@ export function SidePanel({ children }: { children: React.ReactNode }) {
       mt: "always",
       items: [
         {
-          label: "Privacy Policy",
+          label: t("navigation.privacy_policy"),
           link: "https://steemit.com/privacy.html",
           external: true,
         },
         {
-          label: "Terms of Service",
+          label: t("navigation.terms_of_service"),
           link: "https://steemit.com/tos.html",
           external: true,
         },
@@ -179,10 +182,10 @@ export function SidePanel({ children }: { children: React.ReactNode }) {
         showCloseButton={false}
         className="w-[250px] gap-0 overflow-y-auto border-none bg-[#11161A] p-0 pt-12 text-white"
       >
-        <SheetTitle className="sr-only">Menu</SheetTitle>
+        <SheetTitle className="sr-only">{t("navigation.menu")}</SheetTitle>
         {/* legacy CloseButton: sits in the 3rem top padding, own row */}
         <SheetClose
-          aria-label="Close menu"
+          aria-label={t("navigation.close_menu")}
           className="absolute right-4 top-2 text-[2rem] leading-none text-white transition-colors hover:text-[#06D6A9]"
         >
           ×

--- a/components/modules/GlobalModals.tsx
+++ b/components/modules/GlobalModals.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useTranslations } from "next-intl";
+
 import LoginForm from "@/components/modules/LoginForm";
 import {
   Dialog,
@@ -16,6 +18,7 @@ import { hideLogin } from "@/store/slices/userSlice";
  */
 export function GlobalModals() {
   const dispatch = useAppDispatch();
+  const t = useTranslations();
   const open = useAppSelector((s) => s.user.show_login_modal);
 
   return (
@@ -27,7 +30,7 @@ export function GlobalModals() {
     >
       <DialogContent showCloseButton>
         <DialogHeader>
-          <DialogTitle>Login</DialogTitle>
+          <DialogTitle>{t("g.login")}</DialogTitle>
         </DialogHeader>
         <LoginForm embedded />
       </DialogContent>

--- a/components/modules/LoginForm.tsx
+++ b/components/modules/LoginForm.tsx
@@ -108,12 +108,12 @@ export default function LoginForm({ embedded = false }: { embedded?: boolean }) 
       // Step 1: Get account info to retrieve posting public key
       const accountResponse = await fetch(`/api/steem/account?username=${encodeURIComponent(normalizedUsername)}`);
       if (!accountResponse.ok) {
-        throw new Error('Account not found');
+        throw new Error(t('g.account_not_found'));
       }
       const account = await accountResponse.json();
-      
+
       if (!account || !account.posting || !account.posting.key_auths || account.posting.key_auths.length === 0) {
-        throw new Error('Invalid account or posting authority not found');
+        throw new Error(t('loginform_jsx.invalid_account_or_no_posting_authority'));
       }
 
       // Get the posting public key (first key in posting authority)
@@ -122,20 +122,20 @@ export default function LoginForm({ embedded = false }: { embedded?: boolean }) 
       // Step 2: Validate that input is a WIF format private key
       const privateKeyWif = password.trim();
       if (!isWifFormat(privateKeyWif)) {
-        throw new Error('Invalid format. Only posting private keys in WIF format are allowed.');
+        throw new Error(t('loginform_jsx.invalid_wif_format'));
       }
 
       // Step 3: Validate private key matches posting public key
       setValidatingKey(true);
       const validation = validatePostingKey(privateKeyWif, postingPublicKey);
       if (!validation.isValid) {
-        throw new Error(validation.error || 'Invalid posting key');
+        throw new Error(validation.error || t('loginform_jsx.invalid_posting_key'));
       }
 
       // Step 4: Get login challenge from server
       const challengeResponse = await fetch('/api/auth/challenge');
       if (!challengeResponse.ok) {
-        throw new Error('Failed to get login challenge');
+        throw new Error(t('loginform_jsx.failed_to_get_challenge'));
       }
       const { challenge } = await challengeResponse.json();
 
@@ -159,7 +159,7 @@ export default function LoginForm({ embedded = false }: { embedded?: boolean }) 
 
       if (!loginResponse.ok) {
         const errorData = await loginResponse.json();
-        throw new Error(errorData.error || 'Login failed');
+        throw new Error(errorData.error || t('loginform_jsx.login_failed'));
       }
 
       await loginResponse.json();
@@ -200,7 +200,7 @@ export default function LoginForm({ embedded = false }: { embedded?: boolean }) 
       }
     } catch (err: unknown) {
       console.error('Login error:', err);
-      const errorMessage = err instanceof Error ? err.message : 'Login failed. Please try again.';
+      const errorMessage = err instanceof Error ? err.message : t('loginform_jsx.login_failed_try_again');
       setError(errorMessage);
       dispatch(loginError({ error: errorMessage }));
     } finally {

--- a/components/modules/UserSettings.tsx
+++ b/components/modules/UserSettings.tsx
@@ -109,35 +109,35 @@ export default function UserSettings({
     const newErrors: Record<string, string> = {};
 
     if (formData.profile_image && !/^https?:\/\//.test(formData.profile_image)) {
-      newErrors.profile_image = 'Profile image must be a valid URL';
+      newErrors.profile_image = t('settings_jsx.profile_image_invalid_url');
     }
 
     if (formData.cover_image && !/^https?:\/\//.test(formData.cover_image)) {
-      newErrors.cover_image = 'Cover image must be a valid URL';
+      newErrors.cover_image = t('settings_jsx.cover_image_invalid_url');
     }
 
     if (formData.name && formData.name.length > 20) {
-      newErrors.name = 'Name is too long (max 20 characters)';
+      newErrors.name = t('settings_jsx.name_too_long', { max: 20 });
     }
 
     if (formData.name && /^\s*@/.test(formData.name)) {
-      newErrors.name = 'Name must not begin with @';
+      newErrors.name = t('settings_jsx.name_must_not_begin_with');
     }
 
     if (formData.about && formData.about.length > 160) {
-      newErrors.about = 'About is too long (max 160 characters)';
+      newErrors.about = t('settings_jsx.about_too_long', { max: 160 });
     }
 
     if (formData.location && formData.location.length > 30) {
-      newErrors.location = 'Location is too long (max 30 characters)';
+      newErrors.location = t('settings_jsx.location_too_long', { max: 30 });
     }
 
     if (formData.website && formData.website.length > 100) {
-      newErrors.website = 'Website URL is too long (max 100 characters)';
+      newErrors.website = t('settings_jsx.website_too_long', { max: 100 });
     }
 
     if (formData.website && formData.website && !/^https?:\/\//.test(formData.website)) {
-      newErrors.website = 'Website must be a valid URL';
+      newErrors.website = t('settings_jsx.website_invalid_url');
     }
 
     return newErrors;
@@ -194,14 +194,14 @@ export default function UserSettings({
       // Legacy update_account tracking.
       userActionRecord('update_account', { username: accountname });
 
-      setSuccessMessage('Profile updated successfully!');
+      setSuccessMessage(t('settings_jsx.profile_updated'));
 
       if (onProfileUpdate) {
         onProfileUpdate(profileData);
       }
     } catch (error) {
       console.error('Error updating profile:', error);
-      setErrors({ general: 'Failed to update profile. Please try again.' });
+      setErrors({ general: t('settings_jsx.update_failed') });
     } finally {
       setSubmitting(false);
     }
@@ -213,7 +213,7 @@ export default function UserSettings({
   if (!canEdit) {
     return (
       <div className="bg-yellow-50 border border-yellow-200 rounded-lg p-4">
-        <p className="text-yellow-800">You can only edit your own profile settings.</p>
+        <p className="text-yellow-800">{t('settings_jsx.only_own_profile')}</p>
       </div>
     );
   }
@@ -221,7 +221,7 @@ export default function UserSettings({
   return (
     <div className="space-y-8">
       <div>
-        <h2 className="text-2xl font-bold mb-6">Account Settings</h2>
+        <h2 className="text-2xl font-bold mb-6">{t('settings_jsx.account_settings')}</h2>
         
         {/* Success message */}
         {successMessage && (
@@ -241,7 +241,7 @@ export default function UserSettings({
           {/* Profile Image */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
-              Profile Image URL
+              {t('settings_jsx.profile_image_url')}
             </label>
             <input
               type="url"
@@ -250,7 +250,7 @@ export default function UserSettings({
               className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#06D6A9] ${
                 errors.profile_image ? 'border-red-500' : 'border-gray-300'
               }`}
-              placeholder="https://example.com/image.jpg"
+              placeholder={t('settings_jsx.profile_image_placeholder')}
             />
             {errors.profile_image && (
               <p className="mt-1 text-sm text-red-600">{errors.profile_image}</p>
@@ -260,7 +260,7 @@ export default function UserSettings({
           {/* Cover Image */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
-              Cover Image URL
+              {t('settings_jsx.cover_image_url')}
             </label>
             <input
               type="url"
@@ -269,7 +269,7 @@ export default function UserSettings({
               className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#06D6A9] ${
                 errors.cover_image ? 'border-red-500' : 'border-gray-300'
               }`}
-              placeholder="https://example.com/cover.jpg"
+              placeholder={t('settings_jsx.cover_image_placeholder')}
             />
             {errors.cover_image && (
               <p className="mt-1 text-sm text-red-600">{errors.cover_image}</p>
@@ -279,7 +279,7 @@ export default function UserSettings({
           {/* Display Name */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
-              Display Name
+              {t('settings_jsx.profile_name')}
             </label>
             <input
               type="text"
@@ -288,21 +288,21 @@ export default function UserSettings({
               className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#06D6A9] ${
                 errors.name ? 'border-red-500' : 'border-gray-300'
               }`}
-              placeholder="Your display name"
+              placeholder={t('settings_jsx.display_name_placeholder')}
               maxLength={20}
             />
             {errors.name && (
               <p className="mt-1 text-sm text-red-600">{errors.name}</p>
             )}
             <p className="mt-1 text-sm text-gray-500">
-              {(formData.name ?? '').length}/20 characters
+              {t('settings_jsx.characters_used', { count: (formData.name ?? '').length, max: 20 })}
             </p>
           </div>
 
           {/* About */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
-              About
+              {t('settings_jsx.profile_about')}
             </label>
             <textarea
               value={formData.about}
@@ -310,7 +310,7 @@ export default function UserSettings({
               className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#06D6A9] ${
                 errors.about ? 'border-red-500' : 'border-gray-300'
               }`}
-              placeholder="Tell us about yourself..."
+              placeholder={t('settings_jsx.about_placeholder')}
               rows={3}
               maxLength={160}
             />
@@ -318,14 +318,14 @@ export default function UserSettings({
               <p className="mt-1 text-sm text-red-600">{errors.about}</p>
             )}
             <p className="mt-1 text-sm text-gray-500">
-              {(formData.about ?? '').length}/160 characters
+              {t('settings_jsx.characters_used', { count: (formData.about ?? '').length, max: 160 })}
             </p>
           </div>
 
           {/* Location */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
-              Location
+              {t('settings_jsx.profile_location')}
             </label>
             <input
               type="text"
@@ -334,21 +334,21 @@ export default function UserSettings({
               className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#06D6A9] ${
                 errors.location ? 'border-red-500' : 'border-gray-300'
               }`}
-              placeholder="Your location"
+              placeholder={t('settings_jsx.location_placeholder')}
               maxLength={30}
             />
             {errors.location && (
               <p className="mt-1 text-sm text-red-600">{errors.location}</p>
             )}
             <p className="mt-1 text-sm text-gray-500">
-              {(formData.location ?? '').length}/30 characters
+              {t('settings_jsx.characters_used', { count: (formData.location ?? '').length, max: 30 })}
             </p>
           </div>
 
           {/* Website */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
-              Website
+              {t('settings_jsx.profile_website')}
             </label>
             <input
               type="url"
@@ -357,14 +357,14 @@ export default function UserSettings({
               className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#06D6A9] ${
                 errors.website ? 'border-red-500' : 'border-gray-300'
               }`}
-              placeholder="https://yourwebsite.com"
+              placeholder={t('settings_jsx.website_placeholder')}
               maxLength={100}
             />
             {errors.website && (
               <p className="mt-1 text-sm text-red-600">{errors.website}</p>
             )}
             <p className="mt-1 text-sm text-gray-500">
-              {(formData.website ?? '').length}/100 characters
+              {t('settings_jsx.characters_used', { count: (formData.website ?? '').length, max: 100 })}
             </p>
           </div>
 
@@ -375,7 +375,7 @@ export default function UserSettings({
               disabled={submitting}
               className="px-6 py-2 bg-[#06D6A9] text-white rounded-lg hover:opacity-90 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
             >
-              {submitting ? 'Updating...' : 'Update Profile'}
+              {submitting ? t('settings_jsx.updating') : t('settings_jsx.update_profile')}
             </button>
           </div>
         </form>
@@ -383,22 +383,22 @@ export default function UserSettings({
 
       {/* Preferences Section */}
       <div className="border-t pt-8">
-        <h3 className="text-xl font-semibold mb-4">Preferences</h3>
+        <h3 className="text-xl font-semibold mb-4">{t('settings_jsx.preferences')}</h3>
         
         <div className="space-y-4">
           {/* NSFW Content */}
           <div>
             <label className="block text-sm font-medium text-gray-700 mb-2">
-              NSFW Content
+              {t('settings_jsx.not_safe_for_work_nsfw_content')}
             </label>
             <select
               value={nsfwPref}
               onChange={(e) => setNsfwPref(e.target.value)}
               className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-[#06D6A9]"
             >
-              <option value="hide">Hide NSFW content</option>
-              <option value="warn">Warn before showing NSFW content</option>
-              <option value="show">Always show NSFW content</option>
+              <option value="hide">{t('settings_jsx.always_hide')}</option>
+              <option value="warn">{t('settings_jsx.always_warn')}</option>
+              <option value="show">{t('settings_jsx.always_show')}</option>
             </select>
           </div>
 
@@ -430,7 +430,7 @@ export default function UserSettings({
               console.log('Saving preferences:', { nsfwPref });
             }}
           >
-            Save Preferences
+            {t('settings_jsx.save_preferences')}
           </button>
         </div>
       </div>

--- a/messages/en.json
+++ b/messages/en.json
@@ -328,7 +328,12 @@
     "many_followers": "%(count)s Followers",
     "many_posts": "%(count)s Posts",
     "search_history": "History",
-    "announcement": "Announcements"
+    "announcement": "Announcements",
+    "untitled": "Untitled",
+    "scroll_to_top": "Scroll to top",
+    "pagination": "Pagination",
+    "submit_search": "Submit search",
+    "welcome_guide": "Welcome Guide"
   },
   "navigation": {
     "about": "About Steemit, Inc.",
@@ -359,7 +364,11 @@
     "intro_tagline": "Your voice is worth something",
     "intro_paragraph": "Get paid for good content. Post and upvote articles on Steemit to get your share of the daily rewards pool.",
     "jobs": "Jobs at Steemit",
-    "steem_proposals": "Steem Proposals"
+    "steem_proposals": "Steem Proposals",
+    "primary_navigation": "Primary navigation",
+    "menu": "Menu",
+    "close_menu": "Close menu",
+    "breadcrumb": "Breadcrumb"
   },
   "main_menu": {
     "hot": "Hot",
@@ -442,17 +451,19 @@
     "in_week_convert_DEBT_TOKEN_to_LIQUID_TOKEN": "In 3.5 days, convert %(amount)s %(DEBT_TOKEN)s into %(LIQUID_TOKEN)s",
     "view_the_full_context": "View the full context",
     "view_the_direct_parent": "View the direct parent",
-    "you_are_viewing_a_single_comments_thread_from": "You are viewing a single comment's thread from"
+    "you_are_viewing_a_single_comments_thread_from": "You are viewing a single comment's thread from",
+    "post_not_found": "Post not found",
+    "failed_to_load": "Failed to load post or comments"
   },
   "recoveraccountstep1_jsx": {
     "recover_account_intro": "From time to time, a Steemian's owner key may be compromised. Stolen Account Recovery gives the rightful account owner 30 days to recover their account from the moment the thief changed their owner key. Stolen Account Recovery can only be used on %(APP_URL)s if the account owner had previously listed '%(APP_NAME)s' as their account trustee and complied with %(APP_NAME)s's Terms of Service."
   },
   "user_profile": {
     "unknown_account": "Unknown Account",
-    "user_hasnt_made_any_posts_yet": "Looks like %(name)s hasn't made any posts yet!",
+    "user_hasnt_made_any_posts_yet": "{name} hasn't made any posts yet.",
     "user_hasnt_started_bloggin_yet": "Looks like %(name)s hasn't started blogging yet!",
     "user_hasnt_followed_anything_yet": "Looks like %(name)s might not be following anyone yet! If %(name)s recently added new users to follow, their personalized feed will populate once new content is available.",
-    "user_hasnt_had_any_replies_yet": "%(name)s hasn't had any replies yet",
+    "user_hasnt_had_any_replies_yet": "{name} hasn't had any replies yet.",
     "user_hasnt_had_any_notifications_yet": "%(name)s hasn't had any notifications yet",
     "looks_like_you_havent_posted_anything_yet": "Looks like you haven't posted anything yet.",
     "create_a_post": "Create a Post",
@@ -477,7 +488,23 @@
       "other": "%(count)s posts"
     },
     "hide_resteems": "Hide Resteems",
-    "show_all": "Show All"
+    "show_all": "Show All",
+    "reputation_title": "This is {name}'s reputation score. It is based on the history of votes.",
+    "blacklisted_on": "Blacklisted on: {list}",
+    "followers_label": "{count, plural, one {follower} other {followers}}",
+    "posts_label": "{count, plural, one {post} other {posts}}",
+    "following_label": "following",
+    "joined_date": "Joined {date}",
+    "loading_profile": "Loading profile...",
+    "user_not_found": "User not found",
+    "only_view_own_settings": "You can only view your own settings.",
+    "following": "Following",
+    "no_friends_feed": "You haven't followed anyone yet!",
+    "explore_trending": "Explore Trending",
+    "new_users_guide": "New users guide",
+    "user_hasnt_made_any_comments_yet": "{name} hasn't made any comments yet.",
+    "no_pending_payouts": "No pending payouts.",
+    "user_hasnt_posted_anything_yet": "{name} hasn't posted anything yet."
   },
   "post_jsx": {
     "now_showing_comments_with_low_ratings": "Now showing comments with low ratings",
@@ -510,14 +537,25 @@
     "changing_to_a_downvote": "Changing to a Down-Vote",
     "changing_to_a_downvote_will_reset_curation_rewards_for_this_post": "Changing to a Down-Vote will reset your curation rewards for this post",
     "confirm_flag": "Confirm Flag",
-    "and_more": "and %(count)s more",
+    "and_more": "and {count} more",
     "votes_plural": {
       "one": "%(count)s vote",
       "other": "%(count)s votes"
     },
     "must_reached_minimum_payout": "(amount must reach $0.02 for payout)",
     "payout": "Payout",
-    "breakdown": "Breakdown"
+    "breakdown": "Breakdown",
+    "vote_weight": "Vote weight",
+    "downvote_weight": "Downvote weight",
+    "vote_percent": "Vote {percent}%",
+    "downvote_percent": "Downvote {percent}%",
+    "payout_details": "Payout details",
+    "pending_payout_amount": "Pending Payout {value}",
+    "payout_date": "Payout Date {date}",
+    "author_payout": "Author Payout {value}",
+    "curator_payout": "Curator Payout {value}",
+    "voters": "Voters",
+    "vote_count": "{count, plural, one {# vote} other {# votes}}"
   },
   "votesandcomments_jsx": {
     "no_responses_yet_click_to_respond": "No responses yet. Click to respond.",
@@ -576,7 +614,8 @@
     "resources": "Resources"
   },
   "markdownviewer_jsx": {
-    "images_were_hidden_due_to_low_ratings": "Images were hidden due to low ratings."
+    "images_were_hidden_due_to_low_ratings": "Images were hidden due to low ratings.",
+    "embedded_video_title": "{provider} video {id}"
   },
   "postsummary_jsx": {
     "resteemed": "resteemed",
@@ -585,7 +624,8 @@
     "adjust_your": "adjust your",
     "display_preferences": "display preferences",
     "create_an_account": "create an account",
-    "to_save_your_preferences": "to save your preferences"
+    "to_save_your_preferences": "to save your preferences",
+    "this_post_is_nsfw": "This post is"
   },
   "posts_index": {
     "empty_feed_1": "Looks like you haven't followed anything yet",
@@ -599,7 +639,8 @@
     "no_muted_posts": "No muted posts found.",
     "no_followed_posts": "You haven't followed anyone yet! Explore Trending to find people to follow.",
     "no_posts_in_tag": "No posts in #{tag} yet!",
-    "no_posts_found": "No posts found."
+    "no_posts_found": "No posts found.",
+    "unmoderated_tag": "Unmoderated tag"
   },
   "explorepost_jsx": {
     "copied": "Copied Successfully",
@@ -670,7 +711,12 @@
     "wif_required": "Posting private key (WIF) is required",
     "invalid_wif_format": "Invalid format. Please enter your posting private key in WIF format (starts with 5...)",
     "validating_key": "Validating posting private key...",
-    "logging_in": "Logging in..."
+    "logging_in": "Logging in...",
+    "invalid_account_or_no_posting_authority": "Invalid account or posting authority not found",
+    "invalid_posting_key": "Invalid posting key",
+    "failed_to_get_challenge": "Failed to get login challenge",
+    "login_failed": "Login failed",
+    "login_failed_try_again": "Login failed. Please try again."
   },
   "chainvalidation_js": {
     "account_name_should_not_be_empty": "Account name should not be empty.",
@@ -707,8 +753,8 @@
     "upload_error_image": "Please insert only image files.",
     "upload_image": "Upload an image",
     "uploading_image": "Uploading image",
-    "profile_image_url": "Profile picture url",
-    "cover_image_url": "Cover image url",
+    "profile_image_url": "Profile Image URL",
+    "cover_image_url": "Cover Image URL",
     "profile_name": "Display Name",
     "profile_about": "About",
     "profile_location": "Location",
@@ -716,7 +762,28 @@
     "saved": "Saved!",
     "rpc_title": "RPC Node List",
     "rpc_select": "Select RPC Node",
-    "selected_rpc": "Selected RPC Node : %(rpc)s"
+    "selected_rpc": "Selected RPC Node : %(rpc)s",
+    "account_settings": "Account Settings",
+    "only_own_profile": "You can only edit your own profile settings.",
+    "profile_updated": "Profile updated successfully!",
+    "update_failed": "Failed to update profile. Please try again.",
+    "profile_image_placeholder": "https://example.com/image.jpg",
+    "cover_image_placeholder": "https://example.com/cover.jpg",
+    "display_name_placeholder": "Your display name",
+    "about_placeholder": "Tell us about yourself...",
+    "location_placeholder": "Your location",
+    "website_placeholder": "https://yourwebsite.com",
+    "characters_used": "{count}/{max} characters",
+    "profile_image_invalid_url": "Profile image must be a valid URL",
+    "cover_image_invalid_url": "Cover image must be a valid URL",
+    "website_invalid_url": "Website must be a valid URL",
+    "name_too_long": "Name is too long (max {max} characters)",
+    "about_too_long": "About is too long (max {max} characters)",
+    "location_too_long": "Location is too long (max {max} characters)",
+    "website_too_long": "Website URL is too long (max {max} characters)",
+    "update_profile": "Update Profile",
+    "updating": "Updating...",
+    "save_preferences": "Save Preferences"
   },
   "transfer_jsx": {
     "amount_is_in_form": "Amount is in the form 99999.999",
@@ -804,7 +871,13 @@
     "follows": "Follows",
     "resteems": "Resteems",
     "upvotes": "Upvotes",
-    "mentions": "Mentions"
+    "mentions": "Mentions",
+    "marking": "Marking...",
+    "mark_as_read_error": "Failed to mark notifications as read. Please try again.",
+    "empty": "Welcome! You don't have any notifications yet.",
+    "unread": "Unread",
+    "unread_notifications": "{count, plural, one {# unread notification} other {# unread notifications}}",
+    "failed_to_load": "Failed to load notifications"
   },
   "user_roles": {
     "role_permissions": "Role Permissions",
@@ -822,10 +895,84 @@
     "muted_description": "new posts automatically muted",
     "invalid_username": "Please enter a valid username.",
     "invalid_character": "Please enter a username without \"@\".",
-    "invalid_role": "The user already has that role."
+    "invalid_role": "The user already has that role.",
+    "loading_community_data": "Loading community data...",
+    "community_management": "Community Management",
+    "roles_and_members": "Roles & Members",
+    "subscribers": "Subscribers",
+    "no_roles": "No roles found for this community.",
+    "no_subscribers": "No subscribers found for this community.",
+    "view_profile": "View profile"
   },
   "comments": {
     "no_comments_yet": "No comments yet. Be the first to comment!",
-    "load_more_comments": "LOAD MORE COMMENTS"
+    "load_more_comments": "LOAD MORE COMMENTS",
+    "confirm_delete": "Are you sure you want to delete this comment?",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "reply_count": "{count, plural, one {# reply} other {# replies}}",
+    "show_more_replies": "Show {count, plural, one {# more reply} other {# more replies}}",
+    "delete_failed": "Failed to delete the comment. Please try again."
+  },
+  "sidebar": {
+    "new_to_steemit": "New to Steemit?",
+    "community_stats": "{subscribers, plural, one {# subscriber} other {# subscribers}} • {posters, plural, one {# active poster} other {# active posters}}",
+    "coin_marketplace": "Coin Marketplace"
+  },
+  "time_ago": {
+    "just_now": "just now",
+    "minutes": "{count, plural, one {# minute ago} other {# minutes ago}}",
+    "hours": "{count, plural, one {# hour ago} other {# hours ago}}",
+    "days": "{count, plural, one {# day ago} other {# days ago}}",
+    "weeks": "{count, plural, one {# week ago} other {# weeks ago}}",
+    "months": "{count, plural, one {# month ago} other {# months ago}}",
+    "years": "{count, plural, one {# year ago} other {# years ago}}"
+  },
+  "reblog_jsx": {
+    "already_reblogged": "Already reblogged",
+    "reblog_this_post": "Reblog this post",
+    "reblogged": "Reblogged",
+    "reblog": "Reblog"
+  },
+  "degradation_banner": {
+    "outage": "Connection to the Steem network is unstable. Some actions may fail.",
+    "degraded": "Showing cached content — the Steem network is slow to respond."
+  },
+  "share_menu": {
+    "share_on": "Share on {name}"
+  },
+  "search_jsx": {
+    "accounts": "Accounts",
+    "sort_by": "Sort by:",
+    "newest": "Newest",
+    "highest_payout": "Highest Payout",
+    "searching": "Searching...",
+    "nothing_found": "Nothing was found.",
+    "enter_query_hint": "Enter a search query above to find posts, comments, and accounts."
+  },
+  "communities_jsx": {
+    "search_communities": "Search communities",
+    "sort_communities": "Sort communities",
+    "subscribers": "Subscribers",
+    "nothing_found": "Nothing was found.",
+    "stats": "{subscribers, plural, one {# subscriber} other {# subscribers}} • {posters, plural, one {# poster} other {# posters}} • {posts, plural, one {# post} other {# posts}}"
+  },
+  "submit_jsx": {
+    "please_log_in": "Please log in to create a post."
+  },
+  "notfound": {
+    "title": "Sorry! This page doesn't exist.",
+    "head_back": "Not to worry. You can head back to",
+    "our_homepage": "our homepage",
+    "or_check_posts": ", or check out some great posts below.",
+    "menu_new_posts": "new posts",
+    "menu_hot_posts": "hot posts",
+    "menu_trending_posts": "trending posts",
+    "menu_promoted_posts": "promoted posts",
+    "menu_active_posts": "active posts"
+  },
+  "follow_list": {
+    "no_followers": "@{username} has no followers yet.",
+    "not_following": "@{username} is not following anyone yet."
   }
 }

--- a/messages/es.json
+++ b/messages/es.json
@@ -390,10 +390,10 @@
   },
   "user_profile": {
     "unknown_account": "Cuenta desconocida",
-    "user_hasnt_made_any_posts_yet": "Parece que %(name)s aún no ha comenzado a postear",
+    "user_hasnt_made_any_posts_yet": "Parece que {name} aún no ha comenzado a postear",
     "user_hasnt_started_bloggin_yet": "Parece que %(name)s aún no ha comenzado su blog",
     "user_hasnt_followed_anything_yet": "Parece que %(name)s aún no está siguiendo a nadie. Si %(name)s acaba de añadir nuevas cuentas para seguir, el feed personalizado aparecerá cuando el nuevo contenido esté disponible.",
-    "user_hasnt_had_any_replies_yet": "%(name)s todavía no ha tenido ninguna respuesta",
+    "user_hasnt_had_any_replies_yet": "{name} todavía no ha tenido ninguna respuesta",
     "looks_like_you_havent_posted_anything_yet": "Looks like you haven't posted anything yet.",
     "create_a_post": "Create a Post",
     "explore_trending_articles": "Explore Trending Articles",
@@ -442,7 +442,7 @@
     "changing_to_an_upvote": "Cambiando a Up-vote",
     "changing_to_a_downvote": "Cambiando a Down-Vote",
     "confirm_flag": "Confirmar Flag",
-    "and_more": "y %(count)s más",
+    "and_more": "y {count} más",
     "votes_plural": {
       "one": "%(count)s voto",
       "other": "%(count)s votos"

--- a/messages/fr.json
+++ b/messages/fr.json
@@ -400,10 +400,10 @@
   },
   "user_profile": {
     "unknown_account": "Compte inconnu",
-    "user_hasnt_made_any_posts_yet": "Il semblerait que %(name)s n'ait pas encore publié d'article.",
+    "user_hasnt_made_any_posts_yet": "Il semblerait que {name} n'ait pas encore publié d'article.",
     "user_hasnt_started_bloggin_yet": "Il semblerait que %(name)s n'ait pas encore commencer à blogger.",
     "user_hasnt_followed_anything_yet": "Il semblerait que %(name)s ne soit fan de personne. Dans le cas où %(name)s s'abonnerait au fil d'autres utilisateurs, son flux sera automatiquement rempli avec du nouveau contenu.",
-    "user_hasnt_had_any_replies_yet": "%(name)s n'a pas encore reçu de réponse",
+    "user_hasnt_had_any_replies_yet": "{name} n'a pas encore reçu de réponse",
     "looks_like_you_havent_posted_anything_yet": "Looks like you haven't posted anything yet.",
     "create_a_post": "Create a Post",
     "explore_trending_articles": "Explore Trending Articles",
@@ -452,7 +452,7 @@
     "changing_to_an_upvote": "Modifier pour un vote positif",
     "changing_to_a_downvote": "Modifier pour un vote négatif",
     "confirm_flag": "Confirmer la signalisation",
-    "and_more": "et %(count)s en plus",
+    "and_more": "et {count} en plus",
     "votes_plural": {
       "one": "%(count)s vote",
       "other": "%(count)s votes"

--- a/messages/it.json
+++ b/messages/it.json
@@ -395,10 +395,10 @@
   },
   "user_profile": {
     "unknown_account": "Account sconosciuto",
-    "user_hasnt_made_any_posts_yet": "Sembra che %(name)snon abbia ancora pubblicato nessun post! ",
+    "user_hasnt_made_any_posts_yet": "Sembra che {name}non abbia ancora pubblicato nessun post! ",
     "user_hasnt_started_bloggin_yet": "Sembra che %(name)s non abbia ancora iniziato a scrivere!",
     "user_hasnt_followed_anything_yet": "Sembra che %(name)snon stia seguendo ancora nessuno! Se %(name)sha aggiunto di recente nuovi utenti da seguire, il feed personalizzato si riempirà di contenuti non appena ce ne saranno di nuovi. ",
-    "user_hasnt_had_any_replies_yet": "%(name)s hasn't had any replies yet",
+    "user_hasnt_had_any_replies_yet": "{name} hasn't had any replies yet",
     "looks_like_you_havent_posted_anything_yet": "Looks like you haven't posted anything yet.",
     "create_a_post": "Create a Post",
     "explore_trending_articles": "Explore Trending Articles",
@@ -447,7 +447,7 @@
     "changing_to_an_upvote": "Cambia in un upvote",
     "changing_to_a_downvote": "Cambia in un downvote",
     "confirm_flag": "Conferma il flag",
-    "and_more": "e %(count)s in più",
+    "and_more": "e {count} in più",
     "votes_plural": {
       "one": "%(count)s voto",
       "other": "%(count)s voti"

--- a/messages/ja.json
+++ b/messages/ja.json
@@ -397,10 +397,10 @@
   },
   "user_profile": {
     "unknown_account": "不明なアカウント",
-    "user_hasnt_made_any_posts_yet": "%(name)sはまだ1つも投稿していないようです！",
+    "user_hasnt_made_any_posts_yet": "{name}はまだ1つも投稿していないようです！",
     "user_hasnt_started_bloggin_yet": "%(name)sはまだブログを開始していないようです！",
     "user_hasnt_followed_anything_yet": "%(name)sはまだ誰もフォローしていません！%(name)sが最近新しいユーザーをフォローした場合、新しいコンテンツが有効になると個々のフィードに追加されます。",
-    "user_hasnt_had_any_replies_yet": "%(name)sへの返信はまだありません。",
+    "user_hasnt_had_any_replies_yet": "{name}への返信はまだありません。",
     "looks_like_you_havent_posted_anything_yet": "あなたはまだ1つも投稿していないようです！",
     "create_a_post": "投稿を作成する",
     "explore_trending_articles": "トレンド記事を検索する",
@@ -449,7 +449,7 @@
     "changing_to_an_upvote": "Upvoteに変更する",
     "changing_to_a_downvote": "Downvoteに変更する",
     "confirm_flag": "フラグの確認",
-    "and_more": "他%(count)s人",
+    "and_more": "他{count}人",
     "votes_plural": {
       "one": "%(count)s件の投票",
       "other": "%(count)s件の投票"

--- a/messages/ko.json
+++ b/messages/ko.json
@@ -401,10 +401,10 @@
   },
   "user_profile": {
     "unknown_account": "Unknown Account",
-    "user_hasnt_made_any_posts_yet": "%(name)s님은 아직 남긴 글이 없습니다.",
+    "user_hasnt_made_any_posts_yet": "{name}님은 아직 남긴 글이 없습니다.",
     "user_hasnt_started_bloggin_yet": "%(name)s님은 아직 블로깅을 시작하지 않았습니다.",
     "user_hasnt_followed_anything_yet": "Looks like %(name)s might not be following anyone yet! If %(name)s recently added new users to follow, their personalized feed will populate once new content is available.",
-    "user_hasnt_had_any_replies_yet": "%(name)s hasn't had any replies yet",
+    "user_hasnt_had_any_replies_yet": "{name} hasn't had any replies yet",
     "looks_like_you_havent_posted_anything_yet": "아직 포스팅을 하지 않았습니다.",
     "create_a_post": "글쓰기",
     "explore_trending_articles": "대세글 읽어보기",
@@ -453,7 +453,7 @@
     "changing_to_an_upvote": "Changing to an Up-Vote",
     "changing_to_a_downvote": "Changing to a Down-Vote",
     "confirm_flag": "Confirm Flag",
-    "and_more": "and %(count)s more",
+    "and_more": "and {count} more",
     "votes_plural": {
       "one": "%(count)s 보팅",
       "other": "%(count)s 보팅"

--- a/messages/overlays/en.json
+++ b/messages/overlays/en.json
@@ -1,14 +1,21 @@
 {
   "comments": {
     "no_comments_yet": "No comments yet. Be the first to comment!",
-    "load_more_comments": "LOAD MORE COMMENTS"
+    "load_more_comments": "LOAD MORE COMMENTS",
+    "confirm_delete": "Are you sure you want to delete this comment?",
+    "expand": "Expand",
+    "collapse": "Collapse",
+    "reply_count": "{count, plural, one {# reply} other {# replies}}",
+    "show_more_replies": "Show {count, plural, one {# more reply} other {# more replies}}",
+    "delete_failed": "Failed to delete the comment. Please try again."
   },
   "posts_index": {
     "no_pending_posts": "No pending posts found. This view only shows posts within 12-36 hours of payout.",
     "no_muted_posts": "No muted posts found.",
     "no_followed_posts": "You haven't followed anyone yet! Explore Trending to find people to follow.",
     "no_posts_in_tag": "No posts in #{tag} yet!",
-    "no_posts_found": "No posts found."
+    "no_posts_found": "No posts found.",
+    "unmoderated_tag": "Unmoderated tag"
   },
   "reply_editor": {
     "title_required": "Title is required",
@@ -26,6 +33,171 @@
     "wif_required": "Posting private key (WIF) is required",
     "invalid_wif_format": "Invalid format. Please enter your posting private key in WIF format (starts with 5...)",
     "validating_key": "Validating posting private key...",
-    "logging_in": "Logging in..."
+    "logging_in": "Logging in...",
+    "invalid_account_or_no_posting_authority": "Invalid account or posting authority not found",
+    "invalid_posting_key": "Invalid posting key",
+    "failed_to_get_challenge": "Failed to get login challenge",
+    "login_failed": "Login failed",
+    "login_failed_try_again": "Login failed. Please try again."
+  },
+  "g": {
+    "untitled": "Untitled",
+    "scroll_to_top": "Scroll to top",
+    "pagination": "Pagination",
+    "submit_search": "Submit search",
+    "welcome_guide": "Welcome Guide"
+  },
+  "navigation": {
+    "primary_navigation": "Primary navigation",
+    "menu": "Menu",
+    "close_menu": "Close menu",
+    "breadcrumb": "Breadcrumb"
+  },
+  "sidebar": {
+    "new_to_steemit": "New to Steemit?",
+    "community_stats": "{subscribers, plural, one {# subscriber} other {# subscribers}} • {posters, plural, one {# active poster} other {# active posters}}",
+    "coin_marketplace": "Coin Marketplace"
+  },
+  "notificationslist_jsx": {
+    "marking": "Marking...",
+    "mark_as_read_error": "Failed to mark notifications as read. Please try again.",
+    "empty": "Welcome! You don't have any notifications yet.",
+    "unread": "Unread",
+    "unread_notifications": "{count, plural, one {# unread notification} other {# unread notifications}}",
+    "failed_to_load": "Failed to load notifications"
+  },
+  "postsummary_jsx": {
+    "this_post_is_nsfw": "This post is"
+  },
+  "voting_jsx": {
+    "vote_weight": "Vote weight",
+    "downvote_weight": "Downvote weight",
+    "vote_percent": "Vote {percent}%",
+    "downvote_percent": "Downvote {percent}%",
+    "payout_details": "Payout details",
+    "pending_payout_amount": "Pending Payout {value}",
+    "payout_date": "Payout Date {date}",
+    "author_payout": "Author Payout {value}",
+    "curator_payout": "Curator Payout {value}",
+    "voters": "Voters",
+    "vote_count": "{count, plural, one {# vote} other {# votes}}",
+    "and_more": "and {count} more"
+  },
+  "user_profile": {
+    "reputation_title": "This is {name}'s reputation score. It is based on the history of votes.",
+    "blacklisted_on": "Blacklisted on: {list}",
+    "followers_label": "{count, plural, one {follower} other {followers}}",
+    "posts_label": "{count, plural, one {post} other {posts}}",
+    "following_label": "following",
+    "joined_date": "Joined {date}",
+    "loading_profile": "Loading profile...",
+    "user_not_found": "User not found",
+    "only_view_own_settings": "You can only view your own settings.",
+    "following": "Following",
+    "no_friends_feed": "You haven't followed anyone yet!",
+    "explore_trending": "Explore Trending",
+    "new_users_guide": "New users guide",
+    "user_hasnt_made_any_comments_yet": "{name} hasn't made any comments yet.",
+    "no_pending_payouts": "No pending payouts.",
+    "user_hasnt_posted_anything_yet": "{name} hasn't posted anything yet.",
+    "user_hasnt_had_any_replies_yet": "{name} hasn't had any replies yet.",
+    "user_hasnt_made_any_posts_yet": "{name} hasn't made any posts yet."
+  },
+  "time_ago": {
+    "just_now": "just now",
+    "minutes": "{count, plural, one {# minute ago} other {# minutes ago}}",
+    "hours": "{count, plural, one {# hour ago} other {# hours ago}}",
+    "days": "{count, plural, one {# day ago} other {# days ago}}",
+    "weeks": "{count, plural, one {# week ago} other {# weeks ago}}",
+    "months": "{count, plural, one {# month ago} other {# months ago}}",
+    "years": "{count, plural, one {# year ago} other {# years ago}}"
+  },
+  "reblog_jsx": {
+    "already_reblogged": "Already reblogged",
+    "reblog_this_post": "Reblog this post",
+    "reblogged": "Reblogged",
+    "reblog": "Reblog"
+  },
+  "degradation_banner": {
+    "outage": "Connection to the Steem network is unstable. Some actions may fail.",
+    "degraded": "Showing cached content — the Steem network is slow to respond."
+  },
+  "share_menu": {
+    "share_on": "Share on {name}"
+  },
+  "markdownviewer_jsx": {
+    "embedded_video_title": "{provider} video {id}"
+  },
+  "settings_jsx": {
+    "account_settings": "Account Settings",
+    "only_own_profile": "You can only edit your own profile settings.",
+    "profile_updated": "Profile updated successfully!",
+    "update_failed": "Failed to update profile. Please try again.",
+    "profile_image_url": "Profile Image URL",
+    "cover_image_url": "Cover Image URL",
+    "profile_image_placeholder": "https://example.com/image.jpg",
+    "cover_image_placeholder": "https://example.com/cover.jpg",
+    "display_name_placeholder": "Your display name",
+    "about_placeholder": "Tell us about yourself...",
+    "location_placeholder": "Your location",
+    "website_placeholder": "https://yourwebsite.com",
+    "characters_used": "{count}/{max} characters",
+    "profile_image_invalid_url": "Profile image must be a valid URL",
+    "cover_image_invalid_url": "Cover image must be a valid URL",
+    "website_invalid_url": "Website must be a valid URL",
+    "name_too_long": "Name is too long (max {max} characters)",
+    "about_too_long": "About is too long (max {max} characters)",
+    "location_too_long": "Location is too long (max {max} characters)",
+    "website_too_long": "Website URL is too long (max {max} characters)",
+    "update_profile": "Update Profile",
+    "updating": "Updating...",
+    "save_preferences": "Save Preferences"
+  },
+  "search_jsx": {
+    "accounts": "Accounts",
+    "sort_by": "Sort by:",
+    "newest": "Newest",
+    "highest_payout": "Highest Payout",
+    "searching": "Searching...",
+    "nothing_found": "Nothing was found.",
+    "enter_query_hint": "Enter a search query above to find posts, comments, and accounts."
+  },
+  "communities_jsx": {
+    "search_communities": "Search communities",
+    "sort_communities": "Sort communities",
+    "subscribers": "Subscribers",
+    "nothing_found": "Nothing was found.",
+    "stats": "{subscribers, plural, one {# subscriber} other {# subscribers}} • {posters, plural, one {# poster} other {# posters}} • {posts, plural, one {# post} other {# posts}}"
+  },
+  "user_roles": {
+    "loading_community_data": "Loading community data...",
+    "community_management": "Community Management",
+    "roles_and_members": "Roles & Members",
+    "subscribers": "Subscribers",
+    "no_roles": "No roles found for this community.",
+    "no_subscribers": "No subscribers found for this community.",
+    "view_profile": "View profile"
+  },
+  "postfull_jsx": {
+    "post_not_found": "Post not found",
+    "failed_to_load": "Failed to load post or comments"
+  },
+  "submit_jsx": {
+    "please_log_in": "Please log in to create a post."
+  },
+  "notfound": {
+    "title": "Sorry! This page doesn't exist.",
+    "head_back": "Not to worry. You can head back to",
+    "our_homepage": "our homepage",
+    "or_check_posts": ", or check out some great posts below.",
+    "menu_new_posts": "new posts",
+    "menu_hot_posts": "hot posts",
+    "menu_trending_posts": "trending posts",
+    "menu_promoted_posts": "promoted posts",
+    "menu_active_posts": "active posts"
+  },
+  "follow_list": {
+    "no_followers": "@{username} has no followers yet.",
+    "not_following": "@{username} is not following anyone yet."
   }
 }

--- a/messages/overlays/es.json
+++ b/messages/overlays/es.json
@@ -1,0 +1,9 @@
+{
+  "voting_jsx": {
+    "and_more": "y {count} más"
+  },
+  "user_profile": {
+    "user_hasnt_made_any_posts_yet": "Parece que {name} aún no ha comenzado a postear",
+    "user_hasnt_had_any_replies_yet": "{name} todavía no ha tenido ninguna respuesta"
+  }
+}

--- a/messages/overlays/fr.json
+++ b/messages/overlays/fr.json
@@ -1,0 +1,9 @@
+{
+  "voting_jsx": {
+    "and_more": "et {count} en plus"
+  },
+  "user_profile": {
+    "user_hasnt_made_any_posts_yet": "Il semblerait que {name} n'ait pas encore publié d'article.",
+    "user_hasnt_had_any_replies_yet": "{name} n'a pas encore reçu de réponse"
+  }
+}

--- a/messages/overlays/it.json
+++ b/messages/overlays/it.json
@@ -1,0 +1,9 @@
+{
+  "voting_jsx": {
+    "and_more": "e {count} in più"
+  },
+  "user_profile": {
+    "user_hasnt_made_any_posts_yet": "Sembra che {name}non abbia ancora pubblicato nessun post! ",
+    "user_hasnt_had_any_replies_yet": "{name} hasn't had any replies yet"
+  }
+}

--- a/messages/overlays/ja.json
+++ b/messages/overlays/ja.json
@@ -1,0 +1,9 @@
+{
+  "voting_jsx": {
+    "and_more": "他{count}人"
+  },
+  "user_profile": {
+    "user_hasnt_made_any_posts_yet": "{name}はまだ1つも投稿していないようです！",
+    "user_hasnt_had_any_replies_yet": "{name}への返信はまだありません。"
+  }
+}

--- a/messages/overlays/ko.json
+++ b/messages/overlays/ko.json
@@ -1,0 +1,9 @@
+{
+  "voting_jsx": {
+    "and_more": "and {count} more"
+  },
+  "user_profile": {
+    "user_hasnt_made_any_posts_yet": "{name}님은 아직 남긴 글이 없습니다.",
+    "user_hasnt_had_any_replies_yet": "{name} hasn't had any replies yet"
+  }
+}

--- a/messages/overlays/pl.json
+++ b/messages/overlays/pl.json
@@ -1,0 +1,9 @@
+{
+  "voting_jsx": {
+    "and_more": "i {count} więcej"
+  },
+  "user_profile": {
+    "user_hasnt_made_any_posts_yet": "Wygląda na to, że {name} nie opublikował jeszcze żadnych wpisów!",
+    "user_hasnt_had_any_replies_yet": "{name} nie ma jeszcze żadnych odpowiedzi"
+  }
+}

--- a/messages/overlays/ru.json
+++ b/messages/overlays/ru.json
@@ -1,0 +1,9 @@
+{
+  "voting_jsx": {
+    "and_more": "и {count} больше"
+  },
+  "user_profile": {
+    "user_hasnt_made_any_posts_yet": "Похоже, что {name} еще не написал постов!",
+    "user_hasnt_had_any_replies_yet": "{name} еще не получил ответов"
+  }
+}

--- a/messages/overlays/uk.json
+++ b/messages/overlays/uk.json
@@ -1,0 +1,9 @@
+{
+  "voting_jsx": {
+    "and_more": "і ще {count}"
+  },
+  "user_profile": {
+    "user_hasnt_made_any_posts_yet": "Схоже, {name} ще не опублікував жодного допису!",
+    "user_hasnt_had_any_replies_yet": "{name} ще не отримав жодної відповіді"
+  }
+}

--- a/messages/pl.json
+++ b/messages/pl.json
@@ -391,10 +391,10 @@
   },
   "user_profile": {
     "unknown_account": "Konto nieznane",
-    "user_hasnt_made_any_posts_yet": "Wygląda na to, że %(name)s nie opublikował jeszcze żadnych wpisów!",
+    "user_hasnt_made_any_posts_yet": "Wygląda na to, że {name} nie opublikował jeszcze żadnych wpisów!",
     "user_hasnt_started_bloggin_yet": "Wygląda na to, że %(name)s nie zaczął jeszcze blogowania!",
     "user_hasnt_followed_anything_yet": "Wygląda na to, że użytkownik %(name)s jeszcze nikogo nie obserwuje. Jeśli %(name)s zaczął(ęła) obserwować nowych użytkowników jego(jej) osobisty strumień zacznie się zapełniać, gdy powstaną nowe treści.  ",
-    "user_hasnt_had_any_replies_yet": "%(name)s nie ma jeszcze żadnych odpowiedzi",
+    "user_hasnt_had_any_replies_yet": "{name} nie ma jeszcze żadnych odpowiedzi",
     "followers": "Obserwujący",
     "this_is_users_reputations_score_it_is_based_on_history_of_votes": "To są punkty reputacji użytkownika %(name)s.\n\nSystem punktów reputacji bazuje na historii otrzymanych przez użytkownika głosów i jest używany do ukrywania wpisów o niskiej jakości.",
     "follower_count": {
@@ -438,7 +438,7 @@
     "changing_to_an_upvote": "Zmień na głos za",
     "changing_to_a_downvote": "Zmień na głos przeciw",
     "confirm_flag": "Potwierdź oznaczenie flagą",
-    "and_more": "i %(count)s więcej",
+    "and_more": "i {count} więcej",
     "votes_plural": {
       "one": "%(count)s głos",
       "other": "%(count)s głosów"

--- a/messages/ru.json
+++ b/messages/ru.json
@@ -402,10 +402,10 @@
   },
   "user_profile": {
     "unknown_account": "Неизвестный аккаунт",
-    "user_hasnt_made_any_posts_yet": "Похоже, что %(name)s еще не написал постов!",
+    "user_hasnt_made_any_posts_yet": "Похоже, что {name} еще не написал постов!",
     "user_hasnt_started_bloggin_yet": "Похоже. что %(name)s еще не завёл блог!",
     "user_hasnt_followed_anything_yet": "Похоже, что %(name)s еще ни на кого не подписан! Если, %(name)s недавно подписался на новых пользователей, их персонализированный канал будет заполняться сразу после появления нового контента.",
-    "user_hasnt_had_any_replies_yet": "%(name)s еще не получил ответов",
+    "user_hasnt_had_any_replies_yet": "{name} еще не получил ответов",
     "looks_like_you_havent_posted_anything_yet": "Похоже, ты еще ничего не опубликовал.",
     "create_a_post": "Создать сообщение",
     "explore_trending_articles": "Посмотреть статьи, набирающие популярность",
@@ -460,7 +460,7 @@
     "changing_to_an_upvote": "Изменить на голосование 'за'",
     "changing_to_a_downvote": "Изменить на голосование 'против'",
     "confirm_flag": "Подтвердить голос 'против'",
-    "and_more": "и %(count)s больше",
+    "and_more": "и {count} больше",
     "votes_plural": {
       "one": "%(count)s голоса",
       "few": "%(count)s голоса",

--- a/messages/uk.json
+++ b/messages/uk.json
@@ -439,10 +439,10 @@
   },
   "user_profile": {
     "unknown_account": "Невідомий обліковий запис",
-    "user_hasnt_made_any_posts_yet": "Схоже, %(name)s ще не опублікував жодного допису!",
+    "user_hasnt_made_any_posts_yet": "Схоже, {name} ще не опублікував жодного допису!",
     "user_hasnt_started_bloggin_yet": "Схоже, %(name)s ще не почав вести блог!",
     "user_hasnt_followed_anything_yet": "Схоже, %(name)s ще не стежить ні за ким! Якщо %(name)s нещодавно додав нових користувачів для підписки, їх персоналізована стрічка заповниться, щойно стане доступним новий вміст.",
-    "user_hasnt_had_any_replies_yet": "%(name)s ще не отримав жодної відповіді",
+    "user_hasnt_had_any_replies_yet": "{name} ще не отримав жодної відповіді",
     "user_hasnt_had_any_notifications_yet": "%(name)s ще не отримав сповіщень",
     "looks_like_you_havent_posted_anything_yet": "Схоже, ви ще нічого не опублікували.",
     "create_a_post": "Створити допис",
@@ -500,7 +500,7 @@
     "changing_to_a_downvote": "Перехід на голосування проти",
     "changing_to_a_downvote_will_reset_curation_rewards_for_this_post": "Перехід на голосування проти скасує ваші винагороди за кураторство для цієї публікації",
     "confirm_flag": "Підтвердити позначку",
-    "and_more": "і ще %(count)s",
+    "and_more": "і ще {count}",
     "votes_plural": {
       "one": "%(count)s голосів",
       "other": "%(count)s голосів"


### PR DESCRIPTION
## Summary

Migrates the long tail of hardcoded English UI strings to next-intl, completing the i18n rollout started in #4001.

- **33 components/pages** migrated to `useTranslations()`: navigation (PrimaryNavigation / MobileTabBar / SidePanel), right-rail widgets, notifications list, comments, voting, post summary/full, profile header, follow/reblog/subscribe buttons, search / communities / roles / submit pages, settings, login form errors, not-found page, degradation banner, time-ago, share menu, markdown-viewer embeds, and assorted aria labels.
- New keys live in `messages/overlays/en.json` (built via `scripts/build-messages.mjs`, never hand-edited); legacy counterpart placeholders converted to ICU (`{name}`, `{count, plural, …}`) where the keys are now actually used. `messages/en.json` regenerated by the official build script.
- Hand-written plural branches converted to ICU plural: TimeAgo (six time units), Voting vote count, NotificationBadge unread count, Comment reply counts, PostSummary votes title.

## Tests

- `pnpm test`: 235 passing (PrimaryNavigation tests now wrap renders in the intl provider).
- `pnpm lint`: 0 errors on all touched files.

## Notes

- The legacy counterpart-format keys remaining in `messages/en.json` are dead (zero references) except the three this PR activates — those three were converted to ICU in the per-locale overlays (a follow-up commit fixes them in all 8 non-English locale layers, which merge over English at runtime). Any cleanup of the remaining dead keys belongs in the legacy-driven build script — left untouched.
- Other locales fall back to English at runtime for the new keys (existing deep-merge behavior); translations can land per-locale later.
