### PR TITLE
feat(auth): persist posting key in localStorage to match legacy keep-me-logged-in

### DIFF
--- a/__tests__/lib/crypto/key-storage.test.ts
+++ b/__tests__/lib/crypto/key-storage.test.ts
@@ -4,25 +4,81 @@ import {
   decryptAndRetrieveKey,
   clearStoredKey,
   hasStoredKey,
+  getCachedKey,
 } from '@/lib/crypto/key-storage';
+
+function clearMemoryCache() {
+  const w = window as unknown as Record<string, unknown>;
+  delete w['steem_decrypted_key'];
+  delete w['steem_decrypted_key_username'];
+}
 
 describe('key-storage on non-secure contexts (no crypto.subtle)', () => {
   afterEach(() => {
     vi.unstubAllGlobals();
     clearStoredKey();
+    localStorage.clear();
     sessionStorage.clear();
   });
 
-  it('falls back to plaintext sessionStorage and roundtrips the key', async () => {
+  it('falls back to plaintext localStorage and roundtrips the key', async () => {
     // Plain HTTP over a LAN IP has no Web Crypto subtle API at all.
     vi.stubGlobal('crypto', { getRandomValues: (a: Uint8Array) => a });
 
     await encryptAndStoreKey('5K-test-wif', 'alice');
     expect(hasStoredKey()).toBe(true);
+    expect(localStorage.getItem('steem_encrypted_key')).not.toBeNull();
 
-    // Simulate a fresh page load: only sessionStorage survives.
-    delete (window as unknown as Record<string, unknown>)['steem_decrypted_key'];
+    // Simulate a fresh page load: only localStorage survives.
+    clearMemoryCache();
     const result = await decryptAndRetrieveKey();
     expect(result).toEqual({ privateKey: '5K-test-wif', username: 'alice' });
+  });
+
+  it('with persist=false keeps the key in memory only', async () => {
+    vi.stubGlobal('crypto', { getRandomValues: (a: Uint8Array) => a });
+
+    await encryptAndStoreKey('5K-test-wif', 'alice', false);
+    expect(localStorage.getItem('steem_encrypted_key')).toBeNull();
+    expect(sessionStorage.getItem('steem_encrypted_key')).toBeNull();
+    expect(hasStoredKey()).toBe(false);
+    expect(getCachedKey()).toBe('5K-test-wif');
+
+    // Signing within the same tab session still works.
+    const result = await decryptAndRetrieveKey();
+    expect(result).toEqual({ privateKey: '5K-test-wif', username: 'alice' });
+
+    // A page reload drops the key entirely.
+    clearMemoryCache();
+    expect(await decryptAndRetrieveKey()).toBeNull();
+  });
+
+  it('migrates a legacy sessionStorage entry into localStorage', async () => {
+    vi.stubGlobal('crypto', { getRandomValues: (a: Uint8Array) => a });
+
+    // Older versions wrote the (plaintext fallback) entry to sessionStorage.
+    sessionStorage.setItem(
+      'steem_encrypted_key',
+      JSON.stringify({ plain: '5K-test-wif', username: 'alice', timestamp: 1 })
+    );
+
+    const result = await decryptAndRetrieveKey();
+    expect(result).toEqual({ privateKey: '5K-test-wif', username: 'alice' });
+    expect(sessionStorage.getItem('steem_encrypted_key')).toBeNull();
+    expect(localStorage.getItem('steem_encrypted_key')).not.toBeNull();
+  });
+
+  it('clearStoredKey clears localStorage, sessionStorage and the memory cache', async () => {
+    vi.stubGlobal('crypto', { getRandomValues: (a: Uint8Array) => a });
+
+    await encryptAndStoreKey('5K-test-wif', 'alice');
+    sessionStorage.setItem('steem_encrypted_key', '{"plain":"legacy"}');
+
+    clearStoredKey();
+
+    expect(localStorage.getItem('steem_encrypted_key')).toBeNull();
+    expect(sessionStorage.getItem('steem_encrypted_key')).toBeNull();
+    expect(getCachedKey()).toBeNull();
+    expect(hasStoredKey()).toBe(false);
   });
 });

--- a/__tests__/store/authThunks.test.ts
+++ b/__tests__/store/authThunks.test.ts
@@ -25,7 +25,8 @@ describe('logoutThunk', () => {
     const store = makeStore();
     store.dispatch(setUser({ username: 'alice', posting_authority: true }));
     window.localStorage.setItem('autopost2', JSON.stringify({ username: 'alice' }));
-    window.sessionStorage.setItem('steem_encrypted_key', '{"encrypted":"x"}');
+    window.localStorage.setItem('steem_encrypted_key', '{"encrypted":"x"}');
+    window.sessionStorage.setItem('steem_encrypted_key', '{"encrypted":"legacy"}');
 
     await store.dispatch(logoutThunk());
 
@@ -33,6 +34,7 @@ describe('logoutThunk', () => {
     expect(state.current).toEqual({});
     expect(state.logged_out).toBe(true);
     expect(window.localStorage.getItem('autopost2')).toBeNull();
+    expect(window.localStorage.getItem('steem_encrypted_key')).toBeNull();
     expect(window.sessionStorage.getItem('steem_encrypted_key')).toBeNull();
     expect(fetch).toHaveBeenCalledWith('/api/auth/logout', { method: 'POST' });
   });

--- a/components/modules/LoginForm.tsx
+++ b/components/modules/LoginForm.tsx
@@ -12,7 +12,7 @@ import {
   isWifFormat,
   isPublicKeyFormat 
 } from '@/lib/crypto/client';
-import { encryptAndStoreKey, initializeKeyLifecycle } from '@/lib/crypto/key-storage';
+import { encryptAndStoreKey } from '@/lib/crypto/key-storage';
 
 /**
  * LoginForm component
@@ -38,10 +38,6 @@ export default function LoginForm({ embedded = false }: { embedded?: boolean }) 
     if (typeof window !== 'undefined') {
       const saved = localStorage.getItem('saveLogin');
       setSaveLogin(saved !== 'no');
-      
-      // Initialize key lifecycle management
-      const cleanup = initializeKeyLifecycle();
-      return cleanup;
     }
   }, []);
 
@@ -162,18 +158,15 @@ export default function LoginForm({ embedded = false }: { embedded?: boolean }) 
 
       await loginResponse.json();
       
-      // Step 7: Store encrypted private key for subsequent operations
-      // The key is encrypted using application-level key material and stored in sessionStorage
-      // It will be cleared when the tab is closed
-      if (saveLogin) {
-        try {
-          // Encrypt and store the private key
-          // Encryption uses application identifier + username for key derivation
-          await encryptAndStoreKey(privateKeyWif, normalizedUsername);
-        } catch (storageError) {
-          console.error('Failed to store encrypted key:', storageError);
-          // Don't fail login if storage fails, but log the error
-        }
+      // Step 7: Store the private key for subsequent operations.
+      // With "keep me logged in" the encrypted key is persisted to
+      // localStorage until explicit logout (legacy autopost2 behavior);
+      // otherwise it lives only in the in-memory cache for this tab session.
+      try {
+        await encryptAndStoreKey(privateKeyWif, normalizedUsername, saveLogin);
+      } catch (storageError) {
+        console.error('Failed to store encrypted key:', storageError);
+        // Don't fail login if storage fails, but log the error
       }
       
       // Step 8: Update Redux state

--- a/docs/AUTHENTICATION.md
+++ b/docs/AUTHENTICATION.md
@@ -127,8 +127,9 @@ REDIS_KEY_PREFIX=steem:session:
 
 ### Key Management Security
 - **No Server Storage**: Private keys never stored on server
-- **Memory Safety**: Keys cleared from memory after use
-- **Role Restriction**: Only posting authority allowed
+- **Posting Key Only**: Only the lowest-privilege key (posting/memo) is stored; active/owner keys are rejected at login
+- **"Keep me logged in" Persistence**: When checked, the posting key is AES-GCM encrypted and persisted in localStorage until explicit logout (legacy `autopost2` behavior); when unchecked it lives in memory only for the tab session
+- **Obfuscation, Not Password Protection**: The encryption key material (origin + username) is derivable by any same-origin script, so this does not protect against XSS — an accepted trade-off since a posting key cannot move funds (see `docs/KEY_MANAGEMENT.md`)
 - **Public Key Verification**: Server validates against blockchain data
 
 ## Migration from Legacy System

--- a/docs/KEY_MANAGEMENT.md
+++ b/docs/KEY_MANAGEMENT.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The Next.js version implements a secure client-side private key management system that addresses the challenge of maintaining private keys across page refreshes while maintaining security. Unlike the legacy single-page application that could keep keys in memory, this system uses encrypted storage with automatic lifecycle management.
+The Next.js version implements client-side private key management that mirrors the legacy condenser lifecycle: the posting key is kept available for signing for the whole session, and — when the user opts in with "keep me logged in" — persisted across reloads and new tabs until explicit logout. Unlike the legacy app, which stored the posting key as plain hex in `localStorage['autopost2']`, the rewrite stores it AES-GCM encrypted in `localStorage['steem_encrypted_key']`.
 
 ## Architecture
 
@@ -11,42 +11,49 @@ The Next.js version implements a secure client-side private key management syste
 1. **Client-Side Signing**: All transactions are signed on the client before being sent to the API
 2. **API as Forwarder**: The API layer only forwards pre-signed transactions to the Steem network
 3. **No Server Storage**: Private keys are never stored on the server
-4. **Encrypted Storage**: Private keys are encrypted before storage using Web Crypto API
-5. **Automatic Cleanup**: Keys are cleared when pages become hidden or tabs are closed
+4. **Posting Key Only**: Only the lowest-privilege key (posting/memo) is ever stored; active/owner keys are rejected at login
+5. **Legacy Lifecycle**: "Keep me logged in" persists the key until logout; without it the key lives in memory only for the tab session
 
 ## Key Storage System
+
+### Threat Model
+
+- The stored key is the **posting key only** — the lowest-privilege key (posting/memo), never active/owner.
+- Persisting it in localStorage **matches legacy condenser behavior** (legacy stored it as plain hex in `autopost2`).
+- The AES-GCM encryption is **obfuscation only**: the key material (origin + username) is derivable by any same-origin script, so this does **NOT** protect against XSS. Key leakage under XSS is an accepted trade-off, since a posting key cannot move funds.
+- The key **persists until explicit logout**.
 
 ### Storage Mechanism
 
 The system uses a two-tier storage approach:
 
-1. **Encrypted Storage (sessionStorage)**: 
-   - Private keys are encrypted with user's password using AES-GCM
-   - Stored in `sessionStorage` (automatically cleared when tab closes)
-   - Uses PBKDF2 for key derivation (100,000 iterations)
+1. **Persistent Storage (localStorage, opt-in)**:
+   - Written only when "keep me logged in" is checked at login
+   - The posting key is encrypted with AES-GCM before storage (PBKDF2 key derivation, 100,000 iterations)
+   - The encryption key material is derived from `origin:username:key-storage` — publicly derivable, so this is obfuscation, not password protection (see Threat Model)
+   - Survives page reloads, new tabs, and browser restarts; cleared only by explicit logout
 
-2. **Memory Cache**:
-   - Decrypted keys are cached in memory for performance
-   - Automatically cleared when page becomes hidden
-   - Re-encrypted key remains in sessionStorage for later use
+2. **Memory Cache (always)**:
+   - The decrypted key is cached on `window` for fast signing
+   - This is the *only* copy when "keep me logged in" is unchecked — the key is lost when the tab closes or reloads (legacy behavior: unchecked = in-memory only)
+   - Disappears naturally when the tab closes
 
-### Security Features
+On non-secure contexts (plain HTTP, e.g. development over a LAN IP) `crypto.subtle` is unavailable; the system degrades to storing the key unencrypted in localStorage. Production is always HTTPS.
 
-- **Web Crypto API**: Industry-standard encryption
-- **AES-GCM**: Authenticated encryption with associated data
-- **PBKDF2**: Password-based key derivation (100,000 iterations)
-- **Random IV/Salt**: Unique encryption parameters for each storage
-- **Session-Based**: Keys cleared on tab close
-- **Visibility-Based Cleanup**: Memory cache cleared when page hidden
+### Migration from Older Versions
+
+Versions before this change wrote the encrypted key to `sessionStorage`. On first read, `decryptAndRetrieveKey` moves any such entry into localStorage and removes the sessionStorage copy, so existing sessions keep working. `clearStoredKey` clears both storages.
 
 ## Transaction Signing Flow
 
 ### 1. User Login
 
 ```typescript
-// User logs in with password or WIF private key
+// User logs in with their posting WIF private key.
 // After successful authentication:
-await encryptAndStoreKey(privateKeyWif, username, password);
+await encryptAndStoreKey(privateKeyWif, username, saveLogin);
+// saveLogin (the "keep me logged in" checkbox) controls whether the
+// encrypted key is persisted to localStorage or kept in memory only.
 ```
 
 ### 2. Transaction Creation
@@ -111,31 +118,12 @@ const result = await broadcastSignedTransaction(signedTransaction);
 - Does NOT sign or modify transactions
 - Only forwards to Steem network
 
-## Key Lifecycle Management
+## Key Lifecycle
 
-### Initialization
-
-```typescript
-// Initialize on app load
-useEffect(() => {
-  const cleanup = initializeKeyLifecycle();
-  return cleanup;
-}, []);
-```
-
-### Lifecycle Events
-
-1. **Page Visible**: Key loaded from sessionStorage and cached in memory
-2. **Page Hidden**: Memory cache cleared (encrypted key remains)
-3. **Tab Closed**: sessionStorage cleared (all keys removed)
-4. **User Logout**: Explicitly clears all storage
-
-### Memory Cache Strategy
-
-- **Fast Access**: Decrypted keys cached in memory for quick signing
-- **Security**: Cleared when page becomes hidden
-- **Persistence**: Encrypted key remains in sessionStorage
-- **Re-authentication**: User can decrypt again with password if needed
+1. **Login**: Key validated, then cached in memory; encrypted copy persisted to localStorage if "keep me logged in" is checked
+2. **Signing**: Key read from memory cache, falling back to decrypting the localStorage copy
+3. **Page Reload / New Tab**: Memory cache is gone; with "keep me logged in" the key is restored from localStorage, without it the user must log in again
+4. **Logout**: `clearStoredKey()` removes the localStorage entry (plus any legacy sessionStorage entry) and the memory cache
 
 ## Usage Examples
 
@@ -144,7 +132,7 @@ useEffect(() => {
 ```typescript
 import { broadcastComment } from '@/lib/api/broadcast';
 
-// Key is automatically retrieved from memory cache or sessionStorage
+// Key is automatically retrieved from memory cache or localStorage
 const result = await broadcastComment({
   parentAuthor: '',
   parentPermlink: 'hive-123456',
@@ -153,7 +141,6 @@ const result = await broadcastComment({
   title: '',
   body: 'This is my comment',
   jsonMetadata: '{}',
-  // password: 'optional' // Only needed if key not in memory
 });
 ```
 
@@ -193,23 +180,20 @@ const result = await broadcastCustomJson({
 ### Advantages Over Legacy System
 
 1. **No Server-Side Key Storage**: Keys never leave the client
-2. **Encrypted Storage**: Even if sessionStorage is compromised, keys are encrypted
-3. **Automatic Cleanup**: Keys cleared on tab close or page hide
-4. **API Security**: API cannot sign transactions, only forwards them
-5. **Password Protection**: Encrypted keys require password to decrypt
+2. **Encrypted at Rest**: The persisted key is AES-GCM encrypted instead of legacy's plain hex (obfuscation only — see Threat Model)
+3. **API Security**: API cannot sign transactions, only forwards them
+4. **Posting Key Only**: Active/owner keys are rejected, so a leaked key cannot move funds
 
 ### Limitations
 
-1. **Page Refresh**: Requires re-authentication if memory cache cleared
-2. **Password Required**: User must remember password for re-decryption
-3. **Session-Based**: Keys lost on tab close (by design for security)
+1. **XSS**: Any same-origin script can derive the encryption key material and decrypt the stored key. This is an accepted trade-off (posting keys cannot move funds) and is no worse than legacy's plaintext storage.
+2. **Shared Devices**: With "keep me logged in", the key stays on the device until explicit logout — users on shared devices should uncheck it or log out.
 
 ### Best Practices
 
-1. **Use "Keep me logged in"**: Stores encrypted key for session
-2. **Don't share passwords**: Each user should have unique password
-3. **Logout when done**: Explicitly clear keys when finished
-4. **Use secure passwords**: Strong passwords protect encrypted keys
+1. **Uncheck "Keep me logged in" on shared devices**: The key then lives in memory only for the tab session
+2. **Logout when done**: Explicitly clears the persisted key
+3. **Never enter active/owner keys**: The login form rejects them; only the posting key is ever stored
 
 ## Migration from Legacy
 
@@ -217,18 +201,17 @@ const result = await broadcastCustomJson({
 
 | Legacy | Next.js |
 |--------|---------|
-| Memory-only storage | Encrypted sessionStorage + memory cache |
-| Survives page refresh | Requires re-authentication after refresh |
-| No encryption | AES-GCM encryption with password |
-| Server-side signing | Client-side signing only |
+| Plain hex WIF in `localStorage['autopost2']` (opt-in) | AES-GCM encrypted key in `localStorage['steem_encrypted_key']` (opt-in) |
+| Unchecked: key in Redux memory for the tab session | Unchecked: key in memory cache for the tab session |
+| Server-side signing possible | Client-side signing only |
 | API signs transactions | API only forwards |
 
 ### Benefits
 
-1. **Better Security**: Encrypted storage with automatic cleanup
+1. **Better Security at Rest**: Encrypted storage instead of plaintext hex
 2. **API Simplification**: API doesn't need to handle keys
 3. **User Control**: Users control their own keys
-4. **Compliance**: Better alignment with security best practices
+4. **Same UX as Legacy**: Identical "keep me logged in" semantics
 
 ## Implementation Details
 
@@ -244,7 +227,7 @@ const result = await broadcastCustomJson({
 
 - Web Crypto API (browser built-in)
 - `@steemit/steem-js`: Transaction serialization and signing
-- sessionStorage: Encrypted key storage
+- localStorage: Encrypted key storage (opt-in persistence)
 
 ## Future Enhancements
 

--- a/hooks/use-session-hydration.ts
+++ b/hooks/use-session-hydration.ts
@@ -5,9 +5,11 @@
  * Restores user identity into Redux on app mount when a valid server-side
  * session cookie exists (legacy App.jsx auto-login equivalent).
  *
- * Note: this only restores identity/UI state. The encrypted private key in
- * sessionStorage does not survive a page reload by design, so posting
- * actions will prompt for the key again — that is intentional.
+ * Note: this only restores identity/UI state. The posting key is restored
+ * separately by lib/crypto/key-storage: if the user checked "keep me logged
+ * in" the encrypted key in localStorage survives the reload and signing
+ * keeps working; otherwise the key was memory-only and the user must log in
+ * again to sign.
  */
 
 import { useEffect } from 'react';

--- a/lib/crypto/key-storage.ts
+++ b/lib/crypto/key-storage.ts
@@ -1,11 +1,21 @@
 /**
- * Secure client-side private key storage
- * Uses Web Crypto API for encryption and sessionStorage for persistence
- * Memory cache for performance, cleared on page visibility change
+ * Client-side posting key storage.
+ *
+ * Threat model:
+ * - The stored key is the posting key only — the lowest-privilege key
+ *   (posting/memo), never active/owner.
+ * - Persisting it in localStorage matches legacy condenser behavior (legacy
+ *   stored it as plain hex in `autopost2`).
+ * - The AES-GCM encryption is obfuscation only: the key material
+ *   (origin + username) is derivable by any same-origin script, so this does
+ *   NOT protect against XSS. Key leakage under XSS is an accepted trade-off,
+ *   since a posting key cannot move funds.
+ * - The key persists until explicit logout.
  */
 
 const STORAGE_KEY = 'steem_encrypted_key';
 const MEMORY_CACHE_KEY = 'steem_decrypted_key';
+const MEMORY_CACHE_USERNAME_KEY = 'steem_decrypted_key_username';
 const ENCRYPTION_ALGORITHM = 'AES-GCM';
 const KEY_DERIVATION_ALGORITHM = 'PBKDF2';
 
@@ -27,7 +37,7 @@ interface PlainKeyData {
 /**
  * crypto.subtle exists only in secure contexts (HTTPS or localhost). Plain
  * HTTP over a LAN IP (e.g. http://192.168.x.x during development) has no
- * subtle API at all — degrade to plaintext sessionStorage there. That is
+ * subtle API at all — degrade to plaintext localStorage there. That is
  * acceptable: on a non-secure context the page itself is already plaintext,
  * so encryption would buy nothing; production is always HTTPS.
  */
@@ -42,7 +52,7 @@ function isSubtleCryptoAvailable(): boolean {
 function getEncryptionKeyMaterial(username: string): string {
   // Use application identifier + username for key derivation
   // This ensures each user has a unique encryption key
-  const appId = typeof window !== 'undefined' 
+  const appId = typeof window !== 'undefined'
     ? (window.location.origin || 'steem-condenser')
     : 'steem-condenser';
   return `${appId}:${username}:key-storage`;
@@ -79,27 +89,41 @@ async function deriveKey(
   );
 }
 
+function setMemoryCache(privateKeyWif: string, username: string): void {
+  const w = window as unknown as { [key: string]: string };
+  w[MEMORY_CACHE_KEY] = privateKeyWif;
+  w[MEMORY_CACHE_USERNAME_KEY] = username;
+}
+
 /**
- * Encrypt and store private key
- * Uses application-level key material derived from username
+ * Encrypt and store the private key.
+ * Uses application-level key material derived from username.
+ *
+ * The decrypted key is always cached in memory (lost when the tab closes).
+ * With `persist` (the legacy "keep me logged in" checkbox) the encrypted key
+ * is additionally written to localStorage, where it survives reloads and new
+ * tabs until explicit logout — matching legacy condenser's `autopost2`.
  */
 export async function encryptAndStoreKey(
   privateKeyWif: string,
-  username: string
+  username: string,
+  persist = true
 ): Promise<void> {
   if (typeof window === 'undefined') {
     throw new Error('Key storage is only available in browser environment');
   }
 
   // Non-secure context (plain HTTP over LAN etc.): no crypto.subtle.
-  // Fall back to plaintext sessionStorage — see isSubtleCryptoAvailable().
+  // Fall back to plaintext localStorage — see isSubtleCryptoAvailable().
   if (!isSubtleCryptoAvailable()) {
-    console.warn(
-      'Web Crypto subtle API unavailable (non-secure context); storing the posting key unencrypted in sessionStorage. Use HTTPS in production.'
-    );
-    const plainData: PlainKeyData = { plain: privateKeyWif, username, timestamp: Date.now() };
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(plainData));
-    (window as unknown as { [key: string]: string })[MEMORY_CACHE_KEY] = privateKeyWif;
+    if (persist) {
+      console.warn(
+        'Web Crypto subtle API unavailable (non-secure context); storing the posting key unencrypted in localStorage. Use HTTPS in production.'
+      );
+      const plainData: PlainKeyData = { plain: privateKeyWif, username, timestamp: Date.now() };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(plainData));
+    }
+    setMemoryCache(privateKeyWif, username);
     return;
   }
 
@@ -123,23 +147,19 @@ export async function encryptAndStoreKey(
       encoder.encode(privateKeyWif)
     );
 
-    // Store encrypted data
-    const encryptedKeyData: EncryptedKeyData = {
-      encrypted: btoa(String.fromCharCode(...new Uint8Array(encryptedData))),
-      iv: btoa(String.fromCharCode(...iv)),
-      salt: btoa(String.fromCharCode(...salt)),
-      username,
-      timestamp: Date.now(),
-    };
-
-    // Store in sessionStorage (cleared when tab closes)
-    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(encryptedKeyData));
-
-    // Also cache decrypted key in memory for performance
-    // This will be cleared on page visibility change
-    if (typeof window !== 'undefined') {
-      (window as unknown as { [key: string]: string })[MEMORY_CACHE_KEY] = privateKeyWif;
+    if (persist) {
+      const encryptedKeyData: EncryptedKeyData = {
+        encrypted: btoa(String.fromCharCode(...new Uint8Array(encryptedData))),
+        iv: btoa(String.fromCharCode(...iv)),
+        salt: btoa(String.fromCharCode(...salt)),
+        username,
+        timestamp: Date.now(),
+      };
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(encryptedKeyData));
     }
+
+    // Also cache the decrypted key in memory for performance
+    setMemoryCache(privateKeyWif, username);
   } catch (error) {
     console.error('Failed to encrypt and store key:', error);
     throw new Error('Failed to securely store private key');
@@ -156,21 +176,31 @@ export async function decryptAndRetrieveKey(): Promise<{ privateKey: string; use
   }
 
   try {
-    // Check memory cache first
-    const cachedKey = (window as unknown as { [key: string]: string })[MEMORY_CACHE_KEY];
-    if (cachedKey) {
-      const stored = sessionStorage.getItem(STORAGE_KEY);
-      if (stored) {
-        const data: EncryptedKeyData = JSON.parse(stored);
-        return {
-          privateKey: cachedKey,
-          username: data.username,
-        };
+    // Migrate a legacy sessionStorage entry (written by versions before the
+    // key became persistent) into localStorage so it survives like the
+    // legacy autopost2 entry did.
+    if (!localStorage.getItem(STORAGE_KEY)) {
+      const legacy = sessionStorage.getItem(STORAGE_KEY);
+      if (legacy) {
+        localStorage.setItem(STORAGE_KEY, legacy);
+        sessionStorage.removeItem(STORAGE_KEY);
       }
     }
 
-    // Retrieve from sessionStorage
-    const stored = sessionStorage.getItem(STORAGE_KEY);
+    const stored = localStorage.getItem(STORAGE_KEY);
+
+    // Check memory cache first
+    const w = window as unknown as { [key: string]: string };
+    const cachedKey = w[MEMORY_CACHE_KEY];
+    if (cachedKey) {
+      const username = stored
+        ? (JSON.parse(stored) as EncryptedKeyData | PlainKeyData).username
+        : w[MEMORY_CACHE_USERNAME_KEY];
+      if (username) {
+        return { privateKey: cachedKey, username };
+      }
+    }
+
     if (!stored) {
       return null;
     }
@@ -180,7 +210,7 @@ export async function decryptAndRetrieveKey(): Promise<{ privateKey: string; use
     // Plaintext fallback written on non-secure contexts (no crypto.subtle).
     if ('plain' in parsed) {
       const data = parsed as PlainKeyData;
-      (window as unknown as { [key: string]: string })[MEMORY_CACHE_KEY] = data.plain;
+      setMemoryCache(data.plain, data.username);
       return { privateKey: data.plain, username: data.username };
     }
 
@@ -209,7 +239,7 @@ export async function decryptAndRetrieveKey(): Promise<{ privateKey: string; use
     const privateKey = decoder.decode(decryptedData);
 
     // Cache in memory
-    (window as unknown as { [key: string]: string })[MEMORY_CACHE_KEY] = privateKey;
+    setMemoryCache(privateKey, encryptedKeyData.username);
 
     return {
       privateKey,
@@ -232,13 +262,16 @@ export function getCachedKey(): string | null {
 }
 
 /**
- * Check if encrypted key exists in storage
+ * Check if a persisted key exists in storage
  */
 export function hasStoredKey(): boolean {
   if (typeof window === 'undefined') {
     return false;
   }
-  return sessionStorage.getItem(STORAGE_KEY) !== null;
+  return (
+    localStorage.getItem(STORAGE_KEY) !== null ||
+    sessionStorage.getItem(STORAGE_KEY) !== null
+  );
 }
 
 /**
@@ -248,7 +281,7 @@ export function getStoredUsername(): string | null {
   if (typeof window === 'undefined') {
     return null;
   }
-  const stored = sessionStorage.getItem(STORAGE_KEY);
+  const stored = localStorage.getItem(STORAGE_KEY) ?? sessionStorage.getItem(STORAGE_KEY);
   if (!stored) {
     return null;
   }
@@ -267,38 +300,10 @@ export function clearStoredKey(): void {
   if (typeof window === 'undefined') {
     return;
   }
+  localStorage.removeItem(STORAGE_KEY);
+  // Also clear any legacy sessionStorage entry left by older versions.
   sessionStorage.removeItem(STORAGE_KEY);
-  delete (window as unknown as { [key: string]: string })[MEMORY_CACHE_KEY];
-}
-
-/**
- * Initialize key lifecycle management
- * Clears memory cache when page becomes hidden
- */
-export function initializeKeyLifecycle(): () => void {
-  if (typeof window === 'undefined') {
-    return () => {}; // No-op for SSR
-  }
-
-  const handleVisibilityChange = () => {
-    if (document.hidden) {
-      // Page is hidden, clear memory cache for security
-      // Encrypted key remains in sessionStorage
-      delete (window as unknown as { [key: string]: string })[MEMORY_CACHE_KEY];
-    }
-  };
-
-  const handleBeforeUnload = () => {
-    // Clear everything on page unload
-    clearStoredKey();
-  };
-
-  document.addEventListener('visibilitychange', handleVisibilityChange);
-  window.addEventListener('beforeunload', handleBeforeUnload);
-
-  // Return cleanup function
-  return () => {
-    document.removeEventListener('visibilitychange', handleVisibilityChange);
-    window.removeEventListener('beforeunload', handleBeforeUnload);
-  };
+  const w = window as unknown as { [key: string]: string };
+  delete w[MEMORY_CACHE_KEY];
+  delete w[MEMORY_CACHE_USERNAME_KEY];
 }

--- a/store/thunks/authThunks.ts
+++ b/store/thunks/authThunks.ts
@@ -32,7 +32,6 @@ export const loginThunk = createAsyncThunk<
     const {
       username,
       password,
-      saveLogin = false,
       operationType,
     } = payload;
 
@@ -49,18 +48,6 @@ export const loginThunk = createAsyncThunk<
 
       // The actual authentication is now handled in the LoginForm component
       // This thunk is mainly for updating Redux state after successful login
-      
-      // Save login preference if requested
-      if (saveLogin) {
-        if (typeof window !== 'undefined') {
-          const loginData = {
-            username: finalUsername,
-            timestamp: Date.now(),
-            // Never store actual keys in localStorage
-          };
-          localStorage.setItem('autopost2', JSON.stringify(loginData));
-        }
-      }
 
       // Set user in Redux store (minimal info, session is managed server-side)
       dispatch(
@@ -104,10 +91,10 @@ export const loginThunk = createAsyncThunk<
 export const logoutThunk = createAsyncThunk<void, void, { dispatch: AppDispatch }>(
   'auth/logout',
   async (_, { dispatch }) => {
-    // Clear encrypted private key from sessionStorage and memory
+    // Clear the persisted posting key (localStorage + memory cache)
     clearStoredKey();
 
-    // Clear localStorage
+    // Clean up the legacy key written by older versions of condenser
     if (typeof window !== 'undefined') {
       localStorage.removeItem('autopost2');
     }


### PR DESCRIPTION
## Summary

Aligns the rewrite's posting-key lifecycle with legacy condenser's `keep me logged in` behavior.

- **Checked**: the posting key is AES-GCM encrypted and persisted to `localStorage['steem_encrypted_key']` until explicit logout — the equivalent of legacy's plain-hex `autopost2` entry, surviving reloads, new tabs, and browser restarts.
- **Unchecked**: the key lives only in the in-memory cache for the tab session (legacy kept it in Redux). This also fixes a bug where logging in *without* the checkbox left the user unable to sign any on-chain operation.

## Motivation

Previously the encrypted key was written to `sessionStorage` only when the checkbox was checked, and nowhere otherwise — so it neither survived a reload (breaking legacy parity) nor allowed signing at all when unchecked.

## Changes

- `lib/crypto/key-storage.ts`
  - Persistence layer moved from sessionStorage to localStorage (same key name, same AES-GCM + PBKDF2 scheme, same plaintext fallback for non-secure contexts).
  - `encryptAndStoreKey(wif, username, persist = true)`: `persist=false` writes only the memory cache.
  - `decryptAndRetrieveKey` migrates legacy sessionStorage entries into localStorage on first read.
  - `clearStoredKey` clears localStorage, sessionStorage (legacy entries), and the memory cache.
  - Removed `initializeKeyLifecycle` — its `beforeunload` clearing contradicts persist-until-logout, and its listener registration was tied to LoginForm mount/unmount and thus unreliable. Added a threat-model header comment.
- `components/modules/LoginForm.tsx`: always stores the key after login, passing the checkbox as `persist`; dropped the `initializeKeyLifecycle` wiring.
- `store/thunks/authThunks.ts`: removed the write-only `autopost2` dead code in `loginThunk` (no readers anywhere); `logoutThunk` still removes `autopost2` to clean up historical entries.
- Docs: rewrote `docs/KEY_MANAGEMENT.md` (it incorrectly claimed password-based encryption and refresh-invalidation), updated `docs/AUTHENTICATION.md` key-management section and the stale comment in `hooks/use-session-hydration.ts`.
- Tests: updated `__tests__/lib/crypto/key-storage.test.ts` (localStorage fallback, persist=false memory-only semantics, sessionStorage→localStorage migration, clearStoredKey) and `__tests__/store/authThunks.test.ts` (logout clears both storages).

## Threat model

- The stored key is the **posting key only** — the lowest-privilege key (posting/memo), never active/owner.
- Persisting it in localStorage **matches legacy condenser behavior** (legacy stored it as plain hex in `autopost2`).
- The AES-GCM encryption is **obfuscation only**: the key material (origin + username) is derivable by any same-origin script, so this does **NOT** protect against XSS. Key leakage under XSS is an accepted trade-off, since a posting key cannot move funds.
- The key **persists until explicit logout**.

## Testing

- `pnpm test`: 250/250 passed (39 files).
- `pnpm lint`: 0 errors, 20 warnings — identical to the pre-change baseline, no new issues.
- `npx tsc --noEmit`: clean.