### PR TITLE
feat(settings): image upload for profile/cover photos

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,6 +48,11 @@ NEXT_PUBLIC_SIGNUP_URL=https://signup.steemit.com
 # $STM_Config.img_proxy_prefix). Default is the production CDN.
 # NEXT_PUBLIC_IMAGE_PROXY_PREFIX=https://steemitimages.com/
 
+# Image upload endpoint (legacy $STM_Config.upload_image). Settings page
+# profile/cover images are signed with the posting key and uploaded here.
+# Default: https://steemitimages.com
+# NEXT_PUBLIC_UPLOAD_IMAGE_URL=https://steemitimages.com
+
 # External Steemit wallet (Condenser only links out). Production default: https://steemitwallet.com
 # Unset in production build to use that default; set for test/staging, e.g.:
 # NEXT_PUBLIC_WALLET_URL=https://wallet.steemitdev.com

--- a/.env.example
+++ b/.env.example
@@ -48,10 +48,12 @@ NEXT_PUBLIC_SIGNUP_URL=https://signup.steemit.com
 # $STM_Config.img_proxy_prefix). Default is the production CDN.
 # NEXT_PUBLIC_IMAGE_PROXY_PREFIX=https://steemitimages.com/
 
-# Image upload endpoint (legacy $STM_Config.upload_image). Settings page
-# profile/cover images are signed with the posting key and uploaded here.
+# Image upload endpoint (legacy $STM_Config.upload_image / SDC_UPLOAD_IMAGE_URL).
+# Settings page profile/cover images are signed with the posting key and
+# uploaded here. Read at request time and inlined into the SSR HTML (like the
+# GA id), so published images stay environment-agnostic.
 # Default: https://steemitimages.com
-# NEXT_PUBLIC_UPLOAD_IMAGE_URL=https://steemitimages.com
+# SDC_UPLOAD_IMAGE_URL=https://steemitimages.com
 
 # External Steemit wallet (Condenser only links out). Production default: https://steemitwallet.com
 # Unset in production build to use that default; set for test/staging, e.g.:

