### PR TITLE
fix(docker): pin pnpm to 10.17.0 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN apk update && apk add --no-cache \
     g++ \
     git \
     && npm config set registry https://registry.npmjs.org/ \
-    && npm install -g pnpm
+    && npm install -g pnpm@10.17.0
 
 # Set working directory
 WORKDIR /app


### PR DESCRIPTION
## Problem

Docker build fails at `pnpm install --frozen-lockfile`:

```
ERR_PNPM_PNPM_ENGINE_IDENTITY_UNVERIFIABLE
Cannot verify the identity of the @pnpm/exe.linux-x64 native binary: it is missing from pnpm-lock.yaml.
```

The unpinned `npm install -g pnpm` now installs pnpm 11, which refuses the pnpm-10 lockfile. The repo's `packageManager` field, CI, and local dev all standardize on pnpm 10.17.0.

## Fix

Pin `npm install -g pnpm@10.17.0` in the Dockerfile base stage.