### PR TITLE
feat(nav): restore Settings entry under My Profile (own profile only)

### DIFF
--- a/__tests__/components/PrimaryNavigation.test.tsx
+++ b/__tests__/components/PrimaryNavigation.test.tsx
@@ -113,4 +113,16 @@ describe('PrimaryNavigation profile group identity', () => {
     expect(isActive(itemByLabel('My Friends'))).toBe(true);
     expect(screen.getByText('My Profile')).toBeTruthy();
   });
+
+  it('links Settings on the own profile group only', () => {
+    renderNav('/@alice/settings');
+    const settings = itemByLabel('Settings');
+    expect(settings.getAttribute('href')).toBe('/@alice/settings');
+    expect(isActive(settings)).toBe(true);
+  });
+
+  it('hides Settings on other users\' profile groups', () => {
+    renderNav('/@bob/posts');
+    expect(screen.queryByText('Settings')).toBeNull();
+  });
 });

--- a/components/layout/Header.tsx
+++ b/components/layout/Header.tsx
@@ -288,6 +288,11 @@ export function Header() {
                   >
                     {t("g.wallet")}
                   </DropdownMenuItem>
+                  <DropdownMenuItem
+                    onClick={() => router.push(`/@${username}/settings`)}
+                  >
+                    {t("g.settings")}
+                  </DropdownMenuItem>
                   <DropdownMenuItem onClick={() => void handleLogout()}>
                     {t("g.logout")}
                   </DropdownMenuItem>

--- a/components/layout/PrimaryNavigation.tsx
+++ b/components/layout/PrimaryNavigation.tsx
@@ -289,10 +289,12 @@ export function PrimaryNavigation({ pathname }: { pathname: string }) {
     const user = profileGroupUser.toLowerCase();
     // Other users' groups additionally expose Friends Feed (legacy "More"
     // menu); one's own feed lives under Explore > My Friends instead.
+    // Settings is only linked on one's own profile (legacy parity — the
+    // /@user/settings route itself stays reachable for direct visits).
     const sections =
       viewedUser && !isOwnProfile
         ? [...MY_PROFILE_SECTIONS, { segment: "feed", labelKey: "g.friends_feed" }]
-        : MY_PROFILE_SECTIONS;
+        : [...MY_PROFILE_SECTIONS, { segment: "settings", labelKey: "g.settings" }];
     return sections.map(({ segment, labelKey }) => ({
       label: t(labelKey),
       href: profileSectionHref(user, segment),


### PR DESCRIPTION
## Problem

The settings page (`/@user/settings`, `UserSettings`) existed and the route worked, but no UI linked to it:

- avatar menu was trimmed to Profile / Notifications / Wallet / Logout
- the sidebar My Profile group had blog/posts/comments/replies/notifications/subscriptions/payouts but no Settings

## Fix

- Sidebar: Settings as the last child of the My Profile group, **only when viewing one's own profile** (legacy parity; other users' groups keep Friends Feed instead)
- Avatar dropdown: Settings between Wallet and Logout, routing to `/@username/settings`

The route stays reachable for direct visits regardless.

## Tests

Two new cases in `PrimaryNavigation.test.tsx`: Settings links to `/@alice/settings` and is active on the own settings page; hidden on other users' profile groups. Full suite 242/242, lint/tsc clean.