### PR TITLE
fix(dev): allow LAN origins via NEXT_DEV_ALLOWED_ORIGINS

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,6 +37,12 @@ JWT_SECRET=your-secret-key-change-in-production
 # Other Configuration
 NEXT_PUBLIC_SIGNUP_URL=https://signup.steemit.com
 
+# Dev-only (`pnpm dev`): comma-separated extra origins allowed to reach the
+# dev server, HMR websocket included. Next.js blocks non-localhost dev
+# origins by default, so set this when accessing the dev server from another
+# machine on the LAN, e.g. NEXT_DEV_ALLOWED_ORIGINS="192.168.1.10"
+# NEXT_DEV_ALLOWED_ORIGINS=
+
 # Image proxy prefix. Post-body images are proxied through this host as
 # /p/:base58?width=&mode=fit&format=match (mirrors master's
 # $STM_Config.img_proxy_prefix). Default is the production CDN.

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -66,6 +66,12 @@ NEXT_PUBLIC_TRONADS_CONTENT_MOBILE_AD_PID=
 # configured means the module stays hidden.
 STEEM_MARKET_ENDPOINT=
 STEEM_MARKET_TOKEN=
+
+# Dev-only (`pnpm dev`): comma-separated extra origins allowed to reach the
+# dev server, HMR websocket included. Next.js blocks non-localhost dev
+# origins by default, so set this when accessing the dev server from another
+# machine on the LAN (e.g. "192.168.1.10"). Loaded from .env/.env.local.
+NEXT_DEV_ALLOWED_ORIGINS=
 ```
 
 ### Analytics (overseer)

--- a/next.config.ts
+++ b/next.config.ts
@@ -23,6 +23,12 @@ const nextConfig: NextConfig = {
   
   // Server external packages (moved from experimental)
   serverExternalPackages: ['@steemit/steem-js'],
+
+  // Dev-only: extra origins allowed to reach the dev server (HMR websocket
+  // included). Next.js blocks non-localhost dev origins by default; set
+  // NEXT_DEV_ALLOWED_ORIGINS="192.168.1.10,host.local" when accessing the
+  // dev server from another machine on the LAN.
+  allowedDevOrigins: process.env.NEXT_DEV_ALLOWED_ORIGINS?.split(',').map((s) => s.trim()).filter(Boolean),
   
   // Turbopack configuration (Next.js 16 default)
   turbopack: {


### PR DESCRIPTION
## Problem

Accessing `pnpm dev` from another machine on the LAN (e.g. `http://192.168.44.2:3000`) left the page stuck on Loading: Next.js blocks non-localhost origins on the dev server by default, so the HMR websocket handshake is rejected (`ERR_INVALID_HTTP_RESPONSE`, no 101). Confirmed locally with curl — the upgrade to `192.168.44.2` gets no response while `localhost` gets `101 Switching Protocols`.

## Fix

Env-driven `allowedDevOrigins` in `next.config.ts`:

```bash
# .env.local
NEXT_DEV_ALLOWED_ORIGINS="192.168.44.2"
```

Next.js loads `.env`/`.env.local` before evaluating `next.config.ts`, so no inline env prefix is needed. Documented in `.env.example` and `docs/CONFIGURATION.md`.

## Verification

With the var set: handshake returns `101`, and headless Chromium loads `/`, `/trending`, `/login` over the LAN IP with zero console errors (previously 3-4 HMR websocket failures per page).