--- a/__tests__/lib/media/upload-image.test.ts
+++ b/__tests__/lib/media/upload-image.test.ts
@@ -1,0 +1,88 @@
+/**
+ * @vitest-environment node
+ * noble hashes (steem-js 1.2.x) require same-realm Uint8Array; jsdom's
+ * Buffer crosses realms and fails with "expected Uint8Array".
+ */
+import { beforeEach, describe, expect, it, vi, type Mock } from 'vitest';
+
+vi.mock('@/lib/crypto/key-storage', () => ({
+  getCachedKey: vi.fn(),
+  decryptAndRetrieveKey: vi.fn(),
+}));
+
+import { steem } from '@steemit/steem-js';
+import { uploadImage } from '@/lib/media/upload-image';
+import { decryptAndRetrieveKey, getCachedKey } from '@/lib/crypto/key-storage';
+
+const getCachedKeyMock = getCachedKey as unknown as Mock;
+const decryptMock = decryptAndRetrieveKey as unknown as Mock;
+const fetchMock = vi.fn();
+vi.stubGlobal('fetch', fetchMock);
+
+const WIF = steem.auth.toWif('alice', 'password', 'posting');
+
+function makeImageFile(name = 'pic.png', type = 'image/png'): File {
+  return new File([new Uint8Array([1, 2, 3, 4])], name, { type });
+}
+
+function okResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    json: () => Promise.resolve(body),
+  } as Response;
+}
+
+describe('uploadImage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getCachedKeyMock.mockReturnValue(WIF);
+  });
+
+  it('rejects non-image files before touching the key or network', async () => {
+    const file = new File(['x'], 'a.txt', { type: 'text/plain' });
+    await expect(uploadImage(file, 'alice')).rejects.toThrow(/image files/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('fails fast when no posting key is available', async () => {
+    getCachedKeyMock.mockReturnValue(null);
+    decryptMock.mockResolvedValue(null);
+    await expect(uploadImage(makeImageFile(), 'alice')).rejects.toThrow(/login again/);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('signs the ImageSigningChallenge and posts the file to the hoster', async () => {
+    fetchMock.mockResolvedValue(okResponse({ url: 'https://steemitimages.com/abc/pic.png' }));
+
+    const url = await uploadImage(makeImageFile(), 'alice');
+
+    expect(url).toBe('https://steemitimages.com/abc/pic.png');
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [endpoint, init] = fetchMock.mock.calls[0];
+    // /{username}/{signature} — signature is the hex posting-key signature.
+    expect(endpoint).toMatch(/^https:\/\/steemitimages\.com\/alice\/[0-9a-f]{130}$/);
+    expect(init.method).toBe('POST');
+    expect(init.body).toBeInstanceOf(FormData);
+    expect((init.body as FormData).get('file')).toBeTruthy();
+  });
+
+  it('honors NEXT_PUBLIC_UPLOAD_IMAGE_URL when set', async () => {
+    vi.stubEnv('NEXT_PUBLIC_UPLOAD_IMAGE_URL', 'https://img.example.com/');
+    fetchMock.mockResolvedValue(okResponse({ url: 'https://img.example.com/x.png' }));
+
+    await uploadImage(makeImageFile(), 'alice');
+    const [endpoint] = fetchMock.mock.calls[0];
+    expect(endpoint).toMatch(/^https:\/\/img\.example\.com\/alice\//);
+    vi.unstubAllEnvs();
+  });
+
+  it('surfaces hoster error responses', async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: () => Promise.resolve({ error: 'Signature is invalid' }),
+    } as Response);
+    await expect(uploadImage(makeImageFile(), 'alice')).rejects.toThrow('Signature is invalid');
+  });
+});

--- a/__tests__/lib/media/upload-image.test.ts
+++ b/__tests__/lib/media/upload-image.test.ts
@@ -67,14 +67,15 @@ describe('uploadImage', () => {
     expect((init.body as FormData).get('file')).toBeTruthy();
   });
 
-  it('honors NEXT_PUBLIC_UPLOAD_IMAGE_URL when set', async () => {
-    vi.stubEnv('NEXT_PUBLIC_UPLOAD_IMAGE_URL', 'https://img.example.com/');
+  it('honors the runtime-injected SDC_UPLOAD_IMAGE_URL when set', async () => {
+    (globalThis as { __SDC_UPLOAD_IMAGE_URL__?: string }).__SDC_UPLOAD_IMAGE_URL__ =
+      'https://img.example.com/';
     fetchMock.mockResolvedValue(okResponse({ url: 'https://img.example.com/x.png' }));
 
     await uploadImage(makeImageFile(), 'alice');
     const [endpoint] = fetchMock.mock.calls[0];
     expect(endpoint).toMatch(/^https:\/\/img\.example\.com\/alice\//);
-    vi.unstubAllEnvs();
+    delete (globalThis as { __SDC_UPLOAD_IMAGE_URL__?: string }).__SDC_UPLOAD_IMAGE_URL__;
   });
 
   it('surfaces hoster error responses', async () => {

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -24,6 +24,11 @@ export const dynamic = "force-dynamic";
 // injection and no hydration dependency.
 const gaId = process.env.SDC_GOOGLE_ANALYTICS_ID;
 
+// Image upload endpoint (legacy $STM_Config.upload_image): read from the
+// runtime env and inlined into the SSR HTML for the settings-page upload
+// helper (lib/media/upload-image.ts) to pick up client-side.
+const uploadImageUrl = process.env.SDC_UPLOAD_IMAGE_URL;
+
 // viewport-fit=cover is required for env(safe-area-inset-*) to take effect
 // on notched phones (the mobile bottom tab bar pads against it).
 export const viewport: Viewport = {
@@ -100,6 +105,14 @@ gtag('config', '${gaId}');`,
               }}
             />
           </>
+        ) : null}
+        {/* Runtime upload endpoint for lib/media/upload-image.ts. */}
+        {uploadImageUrl ? (
+          <script
+            dangerouslySetInnerHTML={{
+              __html: `window.__SDC_UPLOAD_IMAGE_URL__ = ${JSON.stringify(uploadImageUrl)};`,
+            }}
+          />
         ) : null}
         <ReduxProvider>{children}</ReduxProvider>
       </body>

--- a/components/modules/UserSettings.tsx
+++ b/components/modules/UserSettings.tsx
@@ -1,12 +1,13 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 import { useTranslations } from 'next-intl';
 import { useAppDispatch, useAppSelector } from '@/store/hooks';
 import { setLocale, setUserPreferences } from '@/store/slices/appSlice';
 import { LOCALES, LOCALE_LABELS, DEFAULT_LOCALE, isLocale, type Locale } from '@/lib/i18n/config';
 import { broadcastAccountUpdate } from '@/lib/api/broadcast';
 import { fetchAccount } from '@/lib/api/steem';
+import { uploadImage } from '@/lib/media/upload-image';
 import { userActionRecord } from '@/lib/analytics/overseer';
 
 /** Legacy o2j.ifStringParseJSON. */
@@ -83,6 +84,15 @@ export default function UserSettings({
   const [errors, setErrors] = useState<Record<string, string>>({});
   const [successMessage, setSuccessMessage] = useState('');
 
+  // Image upload state (profile_image / cover_image)
+  const [uploadingImage, setUploadingImage] = useState<
+    'profile_image' | 'cover_image' | null
+  >(null);
+  const fileInputRefs = {
+    profile_image: useRef<HTMLInputElement>(null),
+    cover_image: useRef<HTMLInputElement>(null),
+  };
+
   // User preferences
   const nsfwPref = useAppSelector(
     (state) => state.app.user_preferences.nsfwPref
@@ -155,6 +165,35 @@ export default function UserSettings({
     // Clear error for this field
     if (errors[field]) {
       setErrors(prev => ({ ...prev, [field]: '' }));
+    }
+  };
+
+  // Legacy Settings.jsx upload: send the image to the first-party hoster
+  // (steemitimages.com) and fill the field with the returned URL.
+  const handleImageUpload = async (
+    field: 'profile_image' | 'cover_image',
+    file: File | undefined
+  ) => {
+    if (!file || !currentUser) return;
+    setUploadingImage(field);
+    setErrors(prev => ({ ...prev, [field]: '' }));
+    try {
+      const url = await uploadImage(file, currentUser);
+      handleInputChange(field, url);
+    } catch (error) {
+      console.error('Image upload failed:', error);
+      setErrors(prev => ({
+        ...prev,
+        [field]:
+          error instanceof Error
+            ? error.message
+            : t('settings_jsx.update_failed'),
+      }));
+    } finally {
+      setUploadingImage(null);
+      // Allow re-selecting the same file.
+      const input = fileInputRefs[field].current;
+      if (input) input.value = '';
     }
   };
 
@@ -249,15 +288,36 @@ export default function UserSettings({
             <label className="block text-sm font-medium text-gray-700 mb-2">
               {t('settings_jsx.profile_image_url')}
             </label>
-            <input
-              type="url"
-              value={formData.profile_image}
-              onChange={(e) => handleInputChange('profile_image', e.target.value)}
-              className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#06D6A9] ${
-                errors.profile_image ? 'border-red-500' : 'border-gray-300'
-              }`}
-              placeholder={t('settings_jsx.profile_image_placeholder')}
-            />
+            <div className="flex gap-2">
+              <input
+                type="url"
+                value={formData.profile_image}
+                onChange={(e) => handleInputChange('profile_image', e.target.value)}
+                className={`flex-1 px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#06D6A9] ${
+                  errors.profile_image ? 'border-red-500' : 'border-gray-300'
+                }`}
+                placeholder={t('settings_jsx.profile_image_placeholder')}
+              />
+              <input
+                ref={fileInputRefs.profile_image}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(e) =>
+                  void handleImageUpload('profile_image', e.target.files?.[0])
+                }
+              />
+              <button
+                type="button"
+                disabled={uploadingImage !== null}
+                onClick={() => fileInputRefs.profile_image.current?.click()}
+                className="px-4 py-2 whitespace-nowrap bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors disabled:opacity-50"
+              >
+                {uploadingImage === 'profile_image'
+                  ? t('settings_jsx.uploading_image')
+                  : t('settings_jsx.upload_image')}
+              </button>
+            </div>
             {errors.profile_image && (
               <p className="mt-1 text-sm text-red-600">{errors.profile_image}</p>
             )}
@@ -268,18 +328,42 @@ export default function UserSettings({
             <label className="block text-sm font-medium text-gray-700 mb-2">
               {t('settings_jsx.cover_image_url')}
             </label>
-            <input
-              type="url"
-              value={formData.cover_image}
-              onChange={(e) => handleInputChange('cover_image', e.target.value)}
-              className={`w-full px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#06D6A9] ${
-                errors.cover_image ? 'border-red-500' : 'border-gray-300'
-              }`}
-              placeholder={t('settings_jsx.cover_image_placeholder')}
-            />
+            <div className="flex gap-2">
+              <input
+                type="url"
+                value={formData.cover_image}
+                onChange={(e) => handleInputChange('cover_image', e.target.value)}
+                className={`flex-1 px-3 py-2 border rounded-lg focus:outline-none focus:ring-2 focus:ring-[#06D6A9] ${
+                  errors.cover_image ? 'border-red-500' : 'border-gray-300'
+                }`}
+                placeholder={t('settings_jsx.cover_image_placeholder')}
+              />
+              <input
+                ref={fileInputRefs.cover_image}
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={(e) =>
+                  void handleImageUpload('cover_image', e.target.files?.[0])
+                }
+              />
+              <button
+                type="button"
+                disabled={uploadingImage !== null}
+                onClick={() => fileInputRefs.cover_image.current?.click()}
+                className="px-4 py-2 whitespace-nowrap bg-gray-600 text-white rounded-lg hover:bg-gray-700 transition-colors disabled:opacity-50"
+              >
+                {uploadingImage === 'cover_image'
+                  ? t('settings_jsx.uploading_image')
+                  : t('settings_jsx.upload_image')}
+              </button>
+            </div>
             {errors.cover_image && (
               <p className="mt-1 text-sm text-red-600">{errors.cover_image}</p>
             )}
+            <p className="mt-1 text-xs text-gray-500">
+              {t('settings_jsx.image_hosting_note')}
+            </p>
           </div>
 
           {/* Display Name */}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -49,6 +49,11 @@ REDIS_KEY_PREFIX=steem:session:
 NEXT_PUBLIC_SIGNUP_URL=https://signup.steemit.com
 ELASTICSEARCH_URL=http://localhost:9200
 
+# Image upload endpoint for the settings page profile/cover upload (legacy
+# $STM_Config.upload_image). The client signs the file with the posting key
+# and POSTs it here. Default: https://steemitimages.com
+NEXT_PUBLIC_UPLOAD_IMAGE_URL=https://steemitimages.com
+
 # Analytics (all optional)
 # Google Analytics (gtag.js) property id — scripts are injected only when set.
 SDC_GOOGLE_ANALYTICS_ID=

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -51,8 +51,10 @@ ELASTICSEARCH_URL=http://localhost:9200
 
 # Image upload endpoint for the settings page profile/cover upload (legacy
 # $STM_Config.upload_image). The client signs the file with the posting key
-# and POSTs it here. Default: https://steemitimages.com
-NEXT_PUBLIC_UPLOAD_IMAGE_URL=https://steemitimages.com
+# and POSTs it here. Read at request time and inlined into the SSR HTML (like
+# SDC_GOOGLE_ANALYTICS_ID) — never baked into the bundle.
+# Default: https://steemitimages.com
+SDC_UPLOAD_IMAGE_URL=https://steemitimages.com
 
 # Analytics (all optional)
 # Google Analytics (gtag.js) property id — scripts are injected only when set.

--- a/lib/media/upload-image.ts
+++ b/lib/media/upload-image.ts
@@ -1,0 +1,54 @@
+/**
+ * Client-side image upload to the Steemit image hoster.
+ * Mirrors legacy UserSaga.js uploadImage: the client signs
+ * sha256('ImageSigningChallenge' || file bytes) with the posting key and
+ * POSTs multipart form-data to {uploadUrl}/{username}/{signature}.
+ * The returned URL is served by the first-party image hoster, which is what
+ * the official site can display (third-party image hosts are not proxied).
+ */
+
+import { steem } from '@steemit/steem-js';
+import { getCachedKey, decryptAndRetrieveKey } from '@/lib/crypto/key-storage';
+
+const DEFAULT_UPLOAD_URL = 'https://steemitimages.com';
+
+function uploadBaseUrl(): string {
+  const url = process.env.NEXT_PUBLIC_UPLOAD_IMAGE_URL || DEFAULT_UPLOAD_URL;
+  return url.replace(/\/+$/, '');
+}
+
+/**
+ * Upload an image file for `username`. Returns the hosted image URL.
+ * Requires the posting key in client key storage (logged-in session).
+ */
+export async function uploadImage(file: File, username: string): Promise<string> {
+  if (!file.type.startsWith('image/')) {
+    throw new Error('Please insert only image files.');
+  }
+  const key = getCachedKey() ?? (await decryptAndRetrieveKey())?.privateKey;
+  if (!key) {
+    throw new Error('Private key not available. Please login again.');
+  }
+
+  const data = Buffer.from(await file.arrayBuffer());
+  // The constant prefix proves the client intended an image-hosting upload,
+  // so the server cannot trick it into signing something else (legacy parity).
+  const challenge = Buffer.concat([Buffer.from('ImageSigningChallenge'), data]);
+  // The challenge is binary, so the string-based steem.auth.sign() helper does
+  // not apply; use the Signature class the SDK exposes through steem.auth.
+  // signBuffer() sha256-hashes internally, identical to legacy's
+  // signBufferSha256(sha256(challenge)).
+  const signature = steem.auth.Signature.signBuffer(challenge, key).toHex();
+
+  const formData = new FormData();
+  formData.append('file', file);
+  const res = await fetch(`${uploadBaseUrl()}/${username}/${signature}`, {
+    method: 'POST',
+    body: formData,
+  });
+  const json = await res.json().catch(() => ({}));
+  if (!res.ok || json.error) {
+    throw new Error(json.error || `Upload failed (${res.status})`);
+  }
+  return json.url as string;
+}

--- a/lib/media/upload-image.ts
+++ b/lib/media/upload-image.ts
@@ -12,8 +12,14 @@ import { getCachedKey, decryptAndRetrieveKey } from '@/lib/crypto/key-storage';
 
 const DEFAULT_UPLOAD_URL = 'https://steemitimages.com';
 
+// Runtime config, inlined into the SSR HTML by the root layout from
+// SDC_UPLOAD_IMAGE_URL (legacy $STM_Config.upload_image parity). Read at
+// call time, never baked into the bundle — published images stay
+// environment-agnostic (same rationale as the GA id injection).
 function uploadBaseUrl(): string {
-  const url = process.env.NEXT_PUBLIC_UPLOAD_IMAGE_URL || DEFAULT_UPLOAD_URL;
+  const url =
+    (globalThis as { __SDC_UPLOAD_IMAGE_URL__?: string })
+      .__SDC_UPLOAD_IMAGE_URL__ || DEFAULT_UPLOAD_URL;
   return url.replace(/\/+$/, '');
 }
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -786,7 +786,8 @@
     "save_preferences": "Save Preferences",
     "saving": "Saving...",
     "preferences_saved": "Preferences saved.",
-    "save_preferences_failed": "Failed to save preferences"
+    "save_preferences_failed": "Failed to save preferences",
+    "image_hosting_note": "Note: the official site only displays images hosted on steemitimages.com — third-party image hosts are not shown. Use Upload to host your image."
   },
   "transfer_jsx": {
     "amount_is_in_form": "Amount is in the form 99999.999",

--- a/messages/overlays/en.json
+++ b/messages/overlays/en.json
@@ -154,7 +154,8 @@
     "save_preferences": "Save Preferences",
     "saving": "Saving...",
     "preferences_saved": "Preferences saved.",
-    "save_preferences_failed": "Failed to save preferences"
+    "save_preferences_failed": "Failed to save preferences",
+    "image_hosting_note": "Note: the official site only displays images hosted on steemitimages.com — third-party image hosts are not shown. Use Upload to host your image."
   },
   "search_jsx": {
     "accounts": "Accounts",


### PR DESCRIPTION
## What

The Profile/Cover Image URL fields in Account Settings accepted only hand-pasted URLs. This adds the legacy upload flow (legacy `Settings.jsx` + `UserSaga.uploadImage`):

- New client helper `lib/media/upload-image.ts`: signs `sha256('ImageSigningChallenge' || file bytes)` with the stored posting key (same key-storage path as broadcasts) and POSTs multipart form-data to `{uploadUrl}/{username}/{signature}`.
- Upload button beside both URL inputs with uploading state and inline errors.
- Note under the fields: the official site only displays images hosted on steemitimages.com — third-party image hosts are not shown.

## Upload endpoint config (legacy parity)

Same env var as legacy: **`SDC_UPLOAD_IMAGE_URL`** (default `https://steemitimages.com`). Like legacy's `$STM_Config.upload_image`, it is read **at request time** and inlined into the SSR HTML by the root layout (`window.__SDC_UPLOAD_IMAGE_URL__`, same pattern as the GA id) — never baked into the bundle, so published images stay environment-agnostic. No `NEXT_PUBLIC_` variable. `docs/CONFIGURATION.md` and `.env.example` updated.

## Notes

- Binary challenge can't go through the string-based `steem.auth.sign()`; uses `steem.auth.Signature.signBuffer` (sha256 inside), byte-identical to legacy `signBufferSha256(sha256(challenge))`.
- To point the test env at the dev imagehoster, set `SDC_UPLOAD_IMAGE_URL` in the EB env — no rebuild needed.

## Tests

5 cases for the helper (non-image rejection, missing key, signed request shape, runtime endpoint override, hoster error passthrough). Suite 247/247, lint/tsc clean.